### PR TITLE
feat(dx): give hydration mismatches their own overlay issue kind

### DIFF
--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -22,10 +22,10 @@ Status: experimental. APIs may change before the first release.
 ## Features
 
 - 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge, and a strict production no-op.
+- 💧 **Hydration mismatches, decoded:** counted separately and read back as component, source file, and the two values that disagreed.
 - 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
 - 📦 **Plugin size budgets:** warn when a Nuxt or Nitro plugin drags too much JavaScript into the bundle.
-- 🔍 **Exclusive attribution:** each plugin is charged only for what it alone pulls in, so shared dependencies are not double counted.
-- 🎯 **Per-plugin overrides:** budgets keyed by `defineNuxtPlugin` name or path fragment, with an optional build failure.
+- 🔍 **Exclusive attribution and overrides:** each plugin is charged only for what it alone pulls in, with budgets keyed by `defineNuxtPlugin` name or path fragment.
 
 ## Installation
 
@@ -52,6 +52,33 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+## Hydration mismatches
+
+Hydration mismatches get their own count on the badge and their own section in the report. Vue hands them to `warnHandler` with the DOM nodes already flattened into the message, so the overlay parses that string back apart and pairs it with the component that was hydrating and its source file.
+
+The badge reads `1 err | 1 warn | 5 hydration`, and the panel lists each mismatch as:
+
+```
+HYDRATION Class mismatch in <RandomBadge>
+  file: app/components/RandomBadge.vue
+  on: HTMLSpanElement
+  server: class="warm"
+  client: class="cool"
+```
+
+The copied report gets the same treatment, one heading per mismatch:
+
+```md
+### 2. Class mismatch in <RandomBadge>
+- Component file: `app/components/RandomBadge.vue`
+- Component chain: RandomBadge < Index < RouteProvider < RouterView < NuxtPage
+- DOM node: `HTMLSpanElement`
+- Server rendered: `class="warm"`
+- Client rendered: `class="cool"`
+```
+
+Node, text, children, class, style, and attribute mismatches are all recognised. Vue's follow-up `Hydration completed but contains mismatches.` console error is dropped, since every mismatch behind it is already listed. Two reports of the same mismatch collapse into one entry: a mismatch is identified by where it happened rather than by the values it printed, so a clock rendering `Date.now()` does not stack up a new entry every time it drifts.
 
 ## Plugin size budgets
 

