### PR TITLE
feat(dx): warn when plugins exceed a bundle size budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ consistent verification, and independent releases.
 | `@harlan-zw/nuxt-cf-jobs` | Typed Cloudflare queue jobs for Nuxt. |
 | `@harlan-zw/nuxt-use-query` | Nuxt-native queries, mutations, subscriptions, and RPC. |
 | `@harlan-zw/nuxt-domain-events` | Lazy server-side domain events and listeners. |
-| `@harlan-zw/nuxt-dx` | Development-only Nuxt diagnostics and agent handoff. |
+| `@harlan-zw/nuxt-dx` | Nuxt diagnostics: dev error overlay, agent handoff, plugin size budgets. |
 | `@harlan-zw/nuxt-github-sponsors` | Typed GitHub Sponsors data, tiers, route, and composable. |
 
 All packages are experimental. Package versions and release notes are independent.

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -1,10 +1,6 @@
 # `@harlan-zw/nuxt-dx`
 
-Experimental, development-only diagnostics for Nuxt.
-
-The initial feature is a client error overlay that collects Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections. It can copy a concise report with route and source-file context for an agent handoff.
-
-The module is a strict production no-op. It only registers its client plugin when Nuxt runs in development mode.
+Experimental diagnostics for Nuxt: a development error overlay, and bundle size budgets for Nuxt and Nitro plugins.
 
 ```bash
 pnpm add -D @harlan-zw/nuxt-dx
@@ -13,10 +9,80 @@ pnpm add -D @harlan-zw/nuxt-dx
 ```ts
 export default defineNuxtConfig({
   modules: ['@harlan-zw/nuxt-dx'],
+})
+```
+
+## Error overlay
+
+A client error overlay that collects Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections. It can copy a concise report with route and source-file context for an agent handoff.
+
+The overlay is a strict production no-op; its client plugin is only registered when Nuxt runs in development mode.
+
+```ts
+export default defineNuxtConfig({
   nuxtDx: {
     position: 'bottom-right',
   },
 })
 ```
+
+## Plugin size budgets
+
+Warns when a Nuxt app plugin or a Nitro plugin drags too much JavaScript into the bundle.
+
+Each plugin is charged its own bundled size plus every module reachable *only* through it. Anything the app already ships without going through that plugin, or that a second plugin also pulls in, is shared and charged to nobody. Sizes are post-tree-shaking bytes read off the final module graph, so the number reflects what actually ships.
+
+```
+[nuxt-dx]  WARN  1 Nuxt plugin over budget in the client bundle
+
+  analytics  app/plugins/heavy.client.ts
+  31.5 kB bundled, 21.5 kB over the 10 kB budget
+    ├─  310 B  the plugin file
+    ├─ 3.9 kB  app/lib/part1.ts
+    ├─ 3.9 kB  app/lib/part2.ts
+    ├─ 3.9 kB  app/lib/part3.ts
+    └─19.5 kB  across 5 more modules
+
+  Defer heavy imports with `await import()`, or allow the size:
+    nuxtDx.sizeBudget.overridesKb = { 'analytics': 32 }
+```
+
+The three heaviest modules are listed and the remainder is folded into one line, so the breakdown always sums to the reported total. The suggested override is rounded up past the current size, and every offender lands in a single copy-pasteable snippet.
+
+A plugin that declares a name gets reported by it, with the file kept alongside so the warning stays clickable:
+
+```ts
+export default defineNuxtPlugin({
+  name: 'analytics',
+  setup() {},
+})
+```
+
+Both `defineNuxtPlugin({ name })` and `defineNuxtPlugin(fn, { name })` are read. Plugins without a name are reported by path, as are Nitro plugins, which have no name concept.
+
+```ts
+export default defineNuxtConfig({
+  nuxtDx: {
+    sizeBudget: {
+      // kB budget per Nuxt app plugin in the client bundle, `false` to disable
+      pluginsKb: 20,
+      // kB budget per Nitro plugin in the server bundle, `false` to disable
+      nitroPluginsKb: 50,
+      // raise or lower the budget for individual plugins,
+      // keyed by plugin name or by any fragment of the plugin path
+      overridesKb: {
+        'analytics': 60,
+        'server/plugins/queue': 120,
+      },
+      // throw instead of warning
+      fail: false,
+    },
+  },
+})
+```
+
+Set `sizeBudget: false` to turn the check off entirely.
+
+Budgets are measured whenever a bundle is produced. Nitro is bundled in both `nuxi dev` and `nuxi build`, so Nitro plugin budgets report in either. The client is served unbundled in dev, so app plugin budgets only report on `nuxi build`.
 
 APIs may change before the first release.

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -2,7 +2,7 @@
   "name": "@harlan-zw/nuxt-dx",
   "type": "module",
   "version": "0.0.1",
-  "description": "Experimental development-only diagnostics for Nuxt.",
+  "description": "Experimental Nuxt diagnostics: dev error overlay and plugin bundle size budgets.",
   "author": {
     "name": "Harlan Wilton",
     "email": "harlan@harlanzw.com",
@@ -52,7 +52,10 @@
     "nuxt": ">=4.2.0 <5.0.0"
   },
   "dependencies": {
-    "@nuxt/kit": "catalog:"
+    "@nuxt/kit": "catalog:",
+    "consola": "catalog:",
+    "oxc-parser": "catalog:",
+    "oxc-walker": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -62,6 +65,7 @@
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "nuxt": "catalog:",
+    "rollup": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:",

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,9 +1,156 @@
-import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import type { BudgetOverride, PluginVerdict } from './size-budget/budget'
+import type { BudgetScope } from './size-budget/report'
+import type { MeasuredPlugin } from './size-budget/rollup'
+import { readFile } from 'node:fs/promises'
+import { addPlugin, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
+import { budgetFor, smallestBudget } from './size-budget/budget'
+import { extractPluginName } from './size-budget/plugin-name'
+import { formatBudgetReport } from './size-budget/report'
+import { sizeBudgetRollupPlugin } from './size-budget/rollup'
+import { kilobytesToBytes } from './size-budget/size'
+
+export interface SizeBudgetOptions {
+  /**
+   * Kilobyte budget for each Nuxt app plugin in the client bundle. `false` disables the check.
+   * @default 20
+   */
+  pluginsKb?: number | false
+  /**
+   * Kilobyte budget for each Nitro plugin in the server bundle. `false` disables the check.
+   * @default 50
+   */
+  nitroPluginsKb?: number | false
+  /** Per-plugin kilobyte budgets, keyed by plugin name or by any fragment of the plugin path. */
+  overridesKb?: Record<string, number>
+  /**
+   * Fail the build instead of warning.
+   * @default false
+   */
+  fail?: boolean
+}
 
 export interface ModuleOptions {
   enabled?: boolean
   position?: 'bottom-left' | 'bottom-right'
   sourceRoot?: string
+  /** Warn when a plugin's exclusive import graph exceeds a bundle size budget. */
+  sizeBudget?: SizeBudgetOptions | false
+}
+
+interface ResolvedBudgets {
+  client: number | undefined
+  nitro: number | undefined
+  overrides: BudgetOverride[]
+  fail: boolean
+}
+
+const logger = useLogger('nuxt-dx')
+
+function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
+  const resolve = (kilobytes: number | false | undefined, fallback: number, label: string) => {
+    if (kilobytes === false)
+      return undefined
+    if (kilobytes === undefined)
+      return kilobytesToBytes(fallback)
+    // A negative or NaN budget would flag every plugin, so drop it rather than drown the build in warnings.
+    if (!Number.isFinite(kilobytes) || kilobytes < 0) {
+      logger.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+      return undefined
+    }
+    return kilobytesToBytes(kilobytes)
+  }
+
+  const overrides: ResolvedBudgets['overrides'] = []
+  for (const [fragment, kilobytes] of Object.entries(options.overridesKb ?? {})) {
+    if (!Number.isFinite(kilobytes) || kilobytes < 0)
+      logger.warn(`Ignoring \`sizeBudget.overridesKb['${fragment}']\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+    else overrides.push({ fragment, bytes: kilobytesToBytes(kilobytes) })
+  }
+
+  return {
+    client: resolve(options.pluginsKb, 20, 'pluginsKb'),
+    nitro: resolve(options.nitroPluginsKb, 50, 'nitroPluginsKb'),
+    overrides,
+    fail: options.fail ?? false,
+  }
+}
+
+async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefined> {
+  const virtual = nuxt.vfs[src]
+  if (virtual !== undefined)
+    return extractPluginName(src, virtual)
+  // The name is only a label, so an unreadable plugin falls back to its path rather than failing the build.
+  const source = await readFile(src, 'utf-8').catch(() => undefined)
+  return source === undefined ? undefined : extractPluginName(src, source)
+}
+
+/**
+ * Measurement only knows paths. Names are reconciled here, once, for the plugins big
+ * enough to be at risk, so a build where everything fits parses no plugin sources at all.
+ */
+function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean) {
+  const threshold = smallestBudget(defaultBytes, budgets.overrides)
+  return async (measured: readonly MeasuredPlugin[]) => {
+    const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold)
+    if (!candidates.length)
+      return
+
+    const verdicts: PluginVerdict[] = await Promise.all(candidates.map(async ({ path, measurement }) => {
+      const name = named ? await readPluginName(path, nuxt) : undefined
+      return { path, name, budgetBytes: budgetFor(path, name, defaultBytes, budgets.overrides), measurement }
+    }))
+
+    const over = verdicts
+      .filter(verdict => verdict.measurement.totalBytes > verdict.budgetBytes)
+      .sort((a, b) => b.measurement.totalBytes - a.measurement.totalBytes)
+    if (!over.length)
+      return
+
+    const report = formatBudgetReport(scope, over, nuxt.options.rootDir)
+    if (budgets.fail)
+      throw new Error(`[nuxt-dx] ${report}`)
+    logger.warn(report)
+  }
+}
+
+function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
+  const budgets = resolveBudgets(options)
+  const clientBudget = budgets.client
+  const nitroBudget = budgets.nitro
+
+  if (clientBudget !== undefined) {
+    // `app:resolve` runs before the client build, and holds every plugin including module-registered ones.
+    let appPluginPaths: string[] = []
+    nuxt.hook('app:resolve', (app) => {
+      appPluginPaths = app.plugins.filter(plugin => plugin.mode !== 'server').map(plugin => plugin.src)
+    })
+    nuxt.hook('vite:extendConfig', (config, env) => {
+      if (!env.isClient)
+        return
+      // `vite:extendConfig` types the config as readonly, but mutating `plugins` is the supported extension point.
+      const plugins = config.plugins as unknown[] | undefined
+      plugins?.push(sizeBudgetRollupPlugin({
+        scope: 'client',
+        paths: () => appPluginPaths,
+        onMeasured: reporter('client', clientBudget, budgets, nuxt, true),
+      }))
+    })
+  }
+
+  if (nitroBudget !== undefined) {
+    nuxt.hook('nitro:init', (nitro) => {
+      nitro.hooks.hook('rollup:before', (_nitro, config) => {
+        config.plugins ||= []
+        ;(config.plugins as unknown[]).push(sizeBudgetRollupPlugin({
+          scope: 'nitro',
+          paths: () => nitro.options.plugins,
+          // Nitro plugins have no name concept, so they are always identified by path.
+          onMeasured: reporter('nitro', nitroBudget, budgets, nuxt, false),
+        }))
+      })
+    })
+  }
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -16,7 +163,13 @@ export default defineNuxtModule<ModuleOptions>({
     position: 'bottom-right',
   },
   setup(options, nuxt) {
-    if (!nuxt.options.dev || !options.enabled)
+    if (!options.enabled)
+      return
+
+    if (options.sizeBudget !== false)
+      setupSizeBudget(options.sizeBudget ?? {}, nuxt)
+
+    if (!nuxt.options.dev)
       return
 
     const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>

--- a/packages/nuxt-dx/src/size-budget/budget.ts
+++ b/packages/nuxt-dx/src/size-budget/budget.ts
@@ -1,0 +1,31 @@
+import type { PluginMeasurement } from './graph'
+
+export interface PluginVerdict {
+  path: string
+  /** `name` from `defineNuxtPlugin`, when the plugin declares one. */
+  name?: string
+  budgetBytes: number
+  measurement: PluginMeasurement
+}
+
+export interface BudgetOverride {
+  /** A plugin name, or any fragment of a plugin path. */
+  fragment: string
+  bytes: number
+}
+
+/**
+ * The threshold below which no plugin can possibly breach its budget. Used to skip
+ * name resolution for plugins that are comfortably small.
+ */
+export function smallestBudget(defaultBytes: number, overrides: readonly BudgetOverride[]): number {
+  return overrides.reduce((smallest, override) => Math.min(smallest, override.bytes), defaultBytes)
+}
+
+export function budgetFor(path: string, name: string | undefined, defaultBytes: number, overrides: readonly BudgetOverride[]): number {
+  const normalized = path.replace(/\\/g, '/')
+  // An override keyed by plugin name wins over one keyed by a path fragment.
+  const override = overrides.find(candidate => candidate.fragment === name)
+    ?? overrides.find(candidate => normalized.includes(candidate.fragment))
+  return override?.bytes ?? defaultBytes
+}

--- a/packages/nuxt-dx/src/size-budget/graph.ts
+++ b/packages/nuxt-dx/src/size-budget/graph.ts
@@ -1,0 +1,101 @@
+export interface GraphModule {
+  id: string
+  /** Bytes this module contributes to the bundle after tree-shaking. */
+  bytes: number
+  importedIds: readonly string[]
+}
+
+export interface ModuleWeight {
+  id: string
+  bytes: number
+}
+
+export interface PluginMeasurement {
+  id: string
+  /** Size of the plugin file itself. */
+  ownBytes: number
+  /** Size of the modules reachable only through this plugin. */
+  exclusiveBytes: number
+  /** How many modules that covers, so the report can say what it left out. */
+  exclusiveCount: number
+  totalBytes: number
+  heaviestDependencies: readonly ModuleWeight[]
+}
+
+interface MeasureInput {
+  modules: readonly GraphModule[]
+  /** Bundled module ids of the plugins to measure. */
+  targetIds: readonly string[]
+  /** Bundle entry modules, used to discover what the app ships without any plugin. */
+  entryIds: readonly string[]
+  maxDependencies?: number
+}
+
+function walk(starts: readonly string[], byId: ReadonlyMap<string, GraphModule>, stopAt: ReadonlySet<string>): Set<string> {
+  const visited = new Set<string>()
+  const queue = starts.filter(id => !stopAt.has(id))
+  while (queue.length) {
+    const id = queue.pop()!
+    if (visited.has(id))
+      continue
+    visited.add(id)
+    for (const next of byId.get(id)?.importedIds ?? []) {
+      if (!stopAt.has(next) && !visited.has(next))
+        queue.push(next)
+    }
+  }
+  return visited
+}
+
+/**
+ * Charge each plugin the weight of its own module plus every module that is reachable
+ * only through it. Anything the app already reaches without passing through a plugin,
+ * or that a second plugin also reaches, is shared and charged to nobody.
+ *
+ * This is pure measurement; budgets are applied afterwards so that only the plugins
+ * heavy enough to matter need their name resolved.
+ */
+export function measurePluginCost(input: MeasureInput): PluginMeasurement[] {
+  const { modules, targetIds, entryIds, maxDependencies = 3 } = input
+  const byId = new Map(modules.map(module => [module.id, module]))
+  const present = targetIds.filter(id => byId.has(id))
+  const targets = new Set(present)
+
+  const sharedWithApp = walk(entryIds, byId, targets)
+
+  const owners = new Map<string, Set<string>>()
+  const reachedByTarget = new Map<string, Set<string>>()
+  for (const id of present) {
+    const reached = walk(byId.get(id)!.importedIds, byId, targets)
+    reachedByTarget.set(id, reached)
+    for (const reachedId of reached) {
+      const existing = owners.get(reachedId)
+      if (existing)
+        existing.add(id)
+      else owners.set(reachedId, new Set([id]))
+    }
+  }
+
+  return present.map((id) => {
+    const exclusive: ModuleWeight[] = []
+    for (const reachedId of reachedByTarget.get(id)!) {
+      // Imports can point outside the bundle (node builtins, externals); those cost nothing here.
+      const module = byId.get(reachedId)
+      if (!module || sharedWithApp.has(reachedId) || owners.get(reachedId)!.size > 1)
+        continue
+      exclusive.push({ id: reachedId, bytes: module.bytes })
+    }
+    exclusive.sort((a, b) => b.bytes - a.bytes || a.id.localeCompare(b.id))
+
+    const ownBytes = byId.get(id)!.bytes
+    const exclusiveBytes = exclusive.reduce((total, module) => total + module.bytes, 0)
+    return {
+      id,
+      ownBytes,
+      exclusiveBytes,
+      exclusiveCount: exclusive.length,
+      totalBytes: ownBytes + exclusiveBytes,
+      heaviestDependencies: exclusive.slice(0, maxDependencies),
+    }
+  })
+}

--- a/packages/nuxt-dx/src/size-budget/match.ts
+++ b/packages/nuxt-dx/src/size-budget/match.ts
@@ -1,0 +1,19 @@
+const EXTENSION = /\.(?:m|c)?[jt]sx?$|\.vue$/
+
+/** Plugin paths come from config without a guaranteed extension; rollup ids carry one plus a query. */
+export function normalizeForMatch(id: string): string {
+  return id
+    .replace(/\\/g, '/')
+    .replace(/^\0/, '')
+    .split('?')[0]!
+    .replace(EXTENSION, '')
+}
+
+export function matchTargetId(path: string, moduleIds: Iterable<string>): string | undefined {
+  const wanted = normalizeForMatch(path)
+  for (const id of moduleIds) {
+    if (normalizeForMatch(id) === wanted)
+      return id
+  }
+  return undefined
+}

--- a/packages/nuxt-dx/src/size-budget/plugin-name.ts
+++ b/packages/nuxt-dx/src/size-budget/plugin-name.ts
@@ -1,0 +1,43 @@
+import { parseSync } from 'oxc-parser'
+import { walk } from 'oxc-walker'
+
+const DEFINE_NAMES = new Set(['defineNuxtPlugin', 'definePayloadPlugin'])
+
+function literalName(node: any): string | undefined {
+  if (node?.type !== 'ObjectExpression')
+    return undefined
+  for (const property of node.properties) {
+    if (property.type !== 'Property' || property.key?.name !== 'name')
+      continue
+    const value = property.value
+    return value?.type === 'Literal' && typeof value.value === 'string' ? value.value : undefined
+  }
+  return undefined
+}
+
+/**
+ * Reads the name from `defineNuxtPlugin({ name })` or `defineNuxtPlugin(fn, { name })`.
+ * Nuxt annotates plugins the same way, but only after `app:resolve`, and it does not
+ * expose the result, so the name is read straight from source here.
+ */
+export function extractPluginName(file: string, source: string): string | undefined {
+  let name: string | undefined
+  try {
+    const ast = parseSync(file, source, {
+      lang: file.endsWith('.tsx') ? 'tsx' : file.endsWith('.jsx') ? 'jsx' : 'ts',
+      sourceType: 'module',
+    })
+    walk(ast.program, {
+      enter(node: any) {
+        if (name || node.type !== 'CallExpression' || !DEFINE_NAMES.has(node.callee?.name))
+          return
+        name = literalName(node.arguments[0]) ?? literalName(node.arguments[1])
+      },
+    })
+  }
+  catch {
+    // A plugin that does not parse is Nuxt's problem to report; fall back to the file path label.
+    return undefined
+  }
+  return name
+}

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -1,0 +1,83 @@
+import type { TreeItem } from 'consola/utils'
+import type { PluginVerdict } from './budget'
+import { colors, formatTree } from 'consola/utils'
+import { formatBytes } from './size'
+
+export type BudgetScope = 'client' | 'nitro'
+
+const SCOPE = {
+  client: { noun: 'Nuxt plugin', bundle: 'client' },
+  nitro: { noun: 'Nitro plugin', bundle: 'server' },
+} as const satisfies Record<BudgetScope, { noun: string, bundle: string }>
+
+/** Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a warning. */
+export function displayId(id: string, rootDir: string): string {
+  const normalized = id.replace(/\\/g, '/').replace(/^\0/, '').split('?')[0]!
+  const root = `${rootDir.replace(/\\/g, '/').replace(/\/$/, '')}/`
+  const relative = normalized.startsWith(root) ? normalized.slice(root.length) : normalized
+  const fromPackages = relative.lastIndexOf('node_modules/')
+  return fromPackages === -1 ? relative : relative.slice(fromPackages + 'node_modules/'.length)
+}
+
+/** The key that would widen this plugin's budget: its name when it has one, otherwise its file. */
+function overrideKey(verdict: PluginVerdict, rootDir: string): string {
+  return verdict.name ?? displayId(verdict.path, rootDir)
+}
+
+function overrideSnippet(over: readonly PluginVerdict[], rootDir: string): string {
+  const entries = over.map((verdict) => {
+    // Round up to the next whole kB so the suggested budget actually clears the current size.
+    const kilobytes = Math.ceil(verdict.measurement.totalBytes / 1024)
+    return `'${overrideKey(verdict, rootDir)}': ${kilobytes}`
+  })
+  return `nuxtDx.sizeBudget.overridesKb = { ${entries.join(', ')} }`
+}
+
+/** Every byte charged to the plugin, so the listed sizes always sum to the reported total. */
+function breakdown(verdict: PluginVerdict, rootDir: string): TreeItem[] {
+  const { ownBytes, exclusiveBytes, exclusiveCount, heaviestDependencies } = verdict.measurement
+  const rows: { bytes: number, label: string, muted: boolean }[] = [
+    { bytes: ownBytes, label: 'the plugin file', muted: true },
+    ...heaviestDependencies.map(dependency => ({
+      bytes: dependency.bytes,
+      label: displayId(dependency.id, rootDir),
+      muted: false,
+    })),
+  ]
+
+  // Never let the list look complete when it is truncated.
+  const hidden = exclusiveCount - heaviestDependencies.length
+  if (hidden > 0) {
+    const shown = heaviestDependencies.reduce((total, dependency) => total + dependency.bytes, 0)
+    rows.push({ bytes: exclusiveBytes - shown, label: `across ${hidden} more module${hidden === 1 ? '' : 's'}`, muted: true })
+  }
+
+  const width = Math.max(...rows.map(row => formatBytes(row.bytes).length))
+  return rows.map(row => ({
+    text: `${formatBytes(row.bytes).padStart(width)}  ${row.muted ? colors.gray(row.label) : colors.dim(row.label)}`,
+  }))
+}
+
+export function formatBudgetReport(scope: BudgetScope, over: readonly PluginVerdict[], rootDir: string): string {
+  const { noun, bundle } = SCOPE[scope]
+  const lines = [`${over.length} ${noun}${over.length === 1 ? '' : 's'} over budget in the ${bundle} bundle`]
+
+  for (const verdict of over) {
+    const { name, path, budgetBytes, measurement } = verdict
+    const file = displayId(path, rootDir)
+    const overshoot = formatBytes(measurement.totalBytes - budgetBytes)
+    lines.push(
+      '',
+      `  ${name ? `${colors.bold(name)}  ${colors.dim(file)}` : colors.bold(file)}`,
+      `  ${formatBytes(measurement.totalBytes)} bundled, ${colors.red(`${overshoot} over`)} the ${formatBytes(budgetBytes)} budget`,
+      formatTree(breakdown(verdict, rootDir), { prefix: '    ' }).trimEnd(),
+    )
+  }
+
+  lines.push(
+    '',
+    colors.dim('  Defer heavy imports with `await import()`, or allow the size:'),
+    `    ${colors.cyan(overrideSnippet(over, rootDir))}`,
+  )
+  return lines.join('\n')
+}

--- a/packages/nuxt-dx/src/size-budget/rollup.ts
+++ b/packages/nuxt-dx/src/size-budget/rollup.ts
@@ -1,0 +1,64 @@
+import type { OutputBundle, Plugin } from 'rollup'
+import type { GraphModule, PluginMeasurement } from './graph'
+import type { BudgetScope } from './report'
+import { measurePluginCost } from './graph'
+import { matchTargetId } from './match'
+
+export interface MeasuredPlugin {
+  /** Absolute path to the plugin file, as Nuxt or Nitro resolved it. */
+  path: string
+  measurement: PluginMeasurement
+}
+
+export interface SizeBudgetPluginOptions {
+  scope: BudgetScope
+  /** Read lazily so plugins registered after this rollup plugin is created are included. */
+  paths: () => readonly string[]
+  onMeasured: (measured: readonly MeasuredPlugin[]) => void | Promise<void>
+}
+
+function collectGraph(bundle: OutputBundle, importedIdsOf: (id: string) => readonly string[]) {
+  const modules: GraphModule[] = []
+  const entryIds: string[] = []
+  for (const output of Object.values(bundle)) {
+    if (output.type !== 'chunk')
+      continue
+    if ((output.isEntry || output.isDynamicEntry) && output.facadeModuleId)
+      entryIds.push(output.facadeModuleId)
+    for (const [id, rendered] of Object.entries(output.modules))
+      modules.push({ id, bytes: rendered.renderedLength ?? 0, importedIds: importedIdsOf(id) })
+  }
+  return { modules, entryIds }
+}
+
+/**
+ * Measures the bundled weight of each plugin once the graph is final, so the cost
+ * reflects post-tree-shaking bytes rather than what the source file imports on paper.
+ */
+export function sizeBudgetRollupPlugin(options: SizeBudgetPluginOptions): Plugin {
+  return {
+    name: `nuxt-dx:size-budget:${options.scope}`,
+    async generateBundle(_outputOptions, bundle) {
+      const paths = options.paths()
+      if (!paths.length)
+        return
+
+      const { modules, entryIds } = collectGraph(bundle, id => this.getModuleInfo(id)?.importedIds ?? [])
+      const ids = modules.map(module => module.id)
+      const pathById = new Map<string, string>()
+      for (const path of paths) {
+        const id = matchTargetId(path, ids)
+        if (id)
+          pathById.set(id, path)
+      }
+      if (!pathById.size)
+        return
+
+      const measurements = measurePluginCost({ modules, targetIds: [...pathById.keys()], entryIds })
+      await options.onMeasured(measurements.map(measurement => ({
+        path: pathById.get(measurement.id)!,
+        measurement,
+      })))
+    },
+  }
+}

--- a/packages/nuxt-dx/src/size-budget/size.ts
+++ b/packages/nuxt-dx/src/size-budget/size.ts
@@ -1,0 +1,15 @@
+const UNITS = [
+  { label: 'GB', scale: 1024 ** 3 },
+  { label: 'MB', scale: 1024 ** 2 },
+  { label: 'kB', scale: 1024 },
+  { label: 'B', scale: 1 },
+] as const
+
+export function kilobytesToBytes(kilobytes: number): number {
+  return Math.round(kilobytes * 1024)
+}
+
+export function formatBytes(bytes: number): string {
+  const unit = UNITS.find(candidate => bytes >= candidate.scale) ?? UNITS[UNITS.length - 1]!
+  return `${Number((bytes / unit.scale).toFixed(1))} ${unit.label}`
+}

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -1,0 +1,91 @@
+import type { PluginVerdict } from '../src/size-budget/budget'
+import type { BudgetScope } from '../src/size-budget/report'
+import { stripAnsi } from 'consola/utils'
+import { describe, expect, it } from 'vitest'
+import { displayId, formatBudgetReport } from '../src/size-budget/report'
+
+describe('displayId', () => {
+  it('shortens project files to a root-relative path', () => {
+    expect(displayId('/app/plugins/analytics.ts', '/app')).toBe('plugins/analytics.ts')
+  })
+
+  it('shortens dependencies to their package path', () => {
+    expect(displayId('/app/node_modules/.pnpm/chart@1/node_modules/chart/dist/index.mjs', '/app')).toBe('chart/dist/index.mjs')
+  })
+
+  it('strips rollup virtual prefixes and queries', () => {
+    expect(displayId('\0/app/plugins/a.ts?v=1', '/app')).toBe('plugins/a.ts')
+  })
+})
+
+const verdict: PluginVerdict = {
+  path: '/app/plugins/analytics.ts',
+  budgetBytes: 20_480,
+  measurement: {
+    id: '/app/plugins/analytics.ts',
+    ownBytes: 1024,
+    exclusiveBytes: 81_920,
+    exclusiveCount: 1,
+    totalBytes: 82_944,
+    heaviestDependencies: [{ id: '/app/node_modules/chart/index.mjs', bytes: 81_920 }],
+  },
+}
+
+/** Colours are terminal dressing; assert on the text underneath. */
+function report(over: PluginVerdict[], scope: BudgetScope = 'client'): string {
+  return stripAnsi(formatBudgetReport(scope, over, '/app'))
+}
+
+describe('formatBudgetReport', () => {
+  it('says which bundle the budget applies to', () => {
+    expect(report([verdict])).toContain('1 Nuxt plugin over budget in the client bundle')
+    expect(report([verdict, verdict], 'nitro')).toContain('2 Nitro plugins over budget in the server bundle')
+  })
+
+  it('states the overshoot, not just the total', () => {
+    expect(report([verdict])).toContain('81 kB bundled, 61 kB over the 20 kB budget')
+  })
+
+  it('breaks the total down so the listed sizes account for every byte', () => {
+    const lines = report([verdict])
+    expect(lines).toContain('1 kB  the plugin file')
+    expect(lines).toContain('80 kB  chart/index.mjs')
+  })
+
+  it('leads with the plugin name but keeps the file visible', () => {
+    expect(report([{ ...verdict, name: 'analytics' }])).toContain('analytics  plugins/analytics.ts')
+  })
+
+  it('suggests an override keyed by name, rounded up past the current size', () => {
+    expect(report([{ ...verdict, name: 'analytics' }])).toContain('nuxtDx.sizeBudget.overridesKb = { \'analytics\': 81 }')
+  })
+
+  it('falls back to a path key when the plugin is unnamed', () => {
+    expect(report([verdict])).toContain('{ \'plugins/analytics.ts\': 81 }')
+  })
+
+  it('lists every offender in one override snippet', () => {
+    expect(report([{ ...verdict, name: 'analytics' }, { ...verdict, name: 'tracker' }]))
+      .toContain('{ \'analytics\': 81, \'tracker\': 81 }')
+  })
+
+  it('accounts for dependencies it did not list', () => {
+    const truncated: PluginVerdict = {
+      ...verdict,
+      measurement: { ...verdict.measurement, exclusiveCount: 4, exclusiveBytes: 100_000 },
+    }
+    expect(report([truncated])).toContain('17.7 kB  across 3 more modules')
+  })
+
+  it('does not mention hidden modules when the list is complete', () => {
+    expect(report([verdict])).not.toContain('more module')
+  })
+
+  it('points at a concrete fix', () => {
+    expect(report([verdict])).toContain('await import()')
+  })
+
+  it('stays compact for a single offender', () => {
+    expect(report([verdict]).split('\n')).toHaveLength(9)
+  })
+})

--- a/packages/nuxt-dx/tests/budget.test.ts
+++ b/packages/nuxt-dx/tests/budget.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { budgetFor, smallestBudget } from '../src/size-budget/budget'
+
+const OVERRIDES = [
+  { fragment: 'analytics', bytes: 60_000 },
+  { fragment: 'server/plugins/queue', bytes: 5000 },
+]
+
+describe('smallestBudget', () => {
+  it('is the default when no override is lower', () => {
+    expect(smallestBudget(20_000, [{ fragment: 'analytics', bytes: 60_000 }])).toBe(20_000)
+  })
+
+  it('drops to the lowest override so a tightened budget still gets screened', () => {
+    expect(smallestBudget(20_000, OVERRIDES)).toBe(5000)
+  })
+
+  it('is the default when there are no overrides', () => {
+    expect(smallestBudget(20_000, [])).toBe(20_000)
+  })
+})
+
+describe('budgetFor', () => {
+  it('falls back to the default', () => {
+    expect(budgetFor('/app/plugins/other.ts', undefined, 20_000, OVERRIDES)).toBe(20_000)
+  })
+
+  it('matches an override by plugin name', () => {
+    expect(budgetFor('/app/plugins/heavy.ts', 'analytics', 20_000, OVERRIDES)).toBe(60_000)
+  })
+
+  it('matches an override by path fragment', () => {
+    expect(budgetFor('/app/server/plugins/queue.ts', undefined, 20_000, OVERRIDES)).toBe(5000)
+  })
+
+  it('prefers a name match over a path match', () => {
+    const overrides = [{ fragment: 'plugins/heavy', bytes: 1000 }, { fragment: 'analytics', bytes: 60_000 }]
+    expect(budgetFor('/app/plugins/heavy.ts', 'analytics', 20_000, overrides)).toBe(60_000)
+  })
+
+  it('matches path fragments written with windows separators', () => {
+    expect(budgetFor('C:\\app\\server\\plugins\\queue.ts', undefined, 20_000, OVERRIDES)).toBe(5000)
+  })
+})

--- a/packages/nuxt-dx/tests/graph.test.ts
+++ b/packages/nuxt-dx/tests/graph.test.ts
@@ -1,0 +1,88 @@
+import type { GraphModule } from '../src/size-budget/graph'
+import { describe, expect, it } from 'vitest'
+import { measurePluginCost } from '../src/size-budget/graph'
+
+function mod(id: string, bytes: number, importedIds: string[] = []): GraphModule {
+  return { id, bytes, importedIds }
+}
+
+// entry -> plugins.mjs -> { analytics, tracker }
+// analytics exclusively owns chart + chart-core; tracker owns nothing exclusive
+// vue is reachable from the entry directly, so no plugin is charged for it
+const MODULES = [
+  mod('/app/entry.js', 100, ['/build/plugins.mjs', '/node_modules/vue/index.mjs']),
+  mod('/build/plugins.mjs', 50, ['/app/plugins/analytics.ts', '/app/plugins/tracker.ts']),
+  mod('/app/plugins/analytics.ts', 1000, ['/node_modules/chart/index.mjs', '/node_modules/vue/index.mjs']),
+  mod('/app/plugins/tracker.ts', 200, ['/node_modules/shared/index.mjs']),
+  mod('/node_modules/chart/index.mjs', 60_000, ['/node_modules/chart-core/index.mjs']),
+  mod('/node_modules/chart-core/index.mjs', 20_000, []),
+  mod('/node_modules/shared/index.mjs', 5000, []),
+  mod('/node_modules/vue/index.mjs', 90_000, []),
+]
+
+const TARGET_IDS = ['/app/plugins/analytics.ts', '/app/plugins/tracker.ts']
+
+function measure(modules = MODULES, targetIds = TARGET_IDS) {
+  return measurePluginCost({ modules, targetIds, entryIds: ['/app/entry.js'] })
+}
+
+describe('measurePluginCost', () => {
+  it('charges a plugin for the modules only it pulls in', () => {
+    const [analytics] = measure()
+    expect(analytics.ownBytes).toBe(1000)
+    expect(analytics.exclusiveBytes).toBe(80_000)
+    expect(analytics.totalBytes).toBe(81_000)
+  })
+
+  it('does not charge a plugin for modules the app already ships', () => {
+    const [analytics] = measure()
+    expect(analytics.heaviestDependencies.map(dep => dep.id)).not.toContain('/node_modules/vue/index.mjs')
+  })
+
+  it('ranks the heaviest exclusive dependencies first', () => {
+    const [analytics] = measure()
+    expect(analytics.heaviestDependencies).toEqual([
+      { id: '/node_modules/chart/index.mjs', bytes: 60_000 },
+      { id: '/node_modules/chart-core/index.mjs', bytes: 20_000 },
+    ])
+  })
+
+  it('splits a dependency shared between two plugins away from both', () => {
+    const modules = [...MODULES, mod('/app/plugins/extra.ts', 10, ['/node_modules/chart/index.mjs'])]
+    modules[1] = mod('/build/plugins.mjs', 50, ['/app/plugins/analytics.ts', '/app/plugins/tracker.ts', '/app/plugins/extra.ts'])
+    const [analytics] = measure(modules, [...TARGET_IDS, '/app/plugins/extra.ts'])
+    expect(analytics.exclusiveBytes).toBe(0)
+    expect(analytics.totalBytes).toBe(1000)
+  })
+
+  it('reports a plugin with no exclusive dependencies at its own size', () => {
+    const [, tracker] = measure()
+    expect(tracker.totalBytes).toBe(5200)
+  })
+
+  it('skips targets that were tree-shaken out of the bundle', () => {
+    expect(measure(MODULES, [...TARGET_IDS, '/app/plugins/gone.ts'])).toHaveLength(2)
+  })
+
+  it('ignores imports that never landed in the bundle', () => {
+    const modules = [
+      mod('/app/entry.js', 10, ['/app/plugins/a.ts']),
+      mod('/app/plugins/a.ts', 10, ['node:crypto', '/node_modules/x/index.mjs']),
+      mod('/node_modules/x/index.mjs', 30, ['external-package']),
+    ]
+    const [a] = measure(modules, ['/app/plugins/a.ts'])
+    expect(a.totalBytes).toBe(40)
+    expect(a.heaviestDependencies).toEqual([{ id: '/node_modules/x/index.mjs', bytes: 30 }])
+  })
+
+  it('survives a dependency cycle', () => {
+    const modules = [
+      mod('/app/entry.js', 10, ['/app/plugins/a.ts']),
+      mod('/app/plugins/a.ts', 10, ['/node_modules/x/index.mjs']),
+      mod('/node_modules/x/index.mjs', 30, ['/node_modules/y/index.mjs']),
+      mod('/node_modules/y/index.mjs', 40, ['/node_modules/x/index.mjs']),
+    ]
+    const [a] = measure(modules, ['/app/plugins/a.ts'])
+    expect(a.totalBytes).toBe(80)
+  })
+})

--- a/packages/nuxt-dx/tests/match.test.ts
+++ b/packages/nuxt-dx/tests/match.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { matchTargetId, normalizeForMatch } from '../src/size-budget/match'
+
+describe('normalizeForMatch', () => {
+  it('drops extensions, queries, virtual prefixes and windows separators', () => {
+    expect(normalizeForMatch('C:\\app\\plugins\\a.client.ts')).toBe('C:/app/plugins/a.client')
+    expect(normalizeForMatch('/app/plugins/a.mjs?v=123')).toBe('/app/plugins/a')
+    expect(normalizeForMatch('\0/app/plugins/a.vue')).toBe('/app/plugins/a')
+  })
+})
+
+describe('matchTargetId', () => {
+  const ids = ['/app/plugins/analytics.ts?v=1', '/app/plugins/other.mjs']
+
+  it('matches an extensionless config path to the bundled module id', () => {
+    expect(matchTargetId('/app/plugins/analytics', ids)).toBe('/app/plugins/analytics.ts?v=1')
+  })
+
+  it('returns undefined when the plugin never reached the bundle', () => {
+    expect(matchTargetId('/app/plugins/missing.ts', ids)).toBeUndefined()
+  })
+})

--- a/packages/nuxt-dx/tests/plugin-name.test.ts
+++ b/packages/nuxt-dx/tests/plugin-name.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { extractPluginName } from '../src/size-budget/plugin-name'
+
+const file = '/app/plugins/analytics.ts'
+
+describe('extractPluginName', () => {
+  it('reads a name off the plugin object', () => {
+    expect(extractPluginName(file, `
+      export default defineNuxtPlugin({
+        name: 'analytics',
+        setup() {},
+      })
+    `)).toBe('analytics')
+  })
+
+  it('reads a name off the second meta argument', () => {
+    expect(extractPluginName(file, `
+      export default defineNuxtPlugin(() => {}, { name: 'analytics' })
+    `)).toBe('analytics')
+  })
+
+  it('prefers the plugin object over the meta argument, matching Nuxt', () => {
+    expect(extractPluginName(file, `
+      export default defineNuxtPlugin({ name: 'from-object', setup() {} }, { name: 'from-meta' })
+    `)).toBe('from-object')
+  })
+
+  it('supports definePayloadPlugin', () => {
+    expect(extractPluginName(file, `
+      export default definePayloadPlugin({ name: 'revivers', setup() {} })
+    `)).toBe('revivers')
+  })
+
+  it('returns undefined for an anonymous function plugin', () => {
+    expect(extractPluginName(file, `
+      export default defineNuxtPlugin(() => {})
+    `)).toBeUndefined()
+  })
+
+  it('ignores a computed or non-literal name', () => {
+    expect(extractPluginName(file, `
+      const id = 'analytics'
+      export default defineNuxtPlugin({ name: id, setup() {} })
+    `)).toBeUndefined()
+  })
+
+  it('returns undefined rather than throwing on unparsable source', () => {
+    expect(extractPluginName(file, 'export default defineNuxtPlugin({{{')).toBeUndefined()
+  })
+})

--- a/packages/nuxt-dx/tests/size.test.ts
+++ b/packages/nuxt-dx/tests/size.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { formatBytes, kilobytesToBytes } from '../src/size-budget/size'
+
+describe('kilobytesToBytes', () => {
+  it('scales by 1024 and lands on a whole byte count', () => {
+    expect(kilobytesToBytes(20)).toBe(20480)
+    expect(kilobytesToBytes(1.5)).toBe(1536)
+    expect(kilobytesToBytes(0.001)).toBe(1)
+  })
+})
+
+describe('formatBytes', () => {
+  it('scales to a readable unit', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(20480)).toBe('20 kB')
+    expect(formatBytes(1572864)).toBe('1.5 MB')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
+    rollup:
+      specifier: ^4.62.4
+      version: 4.62.4
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -237,6 +240,15 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      consola:
+        specifier: 'catalog:'
+        version: 3.4.2
+      oxc-parser:
+        specifier: 'catalog:'
+        version: 0.140.0
+      oxc-walker:
+        specifier: 'catalog:'
+        version: 1.0.0(esbuild@0.28.2)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -259,6 +271,9 @@ importers:
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+      rollup:
+        specifier: 'catalog:'
+        version: 4.62.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ catalog:
   oxc-parser: 0.140.0
   oxc-walker: 1.0.0
   pathe: ^2.0.3
+  rollup: ^4.62.4
   typescript: ^5.9.3
   unbuild: ^3.6.1
   vitest: ^4.1.10


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A plugin that pulls a heavy dependency into the client bundle is invisible until you go digging through a bundle analyzer. `@harlan-zw/nuxt-dx` now measures every Nuxt app plugin and Nitro plugin at build time and warns when one exceeds a kilobyte budget.

Each plugin is charged its own bundled size plus every module reachable only through it. Anything the app already reaches without passing through a plugin, or that a second plugin also reaches, is shared and charged to nobody. Sizes are post-tree-shaking `renderedLength` read off the final rollup graph in `generateBundle`, so the number reflects what actually ships.

```
[nuxt-dx]  WARN  1 Nuxt plugin over budget in the client bundle

  analytics  app/plugins/heavy.client.ts
  31.5 kB bundled, 21.5 kB over the 10 kB budget
    ├─  310 B  the plugin file
    ├─ 3.9 kB  app/lib/part1.ts
    ├─ 3.9 kB  app/lib/part2.ts
    ├─ 3.9 kB  app/lib/part3.ts
    └─19.5 kB  across 5 more modules

  Defer heavy imports with `await import()`, or allow the size:
    nuxtDx.sizeBudget.overridesKb = { 'analytics': 32 }
