### PR TITLE
docs: standardise module READMEs on the house style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,71 @@
-# Harlan Nuxt
+<h1>Harlan Nuxt</h1>
 
-Experimental public Nuxt packages maintained together for shared tooling,
-consistent verification, and independent releases.
+[![License][license-src]][license-href]
+[![Nuxt][nuxt-src]][nuxt-href]
+
+A monorepo of experimental Nuxt modules, kept together for shared tooling and consistent verification, and released independently.
+
+Every package here is published under the `experimental` npm tag. Versions and release notes are per package, so one module moving fast never forces a version bump on the others.
+
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
 
 ## Packages
 
-| Package | Purpose |
+| Package | What it does |
 | --- | --- |
-| `@harlan-zw/nuxt-cf-jobs` | Typed Cloudflare queue jobs for Nuxt. |
-| `@harlan-zw/nuxt-use-query` | Nuxt-native queries, mutations, subscriptions, and RPC. |
-| `@harlan-zw/nuxt-domain-events` | Lazy server-side domain events and listeners. |
-| `@harlan-zw/nuxt-dx` | Nuxt diagnostics: dev error overlay, agent handoff, plugin size budgets. |
-| `@harlan-zw/nuxt-github-sponsors` | Typed GitHub Sponsors data, tiers, route, and composable. |
+| [`@harlan-zw/nuxt-cf-jobs`](./packages/nuxt-cf-jobs) | ☁️ Typed Cloudflare Queue jobs with file-based definitions, optional D1 durability, scheduled tasks, and an operations CLI. |
+| [`@harlan-zw/nuxt-use-query`](./packages/nuxt-use-query) | 🔄 Nuxt-native queries, mutations, and subscriptions with SWR, invalidation, polling, and typed RPC contracts. |
+| [`@harlan-zw/nuxt-domain-events`](./packages/nuxt-domain-events) | 📣 Layer-aware server domain events with generated lazy registries and after-commit queue publication. |
+| [`@harlan-zw/nuxt-dx`](./packages/nuxt-dx) | 🚨 Diagnostics: a client error overlay with agent handoff, and bundle size budgets for Nuxt and Nitro plugins. |
+| [`@harlan-zw/nuxt-github-sponsors`](./packages/nuxt-github-sponsors) | 💖 Typed GitHub Sponsors data with tiers, profile overrides, a public route, and a composable. |
 
-All packages are experimental. Package versions and release notes are independent.
+## Development
+
+Requires Node 22.12+ and pnpm.
+
+```bash
+pnpm install
+pnpm dev:prepare
+```
+
+Then, from the repo root to run every package, or from a package directory to run just that one:
+
+```bash
+pnpm lint       # eslint, includes markdown and code blocks
+pnpm typecheck  # nuxt typecheck / tsc per package
+pnpm test       # vitest
+pnpm build      # nuxt-module-builder / obuild
+```
+
+Packages are pnpm workspace members under `packages/*`. Shared dependency versions live in the `catalog:` block of `pnpm-workspace.yaml`, so bump a version there rather than in each package.
 
 ## Releases
 
-Push a `<package>-v<version>` tag, for example `nuxt-dx-v0.0.2`. The trusted
-GitHub Actions publisher releases that package under the `experimental` npm tag
-with provenance.
+Push a `<package>-v<version>` tag, for example `nuxt-dx-v0.0.2`. The trusted GitHub Actions publisher releases that package under the `experimental` npm tag with provenance.
+
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
+## License
+
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/LICENSE.md).
+
+<!-- Badges -->
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/LICENSE.md
+
+[nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
+[nuxt-href]: https://nuxt.com

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-A monorepo of experimental Nuxt modules, kept together for shared tooling and consistent verification, and released independently.
+Experimental Nuxt modules developed in one repo, so they share tooling and a single verification pipeline.
 
-Every package here is published under the `experimental` npm tag. Versions and release notes are per package, so one module moving fast never forces a version bump on the others.
+Every package here publishes under the `experimental` npm tag. Versions and release notes are per package, so one module moving fast never forces a version bump on the others.
 
 <p align="center">
 <table>
@@ -36,7 +36,7 @@ pnpm install
 pnpm dev:prepare
 ```
 
-Then, from the repo root to run every package, or from a package directory to run just that one:
+Run these from the repo root to cover every package, or from a package directory for just that one:
 
 ```bash
 pnpm lint       # eslint, includes markdown and code blocks

--- a/packages/nuxt-cf-jobs/README.md
+++ b/packages/nuxt-cf-jobs/README.md
@@ -725,15 +725,23 @@ pnpm test:e2e
 
 `test` runs the unit project. `test:nitro` runs the generated registry in a real Nuxt server. `test:e2e` starts Wrangler fixtures and exercises the Cloudflare Queues and D1 round trip through workerd.
 
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
 ## License
 
 Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-cf-jobs/LICENSE.md).
 
 <!-- Badges -->