--- a/packages/nuxt-dx/src/runtime/app/hydration.ts
+++ b/packages/nuxt-dx/src/runtime/app/hydration.ts
@@ -1,0 +1,110 @@
+/**
+ * Vue reports hydration mismatches through `warnHandler`, where the DOM nodes it passed as
+ * warning arguments have already been flattened into the message with `String(node)`. Everything
+ * here works off that flattened string so it stays pure and testable outside a browser.
+ */
+
+export type HydrationMismatchKind = 'node' | 'text' | 'children' | 'class' | 'style' | 'attribute'
+
+export interface HydrationMismatch {
+  kind: HydrationMismatchKind
+  /** The DOM interface Vue reported the mismatch on, such as `HTMLParagraphElement`. */
+  element?: string
+  /** What the server sent down. */
+  server?: string
+  /** What the first client render produced. */
+  client?: string
+  /** The sentence Vue attaches when there is no server/client pair to show. */
+  detail?: string
+}
+
+const MISMATCH_KINDS: readonly (readonly [string, HydrationMismatchKind])[] = [
+  ['Hydration node mismatch', 'node'],
+  ['Hydration text content mismatch', 'text'],
+  ['Hydration text mismatch', 'text'],
+  ['Hydration children mismatch', 'children'],
+  ['Hydration class mismatch', 'class'],
+  ['Hydration style mismatch', 'style'],
+  ['Hydration attribute mismatch', 'attribute'],
+]
+
+const MISMATCH_LABELS: Record<HydrationMismatchKind, string> = {
+  node: 'Node mismatch',
+  text: 'Text mismatch',
+  children: 'Children mismatch',
+  class: 'Class mismatch',
+  style: 'Style mismatch',
+  attribute: 'Attribute mismatch',
+}
+
+/** Vue's internal vnode type symbols, which reach the warning as their `toString()`. */
+const VNODE_SYMBOLS: Record<string, string> = {
+  'Symbol(v-cmt)': 'comment node (a v-if placeholder)',
+  'Symbol(v-fgt)': 'fragment',
+  'Symbol(v-txt)': 'text node',
+  'Symbol(v-stc)': 'static vnode',
+}
+
+const SERVER_MARKER = '- rendered on server:'
+const CLIENT_MARKER = '- expected on client:'
+const NOTE_MARKER = '\n  Note:'
+
+/** Vue logs this once per hydration pass, after it has already warned about every mismatch. */
+export const HYDRATION_SUMMARY_ERROR = 'Hydration completed but contains mismatches.'
+
+function readNodeToken(raw: string): string | undefined {
+  const token = raw.trim()
+  if (!token)
+    return undefined
+  if (token in VNODE_SYMBOLS)
+    return VNODE_SYMBOLS[token]
+  // Vue appends a hint such as `(text)` after the node it stringified.
+  const objectTag = /^\[object (\w+)\] ?(.*)$/.exec(token)
+  return objectTag ? `${objectTag[1]}${objectTag[2] ? ` ${objectTag[2]}` : ''}` : token
+}
+
+function readSegment(message: string, marker: string, stopAt: readonly string[]): string | undefined {
+  const start = message.indexOf(marker)
+  if (start < 0)
+    return undefined
+  const rest = message.slice(start + marker.length)
+  const stop = stopAt
+    .map(end => rest.indexOf(end))
+    .filter(index => index >= 0)
+    .sort((a, b) => a - b)[0]
+  // Vue writes `: ` before the value, so one leading space is punctuation rather than content.
+  const value = (stop === undefined ? rest : rest.slice(0, stop)).replace(/^ /, '').replace(/\s+$/, '')
+  return value || undefined
+}
+
+export function parseHydrationWarning(message: string): HydrationMismatch | undefined {
+  const kind = MISMATCH_KINDS.find(([prefix]) => message.startsWith(prefix))?.[1]
+  if (!kind)
+    return undefined
+
+  const [head = '', ...tail] = message.split('\n')
+  const server = readSegment(message, SERVER_MARKER, [CLIENT_MARKER])
+  const client = readSegment(message, CLIENT_MARKER, [NOTE_MARKER])
+  // A node mismatch names no host element: both sides of the pair are nodes rather than values.
+  const isNode = kind === 'node'
+
+  return {
+    kind,
+    element: isNode ? undefined : readNodeToken(/mismatch (?:on|in)(.*)$/.exec(head)?.[1] ?? ''),
+    server: isNode ? readNodeToken(server ?? '') : server,
+    client: isNode ? readNodeToken(client ?? '') : client,
+    detail: server || client ? undefined : tail.join('\n').trim() || undefined,
+  }
+}
+
+/** Turns Vue's `at <Foo>` component trace into the component chain, nearest first. */
+export function parseComponentTrace(trace: string): string[] {
+  return trace
+    .split('\n')
+    .map(line => /^\s*at <([^\s>]+)/.exec(line)?.[1])
+    .filter((name): name is string => Boolean(name))
+}
+
+export function hydrationMismatchLabel(kind: HydrationMismatchKind): string {
+  return MISMATCH_LABELS[kind]
+}

--- a/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
+++ b/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
@@ -1,7 +1,8 @@
 import type { ComponentPublicInstance } from 'vue'
 import type { DiagnosticIssue } from '../report'
 import { defineNuxtPlugin, useRoute, useRuntimeConfig } from '#app'