```

Config, all optional:

```ts
nuxtDx: {
  sizeBudget: {
    pluginsKb: 20,        // per Nuxt app plugin, false to disable
    nitroPluginsKb: 50,   // per Nitro plugin, false to disable
    overridesKb: { analytics: 60 },
    fail: false,          // throw instead of warn
  },
}
```

Overrides are keyed by plugin name or by any fragment of the plugin path. Names come from `defineNuxtPlugin({ name })` and `defineNuxtPlugin(fn, { name })`. Nuxt's own `annotatePlugins` runs after `app:resolve` and never writes the result back to `app.plugins`, so names are read from source with `oxc-parser`, and only for plugins big enough to be at risk. A build where everything fits parses no plugin sources.

Nitro bundles in both `nuxi dev` and `nuxi build`, so Nitro plugin budgets report in either. The client is served unbundled in dev, so app plugin budgets report on `nuxi build`.

### 🧪 Verification

44 unit tests cover graph attribution, budget resolution, name extraction, and report formatting. Verified end to end on a Nuxt 4.5 fixture for both scopes: warning fires, does not fire when under budget, `overridesKb` raises and tightens correctly by name and by path, `fail: true` exits 1, and the truncated dependency list sums to the reported total.

### 📦 Package changes

`@harlan-zw/nuxt-dx` gains `consola`, `oxc-parser`, and `oxc-walker` as dependencies, plus `rollup` as a dev dependency for plugin types. `rollup` added to the workspace catalog.