-[npm-version-src]: https://img.shields.io/npm/v/%40harlanzw%2Fnuxt-cf-jobs/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-src]: https://img.shields.io/npm/v/%40harlan-zw%2Fnuxt-cf-jobs/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
 [npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-cf-jobs
 
-[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlanzw%2Fnuxt-cf-jobs.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlan-zw%2Fnuxt-cf-jobs.svg?style=flat&colorA=18181B&colorB=28CF8D
 [npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-cf-jobs
 
 [license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D

--- a/packages/nuxt-cf-jobs/README.md
+++ b/packages/nuxt-cf-jobs/README.md
@@ -21,14 +21,11 @@ Status: experimental. APIs may change before the first scoped release.
 
 ## Features
 
-- 📁 **File-based jobs:** put a `defineJob` file in `server/jobs` and the module builds the registry.
-- 🔒 **Typed dispatch:** job names, payloads, queues, and broadcast messages are inferred from your files.
+- 📁 **File-based typed jobs:** drop a `defineJob` file in `server/jobs` and the module builds the registry, inferring names, payloads, queues, and broadcast messages.
 - ☁️ **Cloudflare Queues:** route jobs across multiple producer bindings and consume them through Nitro's `cloudflare:queue` hook.
 - 🗄️ **Optional D1 durability:** persist jobs before dispatch, recover missed sends, track attempts, and keep failed jobs.
 - ⏰ **Scheduled tasks:** declare the cron beside the task and generate Nitro and Cloudflare scheduling config from it.
 - 📡 **Realtime progress:** publish job and batch events over Nitro WebSockets and a Durable Object.
-- 🧪 **Queue test harnesses:** run jobs inline, record dispatches, or drive retries on a virtual clock.
-- 🛠️ **Operations CLI:** inspect, retry, prune, and migrate local or remote D1 job tables.
 
 ## Quick start
 

--- a/packages/nuxt-domain-events/README.md
+++ b/packages/nuxt-domain-events/README.md
@@ -1,10 +1,35 @@
-# `@harlan-zw/nuxt-domain-events`
+<h1>@harlan-zw/nuxt-domain-events</h1>
 
-Functional, layer-aware Nuxt server events with generated lazy registries.
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![License][license-src]][license-href]
+[![Nuxt][nuxt-src]][nuxt-href]
+
+Nuxt Domain Events gives your server runtime functional, layer-aware events with generated lazy registries, so a producer never has to import the listeners it triggers.
 
 Status: experimental. APIs may change before the first release.
 
-## Install
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
+
+## Features
+
+- 🗂️ **Generated lazy registries:** layer-aware, so producers never import a queued listener implementation.
+- 🎚️ **Explicit execution modes:** serial synchronous by default, with `sync` isolation, `deferred`, and `queued` as opt-ins.
+- 📦 **Two contract kinds:** `local` for request-scoped state, `transfer` for versioned JSON with a byte limit.
+- 🏷️ **Errors as tagged values:** unknown event, payload mismatch, lazy import failure, registry drift, queue failure, and after-commit misuse.
+- 🔁 **Idempotent queued delivery:** stable delivery IDs derived from your `eventId` and the listener name.
+- 💾 **After-commit publication:** stage queue rows beside domain SQL so a rollback leaves zero queue evidence.
+- ☁️ **Structural Cloudflare adapter:** works with `@harlan-zw/nuxt-cf-jobs` without coupling the event core to it.
+
+## Installation
 
 ```bash
 pnpm add @harlan-zw/nuxt-domain-events
@@ -16,16 +41,61 @@ export default defineNuxtConfig({
 })
 ```
 
+## Execution modes
+
 Listeners run like Laravel listeners. Omitting `execution` means serial synchronous execution with propagated failure. That failure aborts the producer and prevents deferred work or queue publication. `sync` isolation, `deferred`, and `queued` are explicit alternatives.
 
-`local` event contracts may carry request-scoped or mutable state. They support synchronous listeners and same-isolate deferred `waitUntil` listeners, but never queued delivery. `transfer` contracts own a versioned JSON codec and byte limit. Queued delivery parses that contract before importing or invoking the selected listener.
+Queued listeners cannot declare `shouldHandle`; synchronous and deferred listeners may use it as an in-process condition. Queued listeners may declare a functional `failed(payload, context, error)` callback, invoked after terminal settlement.
+
+## Event contracts
+
+`local` event contracts may carry request-scoped or mutable state. They support synchronous listeners and same-isolate deferred `waitUntil` listeners, but never queued delivery.
+
+`transfer` contracts own a versioned JSON codec and byte limit. Queued delivery parses that contract before importing or invoking the selected listener.
+
+## Errors
 
 Runtime errors are tagged `Error` values and reject dispatch. Expected tags include unknown event, payload mismatch, lazy import failure, registry drift, queue failure, and after-commit misuse. Observer defects run the configured fallback, or `console.error`, without changing or relabelling the business outcome.
 
+## Queued listeners
+
 Queued listeners require explicit idempotency and a caller-provided stable `eventId`. The generated delivery ID is stable from `eventId + listenerName`. Producer dispatch never imports a queued listener implementation.
 
-After-commit flow uses `planEvent`, then `commitEventPlan`. In v1, every listener for that event must be queued with `publication: 'after-commit'`. D1 batch is non-interactive, so it cannot run ordinary listeners after domain SQL while still allowing their failure to roll back that SQL. Split the event contract when one producer needs both ordinary and after-commit listeners. The caller-supplied unit of work stages the adapter's unpublished D1 statements beside domain writes. It returns `rolled-back` with zero queue evidence, or the adapter's exact staged-delivery receipt only after D1 resolves. A failed send remains an unpublished durable row for recovery.
+## After-commit events
+
+After-commit flow uses `planEvent`, then `commitEventPlan`. In v1, every listener for that event must be queued with `publication: 'after-commit'`. D1 batch is non-interactive, so it cannot run ordinary listeners after domain SQL while still allowing their failure to roll back that SQL. Split the event contract when one producer needs both ordinary and after-commit listeners.
+
+The caller-supplied unit of work stages the adapter's unpublished D1 statements beside domain writes. It returns `rolled-back` with zero queue evidence, or the adapter's exact staged-delivery receipt only after D1 resolves. A failed send remains an unpublished durable row for recovery.
+
+## Cloudflare Jobs adapter
 
 The `./cf-jobs` adapter accepts the public `@harlan-zw/nuxt-cf-jobs/outbox` functions structurally. This keeps the event core runtime-neutral and the dependency one-way. Its generic delivery definition declares the static `maintenance` queue for `@harlan-zw/nuxt-cf-jobs` registry locality; the public outbox route override intentionally stores each listener job on the queue declared by that listener.
 
-Deferred in v1: mixed ordinary and after-commit listeners on one transaction-bound event, producer-time Laravel `shouldQueue`, cooperative listener timeouts, listener ordering contracts, grouped subscriber modules, dashboards, CLI, and compatibility shims. Queued listeners cannot declare `shouldHandle`; synchronous and deferred listeners may use it as an in-process condition. Queued listeners may declare a functional `failed(payload, context, error)` callback, invoked after terminal settlement.
+## Not in v1
+
+Deferred for now: mixed ordinary and after-commit listeners on one transaction-bound event, producer-time Laravel `shouldQueue`, cooperative listener timeouts, listener ordering contracts, grouped subscriber modules, dashboards, CLI, and compatibility shims.
+
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
+## License
+
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-domain-events/LICENSE.md).
+
+<!-- Badges -->
+[npm-version-src]: https://img.shields.io/npm/v/%40harlan-zw%2Fnuxt-domain-events/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-domain-events
+
+[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlan-zw%2Fnuxt-domain-events.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-domain-events
+
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-domain-events/LICENSE.md
+
+[nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
+[nuxt-href]: https://nuxt.com

--- a/packages/nuxt-domain-events/README.md
+++ b/packages/nuxt-domain-events/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-Nuxt Domain Events gives your server runtime functional, layer-aware events with generated lazy registries, so a producer never has to import the listeners it triggers.
+Nuxt Domain Events lets a producer fire a server-side event without importing any of the listeners that handle it. Registries are generated per layer and imported lazily.
 
 Status: experimental. APIs may change before the first release.
 
@@ -25,9 +25,7 @@ Status: experimental. APIs may change before the first release.
 - 🎚️ **Explicit execution modes:** serial synchronous by default, with `sync` isolation, `deferred`, and `queued` as opt-ins.
 - 📦 **Two contract kinds:** `local` for request-scoped state, `transfer` for versioned JSON with a byte limit.
 - 🏷️ **Errors as tagged values:** unknown event, payload mismatch, lazy import failure, registry drift, queue failure, and after-commit misuse.
-- 🔁 **Idempotent queued delivery:** stable delivery IDs derived from your `eventId` and the listener name.
 - 💾 **After-commit publication:** stage queue rows beside domain SQL so a rollback leaves zero queue evidence.
-- ☁️ **Structural Cloudflare adapter:** works with `@harlan-zw/nuxt-cf-jobs` without coupling the event core to it.
 
 ## Installation
 

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -21,12 +21,11 @@ Status: experimental. APIs may change before the first release.
 
 ## Features
 
-- 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge.
+- 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge, and a strict production no-op.
 - 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
 - 📦 **Plugin size budgets:** warn when a Nuxt or Nitro plugin drags too much JavaScript into the bundle.
 - 🔍 **Exclusive attribution:** each plugin is charged only for what it alone pulls in, so shared dependencies are not double counted.
 - 🎯 **Per-plugin overrides:** budgets keyed by `defineNuxtPlugin` name or path fragment, with an optional build failure.
-- 🚫 **Zero production cost:** the overlay is a strict production no-op.
 
 ## Installation
 

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -1,6 +1,34 @@
-# `@harlan-zw/nuxt-dx`
+<h1>@harlan-zw/nuxt-dx</h1>
 
-Experimental diagnostics for Nuxt: a development error overlay, and bundle size budgets for Nuxt and Nitro plugins.
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![License][license-src]][license-href]
+[![Nuxt][nuxt-src]][nuxt-href]
+
+Nuxt DX is a diagnostics module that surfaces problems you would otherwise have to go looking for: client errors while you develop, and plugins that quietly bloat your bundle when you build.
+
+Status: experimental. APIs may change before the first release.
+
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
+
+## Features
+
+- 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge.
+- 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
+- 📦 **Plugin size budgets:** warn when a Nuxt or Nitro plugin drags too much JavaScript into the bundle.
+- 🔍 **Exclusive attribution:** each plugin is charged only for what it alone pulls in, so shared dependencies are not double counted.
+- 🎯 **Per-plugin overrides:** budgets keyed by `defineNuxtPlugin` name or path fragment, with an optional build failure.
+- 🚫 **Zero production cost:** the overlay is a strict production no-op.
+
+## Installation
 
 ```bash
 pnpm add -D @harlan-zw/nuxt-dx
@@ -85,4 +113,27 @@ Set `sizeBudget: false` to turn the check off entirely.
 
 Budgets are measured whenever a bundle is produced. Nitro is bundled in both `nuxi dev` and `nuxi build`, so Nitro plugin budgets report in either. The client is served unbundled in dev, so app plugin budgets only report on `nuxi build`.
 
-APIs may change before the first release.
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
+## License
+
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-dx/LICENSE.md).
+
+<!-- Badges -->
+[npm-version-src]: https://img.shields.io/npm/v/%40harlan-zw%2Fnuxt-dx/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-dx
+
+[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlan-zw%2Fnuxt-dx.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-dx
+
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-dx/LICENSE.md
+
+[nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
+[nuxt-href]: https://nuxt.com

--- a/packages/nuxt-github-sponsors/README.md
+++ b/packages/nuxt-github-sponsors/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-Nuxt GitHub Sponsors gives your site typed access to your GitHub sponsors, without shipping a UI you then have to fight.
+Nuxt GitHub Sponsors fetches your GitHub sponsors and hands them to your app as typed data. It ships no UI, so your sponsor page stays yours to design.
 
 Status: experimental. APIs may change before the first release.
 
@@ -21,11 +21,9 @@ Status: experimental. APIs may change before the first release.
 
 ## Features
 
-- 🔌 **Route and composable:** a public route plus `useGitHubSponsors()` for a typed response.
-- 📄 **Full pagination:** fetches every active sponsorship page, not just the first.
+- 🔌 **Route and composable:** a public route plus `useGitHubSponsors()` for a typed response, paginated across every active sponsorship.
 - 🔒 **Private sponsors filtered:** only a minimal public DTO leaves the server.
-- 🏅 **Configurable tiers:** assign tier keys by minimum monthly amount.
-- ✏️ **Profile overrides:** correct names, avatars, and links without patching GitHub.
+- 🏅 **Tiers and overrides:** assign tier keys by minimum monthly amount, and correct names, avatars, and links without patching GitHub.
 - ⚡ **One-day SWR cache:** only successful upstream results are cached.
 - 🎨 **Headless by design:** no sponsor UI, so your visual identity stays yours.
 

--- a/packages/nuxt-github-sponsors/README.md
+++ b/packages/nuxt-github-sponsors/README.md
@@ -1,8 +1,35 @@
-# `@harlan-zw/nuxt-github-sponsors`
+<h1>@harlan-zw/nuxt-github-sponsors</h1>
 
-Experimental GitHub Sponsors data for Nuxt sites.
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![License][license-src]][license-href]
+[![Nuxt][nuxt-src]][nuxt-href]
 
-The module registers a public route and `useGitHubSponsors`. The server core fetches all active sponsorship pages, parses GitHub responses, filters private sponsors, projects a minimal public DTO, applies explicit profile overrides, and assigns configurable tiers. Only successful upstream results receive the one-day SWR cache.
+Nuxt GitHub Sponsors gives your site typed access to your GitHub sponsors, without shipping a UI you then have to fight.
+
+Status: experimental. APIs may change before the first release.
+
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
+
+## Features
+
+- 🔌 **Route and composable:** a public route plus `useGitHubSponsors()` for a typed response.
+- 📄 **Full pagination:** fetches every active sponsorship page, not just the first.
+- 🔒 **Private sponsors filtered:** only a minimal public DTO leaves the server.
+- 🏅 **Configurable tiers:** assign tier keys by minimum monthly amount.
+- ✏️ **Profile overrides:** correct names, avatars, and links without patching GitHub.
+- ⚡ **One-day SWR cache:** only successful upstream results are cached.
+- 🎨 **Headless by design:** no sponsor UI, so your visual identity stays yours.
+
+## Installation
 
 ```bash
 pnpm add @harlan-zw/nuxt-github-sponsors
@@ -22,8 +49,39 @@ export default defineNuxtConfig({
 })
 ```
 
-Set `NUXT_GITHUB_SPONSORS_TOKEN` at runtime. The route returns an explicit `unavailable` state with reason `not-configured` when no token exists and a `502` response when GitHub cannot be refreshed. No secret is logged.
+Set `NUXT_GITHUB_SPONSORS_TOKEN` at runtime.
+
+## Usage
+
+The module registers a public route and `useGitHubSponsors`. The server core fetches all active sponsorship pages, parses GitHub responses, filters private sponsors, projects a minimal public DTO, applies explicit profile overrides, and assigns configurable tiers.
 
 The package intentionally has no sponsor UI. Each site keeps control of its visual identity and calls `useGitHubSponsors()` for a typed response.
 
-APIs may change before the first release.
+## Failure states
+
+The route returns an explicit `unavailable` state with reason `not-configured` when no token exists, and a `502` response when GitHub cannot be refreshed. No secret is logged.
+
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
+## License
+
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-github-sponsors/LICENSE.md).
+
+<!-- Badges -->
+[npm-version-src]: https://img.shields.io/npm/v/%40harlan-zw%2Fnuxt-github-sponsors/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-github-sponsors
+
+[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlan-zw%2Fnuxt-github-sponsors.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-github-sponsors
+
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-github-sponsors/LICENSE.md
+
+[nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
+[nuxt-href]: https://nuxt.com

--- a/packages/nuxt-use-query/README.md
+++ b/packages/nuxt-use-query/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-Nuxt Use Query gives you TanStack-shaped query composables built on Nuxt's own primitives, so caching, SWR, and invalidation work with the payload instead of beside it.
+Nuxt Use Query brings TanStack-shaped composables to Nuxt's own data layer, so caching, SWR, and invalidation run through the payload rather than alongside it.
 
 Status: experimental. APIs may change before the first scoped release.
 
@@ -21,11 +21,8 @@ Status: experimental. APIs may change before the first scoped release.
 
 ## Features
 
-- 🔄 **`useNuxtQuery`:** wraps Nuxt `useFetch` with TanStack-style stale-time revalidation, polling, enabled gates, and previous-data display.
-- ✍️ **`useNuxtMutation`:** wires mutations to query invalidation and optimistic cache rollback.
+- 🔄 **Queries and mutations:** `useNuxtQuery` wraps Nuxt `useFetch` with stale-time revalidation, polling, and enabled gates; `useNuxtMutation` adds invalidation and optimistic rollback.
 - 📇 **Typed RPC contracts:** `defineNuxtRpcQuery`, `defineNuxtRpcMutation`, `useNuxtRpcQuery`, and `useNuxtRpc` centralize Client -> API contracts in query folders with [Zod](https://zod.dev) request/response schemas.
-- 🚧 **Build-time enforcement:** optionally flag API path literals outside query folders, and query operations that skip shared contract imports or schemas.
-- 📡 **Server fetch telemetry:** optionally flag slow upstream calls and likely SSR request waterfalls.
 - 🗝️ **Cache control:** `invalidateNuxtQueries`, `getQueryData`, and `setQueryData` work with Nuxt payload and live `_asyncData` state.
 - ⚡ **Realtime bridge:** `useNuxtSubscription` pipes a WebSocket, SSE, or vendor SDK stream into the cache, with an optional `nuxtWebSocketSource` adapter built on [VueUse](https://vueuse.org).
 - 🧵 **SSR-safe by construction:** cache bookkeeping lives on the Nuxt app instance for per-request isolation.
@@ -45,7 +42,7 @@ The RPC composables wrap `useNuxtQuery`, so both layers live in the same cache a
 
 **Why the escape hatch exists**: writing a contract for a fetch you call once is overhead with no payoff. Reach for `useNuxtQuery` directly when there is no second caller to protect.
 
-**Mutations stay manual.** There is no `useNuxtRpcMutation` composable — `useNuxtMutation` plus `rpc.execute(operation, body)` is the recommended pattern (see [Execute Mutations](#4-execute-mutations) below). The thing worth writing by hand is the `invalidates` list, since a mutation operation does not know which read queries it should refresh; an auto-wrapper would hide exactly the decision you should make explicitly.
+**Mutations stay manual.** There is no `useNuxtRpcMutation` composable; `useNuxtMutation` plus `rpc.execute(operation, body)` is the recommended pattern (see [Execute Mutations](#4-execute-mutations) below). The thing worth writing by hand is the `invalidates` list, since a mutation operation does not know which read queries it should refresh; an auto-wrapper would hide exactly the decision you should make explicitly.
 
 ## Query Defaults
 
@@ -266,7 +263,7 @@ await updateSite.mutate({ name: 'Docs' })
 
 ## Escape Hatch: `useNuxtQuery` Directly
 
-Skip the RPC layer when the contract isn't yours to define — third-party APIs, one-off internal calls, prototypes, file downloads, or any request where a Zod schema would be ceremony with no payoff:
+Skip the RPC layer when the contract isn't yours to define: third-party APIs, one-off internal calls, prototypes, file downloads, or any request where a Zod schema would be ceremony with no payoff:
 
 ```ts
 const search = ref('')
@@ -325,7 +322,7 @@ if (previous)
 
 ## Realtime: `useNuxtSubscription`
 
-`useNuxtSubscription` bridges a realtime message stream into the cache. It does **not** own a connection: you inject the transport through `source`, and each message turns into explicit cache operations. The connection (auth, channels, reconnect) stays in whatever already owns it — a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) module, a vendor SDK, raw `useWebSocket` — and this is the standard seam from "a message arrived" to "this read is now stale".
+`useNuxtSubscription` bridges a realtime message stream into the cache. It does **not** own a connection: you inject the transport through `source`, and each message turns into explicit cache operations. The connection (auth, channels, reconnect) stays in whatever already owns it: a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) module, a vendor SDK, raw `useWebSocket`. This is the standard seam from "a message arrived" to "this read is now stale".
 
 ```ts
 import { z } from 'zod'
@@ -338,7 +335,7 @@ useNuxtSubscription({
   source: ctx => connectChannel('job-status', ctx.push),
   // Parse the untrusted frame once, at the boundary.
   schema: jobEvent,
-  // Map the parsed message to cache operations. Explicit by design — you
+  // Map the parsed message to cache operations. Explicit by design: you
   // decide which reads move, the same as a mutation's `invalidates`.
   onMessage: e => invalidateNuxtQueries(`sites:${e.siteId}`),
 })
@@ -346,9 +343,9 @@ useNuxtSubscription({
 
 It mirrors the rest of the package: callbacks run inside the Nuxt context (so the global cache helpers and composables resolve), failures surface through `onError` and an `error` ref rather than being swallowed, and `status` reports bridge establishment (`idle` / `connecting` / `active` / `error`).
 
-**`source` may call composables.** It runs in its own effect scope, so if your transport is itself a composable (`useWebSocket`, a channel composable), call it directly in `source` — its `onScopeDispose` / watchers are torn down with the subscription. Create them synchronously (before any `await`); only the synchronous portion of an async source is scoped.
+**`source` may call composables.** It runs in its own effect scope, so if your transport is itself a composable (`useWebSocket`, a channel composable), call it directly in `source`; its `onScopeDispose` and watchers are torn down with the subscription. Create them synchronously (before any `await`); only the synchronous portion of an async source is scoped.
 
-**Reconnect is a boundary, not magic.** The bridge only sees messages that arrive; events missed while the socket was down are not its concern. Cold-start recovery stays with `useNuxtQuery`'s refetch-on-mount. For mid-session reconnects, run `onReconnect` — typically a wider invalidation that catches up everything that drifted while disconnected. If the transport exposes a connection-status ref, `ctx.resyncOn` wires it for you (it fires `onReconnect` on every reconnect, never the initial connect); otherwise call `ctx.resync()` yourself:
+**Reconnect is a boundary you wire up yourself.** The bridge only sees messages that arrive; events missed while the socket was down are not its concern. Cold-start recovery stays with `useNuxtQuery`'s refetch-on-mount. For mid-session reconnects, run `onReconnect`, typically a wider invalidation that catches up everything that drifted while disconnected. If the transport exposes a connection-status ref, `ctx.resyncOn` wires it for you (it fires `onReconnect` on every reconnect, never the initial connect); otherwise call `ctx.resync()` yourself:
 
 ```ts
 useNuxtSubscription({
@@ -447,7 +444,7 @@ Use `telemetry: true` for the defaults. Set `timeout: false` to disable the defa
 const largePayloadThreshold = {
   default: 300_000,
   hosts: {
-    // a data/export API whose big responses are expected — silence it
+    // a data/export API whose big responses are expected, so silence it
     'searchconsole.googleapis.com': false,
   },
 }

--- a/packages/nuxt-use-query/README.md
+++ b/packages/nuxt-use-query/README.md
@@ -1,23 +1,34 @@
-# Nuxt Use Query
+<h1>@harlan-zw/nuxt-use-query</h1>
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-> Nuxt-native query composables with SWR, invalidation, polling, and optimistic cache writes.
+Nuxt Use Query gives you TanStack-shaped query composables built on Nuxt's own primitives, so caching, SWR, and invalidation work with the payload instead of beside it.
 
 Status: experimental. APIs may change before the first scoped release.
 
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
+
 ## Features
 
-- `useNuxtQuery` wraps Nuxt `useFetch` with TanStack-style stale-time revalidation, polling, enabled gates, and previous-data display.
-- `useNuxtMutation` wires mutations to query invalidation and optimistic cache rollback.
-- `defineNuxtRpcQuery`, `defineNuxtRpcMutation`, `useNuxtRpcQuery`, and `useNuxtRpc` let apps centralize Client -> API contracts in query folders with [Zod](https://zod.dev) request/response schemas.
-- Optional build-time contract enforcement flags API path literals outside query folders and query operations that skip shared contract imports or schemas.
-- Optional server `$fetch` telemetry flags slow upstream calls and likely SSR request waterfalls.
-- `invalidateNuxtQueries`, `getQueryData`, and `setQueryData` work with Nuxt payload and live `_asyncData` state.
-- `useNuxtSubscription` bridges a realtime message stream (WebSocket, SSE, vendor SDK) into the cache, with an optional `nuxtWebSocketSource` adapter built on [VueUse](https://vueuse.org).
-- Cache bookkeeping is stored on the Nuxt app instance for SSR-safe per-request isolation.
+- 🔄 **`useNuxtQuery`:** wraps Nuxt `useFetch` with TanStack-style stale-time revalidation, polling, enabled gates, and previous-data display.
+- ✍️ **`useNuxtMutation`:** wires mutations to query invalidation and optimistic cache rollback.
+- 📇 **Typed RPC contracts:** `defineNuxtRpcQuery`, `defineNuxtRpcMutation`, `useNuxtRpcQuery`, and `useNuxtRpc` centralize Client -> API contracts in query folders with [Zod](https://zod.dev) request/response schemas.
+- 🚧 **Build-time enforcement:** optionally flag API path literals outside query folders, and query operations that skip shared contract imports or schemas.
+- 📡 **Server fetch telemetry:** optionally flag slow upstream calls and likely SSR request waterfalls.
+- 🗝️ **Cache control:** `invalidateNuxtQueries`, `getQueryData`, and `setQueryData` work with Nuxt payload and live `_asyncData` state.
+- ⚡ **Realtime bridge:** `useNuxtSubscription` pipes a WebSocket, SSE, or vendor SDK stream into the cache, with an optional `nuxtWebSocketSource` adapter built on [VueUse](https://vueuse.org).
+- 🧵 **SSR-safe by construction:** cache bookkeeping lives on the Nuxt app instance for per-request isolation.
 
 ## Choosing A Layer
 
@@ -539,15 +550,27 @@ With enforcement enabled:
 
 Start without enforcement while migrating an existing site, then enable it once queries and contracts have been moved into the recommended directories.
 
+## Sponsors
+
+<p align="center">
+  <a href="https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg">
+    <img src='https://raw.githubusercontent.com/harlan-zw/static/main/sponsors.svg' alt='sponsors'/>
+  </a>
+</p>
+
 ## License
 
-[MIT](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-use-query/LICENSE.md)
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-use-query/LICENSE.md).
 
-[npm-version-src]: https://img.shields.io/npm/v/%40harlanzw%2Fnuxt-use-query/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+<!-- Badges -->
+[npm-version-src]: https://img.shields.io/npm/v/%40harlan-zw%2Fnuxt-use-query/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
 [npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-use-query
 
-[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlanzw%2Fnuxt-use-query.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-src]: https://img.shields.io/npm/dm/%40harlan-zw%2Fnuxt-use-query.svg?style=flat&colorA=18181B&colorB=28CF8D
 [npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-use-query
+
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/packages/nuxt-use-query/LICENSE.md
 
 [nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
 [nuxt-href]: https://nuxt.com


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The five package READMEs had drifted badly: 743, 553, 88, 31 and 29 lines, with three of them missing badges and structure entirely. This brings them all onto the format already used by `nuxt-robots`, `nuxt-og-image`, `nuxt-link-checker` and `@nuxtjs/sitemap`.

Template: `<h1>` → badge row → one-line pitch → status → sponsor block → `## Features` with emoji bullets → usage sections → `## Sponsors` → `## License` → badge definitions.

| Package | Before | Change |
| --- | --- | --- |
| `nuxt-cf-jobs` | already conformant | badge URL fix, Sponsors block |
| `nuxt-use-query` | partial | `<h1>`, license badge, sponsor blocks, emoji features, badge URL fix |
| `nuxt-dx` | no badges | full header and footer |
| `nuxt-domain-events` | wall of prose | full treatment, sectioned by topic |
| `nuxt-github-sponsors` | minimal | full treatment |

### 🐞 Badge fix

`nuxt-cf-jobs` and `nuxt-use-query` encoded the npm scope as `%40harlanzw` with no hyphen, but the packages publish as `@harlan-zw/*`. Both version and downloads badges have been rendering an "invalid" badge. Verified against shields:

```
old (%40harlanzw):  invalid
new (%40harlan-zw): v0.0.1
```

### 📓 Root README

Linked package table with real descriptions, plus a Development section covering `pnpm install && pnpm dev:prepare`, the four verification commands, and the `catalog:` convention in `pnpm-workspace.yaml`. Release-tag docs kept as-is.

`nuxt-domain-events` content was restructured into sections rather than rewritten, so no behavioural claims changed.

### 🧪 Verification

`pnpm lint` passes across all packages; eslint covers markdown and fenced code blocks in this repo. Structural check confirms all five READMEs now carry each element of the template exactly once, and no `%40harlanzw` references remain.