-import { formatDiagnosticReport, relativeSourcePath } from '../report'
+import { HYDRATION_SUMMARY_ERROR, parseComponentTrace, parseHydrationWarning } from '../hydration'
+import { formatDiagnosticReport, formatIssueLine, issueSignature, relativeSourcePath } from '../report'
 
 interface DebugComponent extends ComponentPublicInstance {
   $: ComponentPublicInstance['$'] & {
@@ -70,26 +71,31 @@ export default defineNuxtPlugin((nuxtApp) => {
   document.body.append(badge, panel)
 
   const render = () => {
-    const errors = issues.filter(issue => issue.kind === 'error').length
-    const warnings = issues.length - errors
-    badge.textContent = issues.length ? `${errors} err | ${warnings} warn` : '0 issues'
-    badge.style.background = errors ? '#dc2626' : warnings ? '#ca8a04' : '#16a34a'
-    content.textContent = issues.map(issue => `${issue.kind === 'error' ? 'ERR' : 'WARN'} ${issue.message}`).join('\n\n') || 'No issues'
+    const count = (kind: DiagnosticIssue['kind']) => issues.filter(issue => issue.kind === kind).length
+    const errors = count('error')
+    const warnings = count('warning')
+    const hydration = count('hydration')
+    badge.textContent = issues.length ? `${errors} err | ${warnings} warn | ${hydration} hydration` : '0 issues'
+    badge.style.background = errors ? '#dc2626' : hydration ? '#7c3aed' : warnings ? '#ca8a04' : '#16a34a'
+    content.textContent = issues.map(formatIssueLine).join('\n\n') || 'No issues'
   }
 
-  const addIssue = (kind: DiagnosticIssue['kind'], message: string) => {
-    const key = `${kind}:${message}`
+  const addIssue = (issue: DiagnosticIssue) => {
+    const key = issueSignature(issue)
     if (seen.has(key))
       return
     seen.add(key)
-    issues.push({ kind, message })
+    issues.push(issue)
     render()
   }
 
+  const sourceFile = (instance: ComponentPublicInstance | null): string | undefined => {
+    const file = (instance as DebugComponent | null)?.$?.type?.__file
+    return file ? relativeSourcePath(file, config.sourceRoot) : undefined
+  }
   const sourceDetails = (instance: ComponentPublicInstance | null): string => {
-    const debug = instance as DebugComponent | null
-    const file = debug?.$?.type?.__file
-    return file ? `\n  file: ${relativeSourcePath(file, config.sourceRoot)}` : ''
+    const file = sourceFile(instance)
+    return file ? `\n  file: ${file}` : ''
   }
 
   const makeButton = (label: string, action: () => void) => {
@@ -104,15 +110,23 @@ export default defineNuxtPlugin((nuxtApp) => {
   const previousWarnHandler = nuxtApp.vueApp.config.warnHandler
   const previousErrorHandler = nuxtApp.vueApp.config.errorHandler
 
-  const warnHandler: typeof previousWarnHandler = (message, instance) => {
+  const warnHandler: typeof previousWarnHandler = (message, instance, trace) => {
+    const mismatch = parseHydrationWarning(message.trim())
+    if (mismatch) {
+      const chain = parseComponentTrace(trace)
+      const issue: DiagnosticIssue = { kind: 'hydration', mismatch, component: chain[0], componentFile: sourceFile(instance), trace: chain }
+      addIssue(issue)
+      console.warn(`[nuxt-dx] ${formatIssueLine(issue)}`)
+      return
+    }
     const formatted = `${message.trim()}${sourceDetails(instance)}`
-    addIssue('warning', formatted)
+    addIssue({ kind: 'warning', message: formatted })
     console.warn(`[Vue warn]: ${formatted}`)
   }
   const errorHandler: typeof previousErrorHandler = (error, instance, info) => {
     const message = error instanceof Error ? error.stack ?? error.message : String(error)
     const formatted = `${info}: ${message}${sourceDetails(instance)}`
-    addIssue('error', formatted)
+    addIssue({ kind: 'error', message: formatted })
     originalConsoleError(`[Vue error]: ${formatted}`)
   }
   nuxtApp.vueApp.config.warnHandler = warnHandler
@@ -120,14 +134,15 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const patchedConsoleError = (...args: unknown[]) => {
     const message = args.map(value => value instanceof Error ? value.stack ?? value.message : String(value)).join(' ').trim()
-    if (message && !message.startsWith('[Vue error]:'))
-      addIssue('error', message)
+    // Vue logs its hydration summary after warning about each mismatch, which the panel already lists.
+    if (message && !message.startsWith('[Vue error]:') && message !== HYDRATION_SUMMARY_ERROR)
+      addIssue({ kind: 'error', message })
     originalConsoleError(...args)
   }
   console.error = patchedConsoleError
 
-  const onWindowError = (event: ErrorEvent) => addIssue('error', event.message || String(event.error))
-  const onUnhandledRejection = (event: PromiseRejectionEvent) => addIssue('error', `Unhandled rejection: ${String(event.reason)}`)
+  const onWindowError = (event: ErrorEvent) => addIssue({ kind: 'error', message: event.message || String(event.error) })
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => addIssue({ kind: 'error', message: `Unhandled rejection: ${String(event.reason)}` })
   window.addEventListener('error', onWindowError)
   window.addEventListener('unhandledrejection', onUnhandledRejection)
 

--- a/packages/nuxt-dx/src/runtime/app/report.ts
+++ b/packages/nuxt-dx/src/runtime/app/report.ts
@@ -1,7 +1,21 @@
-export interface DiagnosticIssue {
-  kind: 'error' | 'warning'
-  message: string
+import type { HydrationMismatch } from './hydration'
+import { hydrationMismatchLabel } from './hydration'
+
+export interface HydrationIssue {
+  kind: 'hydration'
+  mismatch: HydrationMismatch
+  /** The component Vue was hydrating, from the head of its warning trace. */
+  component?: string
+  /** That component's source file, relative to the configured source root. */
+  componentFile?: string
+  /** The component chain Vue reported, nearest first. */
+  trace?: readonly string[]
 }
+
+export type DiagnosticIssue
+  = | { kind: 'error', message: string }
+    | { kind: 'warning', message: string }
+    | HydrationIssue
 
 export interface DiagnosticReportInput {
   url: string
@@ -17,6 +31,71 @@ export function relativeSourcePath(file: string, sourceRoot: string): string {
   return normalizedFile.startsWith(prefix) ? normalizedFile.slice(prefix.length) : normalizedFile
 }
 
+function hydrationHeading(issue: HydrationIssue): string {
+  const label = hydrationMismatchLabel(issue.mismatch.kind)
+  return issue.component ? `${label} in <${issue.component}>` : label
+}
+
+/**
+ * The values differ on every render for the common `Date.now()` style mismatch, so the identity of
+ * a hydration issue is where it happened rather than what it printed.
+ */
+export function issueSignature(issue: DiagnosticIssue): string {
+  if (issue.kind !== 'hydration')
+    return `${issue.kind}:${issue.message}`
+  const { kind, element } = issue.mismatch
+  return `hydration:${kind}:${issue.component ?? ''}:${issue.componentFile ?? ''}:${element ?? ''}`
+}
+
+/** The single-issue summary the overlay panel shows. */
+export function formatIssueLine(issue: DiagnosticIssue): string {
+  if (issue.kind === 'error')
+    return `ERR ${issue.message}`
+  if (issue.kind === 'warning')
+    return `WARN ${issue.message}`
+
+  const { server, client, detail, element } = issue.mismatch
+  const lines = [`HYDRATION ${hydrationHeading(issue)}`]
+  if (issue.componentFile)
+    lines.push(`  file: ${issue.componentFile}`)
+  if (element)
+    lines.push(`  on: ${element}`)
+  if (server !== undefined)
+    lines.push(`  server: ${server}`)
+  if (client !== undefined)
+    lines.push(`  client: ${client}`)
+  if (detail)
+    lines.push(`  ${detail}`)
+  return lines.join('\n')
+}
+
+function hydrationSection(issues: readonly HydrationIssue[]): string[] {
+  const lines = [
+    '',
+    '## Hydration mismatches',
+    '',
+    'The server HTML and the first client render disagree. Make the two renders agree at the source; reach for `<ClientOnly>` or a mounted guard only when the value is genuinely client only.',
+  ]
+  issues.forEach((issue, index) => {
+    const { server, client, detail, element } = issue.mismatch
+    lines.push('', `### ${index + 1}. ${hydrationHeading(issue)}`)
+    if (issue.componentFile)
+      lines.push(`- Component file: \`${issue.componentFile}\``)
+    if (issue.trace?.length)
+      lines.push(`- Component chain: ${issue.trace.join(' < ')}`)
+    if (element)
+      lines.push(`- DOM node: \`${element}\``)
+    if (server !== undefined)
+      lines.push(`- Server rendered: \`${server}\``)
+    if (client !== undefined)
+      lines.push(`- Client rendered: \`${client}\``)
+    if (detail)
+      lines.push(`- Detail: ${detail}`)
+  })
+  lines.push('')
+  return lines
+}
+
 export function formatDiagnosticReport(input: DiagnosticReportInput): string {
   const lines = [
     'Fix the following client-side issues on this page.',
@@ -28,8 +107,12 @@ export function formatDiagnosticReport(input: DiagnosticReportInput): string {
   if (input.pageComponent)
     lines.push(`- Page component: ${input.pageComponent}`)
 
+  const hydration = input.issues.filter((issue): issue is HydrationIssue => issue.kind === 'hydration')
+  if (hydration.length)
+    lines.push(...hydrationSection(hydration))
+
   for (const kind of ['error', 'warning'] as const) {
-    const issues = input.issues.filter(issue => issue.kind === kind)
+    const issues = input.issues.filter((issue): issue is Extract<DiagnosticIssue, { message: string }> => issue.kind === kind)
     if (!issues.length)
       continue
     lines.push('', `## ${kind === 'error' ? 'Errors' : 'Warnings'}`)

--- a/packages/nuxt-dx/tests/hydration.test.ts
+++ b/packages/nuxt-dx/tests/hydration.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { parseComponentTrace, parseHydrationWarning } from '../src/runtime/app/hydration'
+
+// Captured from Vue 3.5.41 running a Nuxt 4 dev server, as `warnHandler` receives them: Vue has
+// already flattened the DOM nodes it passed as warning arguments into the message.
+const TEXT_CONTENT_WARNING = `Hydration text content mismatch on[object HTMLParagraphElement]
+  - rendered on server:  Rendered at 1786426149186
+  - expected on client:  Rendered at 1786426150046`
+
+const CLASS_WARNING = `Hydration class mismatch on[object HTMLSpanElement]
+  - rendered on server: class="warm"
+  - expected on client: class="cool"
+  Note: this mismatch is check-only. The DOM will not be rectified in production due to performance overhead.
+  You should fix the source of the mismatch.`
+
+const NODE_WARNING = `Hydration node mismatch:
+- rendered on server:[object HTMLSpanElement]
+- expected on client:Symbol(v-cmt)`
+
+const CHILDREN_WARNING = `Hydration children mismatch on[object HTMLDivElement]
+Server rendered element contains more child nodes than client vdom.`
+
+const TEXT_NODE_WARNING = `Hydration text mismatch in[object HTMLDivElement]
+  - rendered on server: "12"
+  - expected on client: "13"`
+
+describe('parseHydrationWarning', () => {
+  it('reads the element and both sides of a text content mismatch', () => {
+    expect(parseHydrationWarning(TEXT_CONTENT_WARNING)).toEqual({
+      kind: 'text',
+      element: 'HTMLParagraphElement',
+      server: ' Rendered at 1786426149186',
+      client: ' Rendered at 1786426150046',
+      detail: undefined,
+    })
+  })
+
+  it('drops the check-only footnote Vue appends to prop mismatches', () => {
+    expect(parseHydrationWarning(CLASS_WARNING)).toEqual({
+      kind: 'class',
+      element: 'HTMLSpanElement',
+      server: 'class="warm"',
+      client: 'class="cool"',
+      detail: undefined,
+    })
+  })
+
+  it('names the vnode symbol a node mismatch reports on the client side', () => {
+    expect(parseHydrationWarning(NODE_WARNING)).toEqual({
+      kind: 'node',
+      element: undefined,
+      server: 'HTMLSpanElement',
+      client: 'comment node (a v-if placeholder)',
+      detail: undefined,
+    })
+  })
+
+  it('keeps the trailing sentence when there is no server/client pair', () => {
+    expect(parseHydrationWarning(CHILDREN_WARNING)).toEqual({
+      kind: 'children',
+      element: 'HTMLDivElement',
+      server: undefined,
+      client: undefined,
+      detail: 'Server rendered element contains more child nodes than client vdom.',
+    })
+  })
+
+  it('handles the `in` phrasing Vue uses for text vnodes', () => {
+    expect(parseHydrationWarning(TEXT_NODE_WARNING)).toMatchObject({
+      kind: 'text',
+      element: 'HTMLDivElement',
+      server: '"12"',
+      client: '"13"',
+    })
+  })
+
+  it.each([
+    'Failed to resolve component: NuxtLnk',
+    'Invalid prop: type check failed for prop "count".',
+    'Extraneous non-props attributes (class) were passed to component',
+    '',
+  ])('ignores the unrelated warning %j', (message) => {
+    expect(parseHydrationWarning(message)).toBeUndefined()
+  })
+})
+
+describe('parseComponentTrace', () => {
+  it('reads the component chain nearest first', () => {
+    expect(parseComponentTrace('at <DriftingClock>\nat <Index>\nat <NuxtRoot>')).toEqual(['DriftingClock', 'Index', 'NuxtRoot'])
+  })
+
+  it('drops the props Vue inlines into a trace entry', () => {
+    expect(parseComponentTrace('at <Badge seed=11 >\nat <Index>')).toEqual(['Badge', 'Index'])
+  })
+
+  it('returns nothing for an empty trace', () => {
+    expect(parseComponentTrace('')).toEqual([])
+  })
+})

--- a/packages/nuxt-dx/tests/report.test.ts
+++ b/packages/nuxt-dx/tests/report.test.ts
@@ -1,5 +1,21 @@
+import type { HydrationIssue } from '../src/runtime/app/report'
 import { describe, expect, it } from 'vitest'
-import { formatDiagnosticReport, relativeSourcePath } from '../src/runtime/app/report'
+import { parseHydrationWarning } from '../src/runtime/app/hydration'
+import { formatDiagnosticReport, formatIssueLine, issueSignature, relativeSourcePath } from '../src/runtime/app/report'
+
+const CLOCK_WARNING = `Hydration text content mismatch on[object HTMLParagraphElement]
+  - rendered on server:  Rendered at 1786426149186
+  - expected on client:  Rendered at 1786426150046`
+
+function clockIssue(warning = CLOCK_WARNING): HydrationIssue {
+  return {
+    kind: 'hydration',
+    mismatch: parseHydrationWarning(warning)!,
+    component: 'DriftingClock',
+    componentFile: 'app/components/DriftingClock.vue',
+    trace: ['DriftingClock', 'Index', 'NuxtPage'],
+  }
+}
 
 describe('diagnostic report', () => {
   it('normalizes source files relative to the configured root', () => {
@@ -16,5 +32,58 @@ describe('diagnostic report', () => {
         { kind: 'warning', message: 'careful' },
       ],
     })).toContain('## Errors\n### 1.\nboom')
+  })
+
+  it('reports a hydration mismatch by component, file and differing values', () => {
+    const report = formatDiagnosticReport({
+      url: 'http://localhost:3000/',
+      routeName: 'index',
+      pageComponent: 'pages/index.vue',
+      issues: [clockIssue()],
+    })
+    expect(report).toContain('## Hydration mismatches')
+    expect(report).toContain('### 1. Text mismatch in <DriftingClock>')
+    expect(report).toContain('- Component file: `app/components/DriftingClock.vue`')
+    expect(report).toContain('- Component chain: DriftingClock < Index < NuxtPage')
+    expect(report).toContain('- DOM node: `HTMLParagraphElement`')
+    expect(report).toContain('- Server rendered: ` Rendered at 1786426149186`')
+    expect(report).toContain('- Client rendered: ` Rendered at 1786426150046`')
+  })
+
+  it('puts hydration mismatches ahead of errors and warnings', () => {
+    const report = formatDiagnosticReport({
+      url: 'http://localhost:3000/',
+      routeName: 'index',
+      issues: [{ kind: 'error', message: 'boom' }, clockIssue()],
+    })
+    expect(report.indexOf('## Hydration mismatches')).toBeLessThan(report.indexOf('## Errors'))
+  })
+
+  it('summarises a hydration mismatch for the overlay panel', () => {
+    expect(formatIssueLine(clockIssue())).toBe([
+      'HYDRATION Text mismatch in <DriftingClock>',
+      '  file: app/components/DriftingClock.vue',
+      '  on: HTMLParagraphElement',
+      '  server:  Rendered at 1786426149186',
+      '  client:  Rendered at 1786426150046',
+    ].join('\n'))
+  })
+})
+
+describe('issueSignature', () => {
+  it('collapses a mismatch whose values drift on every render', () => {
+    const later = CLOCK_WARNING.replace('1786426150046', '1786426999999')
+    expect(issueSignature(clockIssue(later))).toBe(issueSignature(clockIssue()))
+  })
+
+  it('separates two mismatches from the same component', () => {
+    const classWarning = `Hydration class mismatch on[object HTMLSpanElement]
+  - rendered on server: class="warm"
+  - expected on client: class="cool"`
+    expect(issueSignature(clockIssue(classWarning))).not.toBe(issueSignature(clockIssue()))
+  })
+
+  it('keeps errors and warnings with the same text apart', () => {
+    expect(issueSignature({ kind: 'error', message: 'boom' })).not.toBe(issueSignature({ kind: 'warning', message: 'boom' }))
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hydration mismatches are the highest-frequency Nuxt dev annoyance and the worst-formatted thing the overlay showed. Vue reports them through `warnHandler`, and by the time the handler runs, Vue has already flattened the DOM nodes it passed as warning arguments into the message with `String(node)`. The overlay filed that string under generic warnings, so the copied report handed a coding agent `[object HTMLParagraphElement]` and nothing to act on.

Mismatches now get their own issue kind alongside `error` and `warning`:

- `parseHydrationWarning()` in the new `src/runtime/app/hydration.ts` reads Vue 3.5's six mismatch messages (node, text, children, class, style, attribute) back apart into kind, DOM node, and the server/client pair, translating Vue's vnode symbols (`Symbol(v-cmt)`) into something readable. `parseComponentTrace()` reads the `at <Foo>` trace into a component chain.
- The badge counts them separately: `1 err | 1 warn | 5 hydration`.
- A mismatch is identified by where it happened rather than by the values it printed, so a component rendering `Date.now()` does not stack a new entry every time it drifts.
- Vue's follow-up `Hydration completed but contains mismatches.` console error is dropped, since every mismatch behind it is now listed.

Parsing and formatting stayed pure and live in `hydration.ts` and `report.ts`; the plugin file is still the effectful shell, and still restores every handler it patches on HMR dispose.

**Before**, in the copied report, under `## Warnings` mixed in with everything else:

```
## Warnings
### 1.
Hydration text content mismatch on[object HTMLParagraphElement]
  - rendered on server:  Rendered at 1786426149186
  - expected on client:  Rendered at 1786426150046
  file: app/components/DriftingClock.vue
### 2.
Hydration class mismatch on[object HTMLSpanElement]
  - rendered on server: class="warm"
  - expected on client: class="cool"
  Note: this mismatch is check-only. The DOM will not be rectified in production due to performance overhead.
  You should fix the source of the mismatch.
  file: app/components/RandomBadge.vue
### 3.
Hydration node mismatch:
- rendered on server:[object HTMLSpanElement]
- expected on client:Symbol(v-cmt)
  file: app/components/ExtraChild.vue
```

**After**, its own section, ahead of errors and warnings:

```md
## Hydration mismatches

The server HTML and the first client render disagree. Make the two renders agree at the source; reach for `<ClientOnly>` or a mounted guard only when the value is genuinely client only.

### 1. Text mismatch in <DriftingClock>
- Component file: `app/components/DriftingClock.vue`
- Component chain: DriftingClock < Index < RouteProvider < RouterView < NuxtPage < App < NuxtRoot
- DOM node: `HTMLParagraphElement`
- Server rendered: ` Rendered at 1786426600146`
- Client rendered: ` Rendered at 1786426600184`

### 2. Class mismatch in <RandomBadge>
- Component file: `app/components/RandomBadge.vue`
- Component chain: RandomBadge < Index < RouteProvider < RouterView < NuxtPage < App < NuxtRoot
- DOM node: `HTMLSpanElement`
- Server rendered: `class="warm"`
- Client rendered: `class="cool"`

### 4. Node mismatch in <ExtraChild>
- Component file: `app/components/ExtraChild.vue`
- Component chain: ExtraChild < Index < RouteProvider < RouterView < NuxtPage < App < NuxtRoot
- Server rendered: `HTMLSpanElement`
- Client rendered: `comment node (a v-if placeholder)`
```

The overlay panel gets the same summary, one block per mismatch:

```
HYDRATION Class mismatch in <RandomBadge>
  file: app/components/RandomBadge.vue
  on: HTMLSpanElement
  server: class="warm"
  client: class="cool"
```

### 🧪 Verification

Real browser, not just unit tests. A throwaway Nuxt 4.5.2 / Vue 3.5.41 fixture was built in a temp dir with four deliberate mismatches (a `Date.now()` text drift, a server/client `class`, a server/client `title` attribute, and a `v-if` that only renders on the server), plus an unresolved component and a `console.error` so the other sections stayed populated. `nuxi dev` served it and `dev-browser` drove it:

- Badge rendered `1 err | 1 warn | 5 hydration`.
- The panel listed every mismatch with its component, file, DOM node, and both values.
- Clicking Copy produced exactly the report quoted above, captured off the real clipboard call.
- The raw Vue warning strings from that same run are checked in as test fixtures in `tests/hydration.test.ts`.

In `packages/nuxt-dx`:

- `pnpm test` — 8 files, 62 tests passing, including 13 new ones covering every mismatch kind, the unrelated-warning rejections, trace parsing, report formatting, and signature collapsing.
- `pnpm lint` — clean.
- `pnpm typecheck` — clean.
