### PR TITLE
feat(dx): attribute client bundle cost to Nuxt modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every package here publishes under the `experimental` npm tag. Versions and rele
 | [`@harlan-zw/nuxt-cf-jobs`](./packages/nuxt-cf-jobs) | ☁️ Typed Cloudflare Queue jobs with file-based definitions, optional D1 durability, scheduled tasks, and an operations CLI. |
 | [`@harlan-zw/nuxt-use-query`](./packages/nuxt-use-query) | 🔄 Nuxt-native queries, mutations, and subscriptions with SWR, invalidation, polling, and typed RPC contracts. |
 | [`@harlan-zw/nuxt-domain-events`](./packages/nuxt-domain-events) | 📣 Layer-aware server domain events with generated lazy registries and after-commit queue publication. |
-| [`@harlan-zw/nuxt-dx`](./packages/nuxt-dx) | 🚨 Diagnostics: a client error overlay with agent handoff, and bundle size budgets for Nuxt and Nitro plugins. |
+| [`@harlan-zw/nuxt-dx`](./packages/nuxt-dx) | 🚨 Diagnostics: a client error overlay with agent handoff, and bundle size budgets for Nuxt plugins, Nitro plugins, and Nuxt modules. |
 | [`@harlan-zw/nuxt-github-sponsors`](./packages/nuxt-github-sponsors) | 💖 Typed GitHub Sponsors data with tiers, profile overrides, a public route, and a composable. |
 
 ## Development

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-Nuxt DX is a diagnostics module that surfaces problems you would otherwise have to go looking for: client errors while you develop, and plugins that quietly bloat your bundle when you build.
+Nuxt DX is a diagnostics module that surfaces problems you would otherwise have to go looking for: client errors while you develop, and the plugins and modules that quietly bloat your bundle when you build.
 
 Status: experimental. APIs may change before the first release.
 
@@ -24,8 +24,8 @@ Status: experimental. APIs may change before the first release.
 - 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge, and a strict production no-op.
 - 💧 **Hydration mismatches, decoded:** counted separately and read back as component, source file, and the two values that disagreed.
 - 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
-- 📦 **Plugin size budgets:** warn when a Nuxt or Nitro plugin drags too much JavaScript into the bundle.
-- 🔍 **Exclusive attribution and overrides:** each plugin is charged only for what it alone pulls in, with budgets keyed by `defineNuxtPlugin` name or path fragment.
+- 📦 **Size budgets:** warn when a Nuxt plugin, a Nitro plugin, or an installed Nuxt module drags too much JavaScript into the bundle, so you can answer which of your modules cost you 80 kB.
+- 🔍 **Exclusive attribution and overrides:** each plugin and module is charged only for what it alone pulls in, with budgets keyed by plugin name, module name, or path fragment.
 
 ## Installation
 
@@ -114,6 +114,36 @@ export default defineNuxtPlugin({
 
 Both `defineNuxtPlugin({ name })` and `defineNuxtPlugin(fn, { name })` are read. Plugins without a name are reported by path, as are Nitro plugins, which have no name concept.
 
+## Module size budgets
+
+Answers the question a plugin budget cannot: you installed five modules, which one added 80 kB to the client bundle?
+
+Every bundled file that ships from a module's own package is charged to that module, along with everything those files reach exclusively. A dependency two modules both import is shared, so neither is billed for it, and the number moves as your app changes: install a second module that also uses `cookie-es` and the first module's charge drops by that much.
+
+```
+[nuxt-dx]  WARN  2 Nuxt modules over budget in the client bundle
+
+  @nuxtjs/i18n
+  57.2 kB bundled, 52.2 kB over the 5 kB budget
+    ├─48.3 kB  the module's own files
+    ├─ 6.1 kB  @intlify/shared/dist/shared.mjs
+    ├─ 2.5 kB  h3/dist/index.mjs
+    └─  276 B  virtual:nuxt:.nuxt%2Fi18n-options.mjs
+
+  nuxt-site-config
+  5.2 kB bundled, 252 B over the 5 kB budget
+    ├─2.7 kB  the module's own files
+    ├─2.3 kB  site-config-stack/dist/index.mjs
+    └─ 219 B  virtual:nuxt:.nuxt%2Fnuxt-site-config%2Fi18n-plugin-deps.mjs
+
+  Defer heavy imports with `await import()`, or allow the size:
+    nuxtDx.sizeBudget.overridesKb = { '@nuxtjs/i18n': 58, 'nuxt-site-config': 6 }
+```
+
+Modules are reported by the name they declare in their own `meta`, which is also the key an override takes. Modules you never installed yourself show up too, `nuxt-site-config` above arrived as a dependency of another module, and it is charged like any other.
+
+## Configuring budgets
+
 ```ts
 export default defineNuxtConfig({
   nuxtDx: {
@@ -122,10 +152,13 @@ export default defineNuxtConfig({
       pluginsKb: 20,
       // kB budget per Nitro plugin in the server bundle, `false` to disable
       nitroPluginsKb: 50,
-      // raise or lower the budget for individual plugins,
-      // keyed by plugin name or by any fragment of the plugin path
+      // kB budget per Nuxt module in the client bundle, `false` to disable
+      modulesKb: 50,
+      // raise or lower the budget for individual plugins and modules,
+      // keyed by plugin name, module name, or any fragment of the path
       overridesKb: {
         'analytics': 60,
+        '@nuxtjs/i18n': 80,
         'server/plugins/queue': 120,
       },
       // throw instead of warning
@@ -137,7 +170,7 @@ export default defineNuxtConfig({
 
 Set `sizeBudget: false` to turn the check off entirely.
 
-Budgets are measured whenever a bundle is produced. Nitro is bundled in both `nuxi dev` and `nuxi build`, so Nitro plugin budgets report in either. The client is served unbundled in dev, so app plugin budgets only report on `nuxi build`.
+Budgets are measured whenever a bundle is produced. Nitro is bundled in both `nuxi dev` and `nuxi build`, so Nitro plugin budgets report in either. The client is served unbundled in dev, so app plugin and module budgets only report on `nuxi build`.
 
 ## Sponsors
 

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -2,7 +2,7 @@
   "name": "@harlan-zw/nuxt-dx",
   "type": "module",
   "version": "0.0.1",
-  "description": "Experimental Nuxt diagnostics: dev error overlay and plugin bundle size budgets.",
+  "description": "Experimental Nuxt diagnostics: dev error overlay and plugin and module bundle size budgets.",
   "author": {
     "name": "Harlan Wilton",
     "email": "harlan@harlanzw.com",

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,14 +1,19 @@
 import type { Nuxt } from '@nuxt/schema'
-import type { BudgetOverride, PluginVerdict } from './size-budget/budget'
+import type { BudgetOverride, BudgetVerdict } from './size-budget/budget'
+import type { ModuleOwner } from './size-budget/module-packages'
 import type { BudgetScope } from './size-budget/report'
-import type { MeasuredPlugin } from './size-budget/rollup'
+import type { MeasuredTarget } from './size-budget/rollup'
+import { realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { addPlugin, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
+import { isAbsolute } from 'node:path'
+import { addPlugin, createResolver, defineNuxtModule, resolveModule, useLogger } from '@nuxt/kit'
 import { budgetFor, smallestBudget } from './size-budget/budget'
+import { moduleRoot } from './size-budget/module-packages'
 import { extractPluginName } from './size-budget/plugin-name'
 import { formatBudgetReport } from './size-budget/report'
 import { sizeBudgetRollupPlugin } from './size-budget/rollup'
 import { kilobytesToBytes } from './size-budget/size'
+import { moduleTargets, pluginTargets } from './size-budget/targets'
 
 export interface SizeBudgetOptions {
   /**
@@ -21,7 +26,12 @@ export interface SizeBudgetOptions {
    * @default 50
    */
   nitroPluginsKb?: number | false
-  /** Per-plugin kilobyte budgets, keyed by plugin name or by any fragment of the plugin path. */
+  /**
+   * Kilobyte budget for each Nuxt module in the client bundle. `false` disables the check.
+   * @default 50
+   */
+  modulesKb?: number | false
+  /** Per-target kilobyte budgets, keyed by plugin name, module name, or any fragment of the path. */
   overridesKb?: Record<string, number>
   /**
    * Fail the build instead of warning.
@@ -34,13 +44,14 @@ export interface ModuleOptions {
   enabled?: boolean
   position?: 'bottom-left' | 'bottom-right'
   sourceRoot?: string
-  /** Warn when a plugin's exclusive import graph exceeds a bundle size budget. */
+  /** Warn when a plugin's or module's exclusive import graph exceeds a bundle size budget. */
   sizeBudget?: SizeBudgetOptions | false
 }
 
 interface ResolvedBudgets {
   client: number | undefined
   nitro: number | undefined
+  modules: number | undefined
   overrides: BudgetOverride[]
   fail: boolean
 }
@@ -53,7 +64,7 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
       return undefined
     if (kilobytes === undefined)
       return kilobytesToBytes(fallback)
-    // A negative or NaN budget would flag every plugin, so drop it rather than drown the build in warnings.
+    // A negative or NaN budget would flag everything, so drop it rather than drown the build in warnings.
     if (!Number.isFinite(kilobytes) || kilobytes < 0) {
       logger.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
       return undefined
@@ -71,6 +82,7 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
   return {
     client: resolve(options.pluginsKb, 20, 'pluginsKb'),
     nitro: resolve(options.nitroPluginsKb, 50, 'nitroPluginsKb'),
+    modules: resolve(options.modulesKb, 50, 'modulesKb'),
     overrides,
     fail: options.fail ?? false,
   }
@@ -86,18 +98,19 @@ async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefin
 }
 
 /**
- * Measurement only knows paths. Names are reconciled here, once, for the plugins big
+ * Measurement only knows paths. Plugin names are reconciled here, once, for the plugins big
  * enough to be at risk, so a build where everything fits parses no plugin sources at all.
  */
 function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean) {
   const threshold = smallestBudget(defaultBytes, budgets.overrides)
-  return async (measured: readonly MeasuredPlugin[]) => {
+  return async (measured: readonly MeasuredTarget[]) => {
     const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold)
     if (!candidates.length)
       return
 
-    const verdicts: PluginVerdict[] = await Promise.all(candidates.map(async ({ path, measurement }) => {
-      const name = named ? await readPluginName(path, nuxt) : undefined
+    const verdicts: BudgetVerdict[] = await Promise.all(candidates.map(async (target) => {
+      const { path, measurement } = target
+      const name = target.name ?? (named ? await readPluginName(path, nuxt) : undefined)
       return { path, name, budgetBytes: budgetFor(path, name, defaultBytes, budgets.overrides), measurement }
     }))
 
@@ -114,27 +127,78 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
   }
 }
 
+/**
+ * The file a module was loaded from. `entryPath` is whatever `modules` held, usually a bare
+ * specifier, and vite resolves through symlinks, so a pnpm module's bundled ids sit under the
+ * store path rather than under the link Nuxt loaded it from.
+ */
+function moduleEntryFile(entryPath: string, nuxt: Nuxt): string | undefined {
+  let file = entryPath
+  if (!isAbsolute(file)) {
+    try {
+      file = resolveModule(entryPath, { paths: [nuxt.options.rootDir, ...nuxt.options.modulesDir] })
+    }
+    catch {
+      // A module Nuxt can no longer resolve cannot be matched to bundled files; leave it unattributed.
+      return undefined
+    }
+  }
+  try {
+    return realpathSync(file)
+  }
+  catch {
+    return file
+  }
+}
+
+function installedModuleOwners(nuxt: Nuxt): ModuleOwner[] {
+  const owners: ModuleOwner[] = []
+  for (const installed of nuxt.options._installedModules ?? []) {
+    // Inline and function modules have no file of their own, so nothing can be charged to them.
+    if (!installed.entryPath)
+      continue
+    const file = moduleEntryFile(installed.entryPath, nuxt)
+    if (file)
+      owners.push({ name: installed.meta?.name, root: moduleRoot(file) })
+  }
+  return owners
+}
+
 function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
   const budgets = resolveBudgets(options)
   const clientBudget = budgets.client
   const nitroBudget = budgets.nitro
+  const moduleBudget = budgets.modules
 
+  // `app:resolve` runs before the client build, and holds every plugin including module-registered ones.
+  let appPluginPaths: string[] = []
   if (clientBudget !== undefined) {
-    // `app:resolve` runs before the client build, and holds every plugin including module-registered ones.
-    let appPluginPaths: string[] = []
     nuxt.hook('app:resolve', (app) => {
       appPluginPaths = app.plugins.filter(plugin => plugin.mode !== 'server').map(plugin => plugin.src)
     })
+  }
+
+  if (clientBudget !== undefined || moduleBudget !== undefined) {
     nuxt.hook('vite:extendConfig', (config, env) => {
       if (!env.isClient)
         return
       // `vite:extendConfig` types the config as readonly, but mutating `plugins` is the supported extension point.
       const plugins = config.plugins as unknown[] | undefined
-      plugins?.push(sizeBudgetRollupPlugin({
-        scope: 'client',
-        paths: () => appPluginPaths,
-        onMeasured: reporter('client', clientBudget, budgets, nuxt, true),
-      }))
+      if (clientBudget !== undefined) {
+        plugins?.push(sizeBudgetRollupPlugin({
+          scope: 'client',
+          targets: ids => pluginTargets(appPluginPaths, ids),
+          onMeasured: reporter('client', clientBudget, budgets, nuxt, true),
+        }))
+      }
+      if (moduleBudget !== undefined) {
+        plugins?.push(sizeBudgetRollupPlugin({
+          scope: 'modules',
+          // Read at bundle time: modules keep installing while the config is assembled.
+          targets: ids => moduleTargets(installedModuleOwners(nuxt), ids),
+          onMeasured: reporter('modules', moduleBudget, budgets, nuxt, false),
+        }))
+      }
     })
   }
 
@@ -144,8 +208,8 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
         config.plugins ||= []
         ;(config.plugins as unknown[]).push(sizeBudgetRollupPlugin({
           scope: 'nitro',
-          paths: () => nitro.options.plugins,
           // Nitro plugins have no name concept, so they are always identified by path.
+          targets: ids => pluginTargets(nitro.options.plugins, ids),
           onMeasured: reporter('nitro', nitroBudget, budgets, nuxt, false),
         }))
       })

--- a/packages/nuxt-dx/src/size-budget/budget.ts
+++ b/packages/nuxt-dx/src/size-budget/budget.ts
@@ -1,21 +1,21 @@
-import type { PluginMeasurement } from './graph'
+import type { CostMeasurement } from './graph'
 
-export interface PluginVerdict {
+export interface BudgetVerdict {
   path: string
-  /** `name` from `defineNuxtPlugin`, when the plugin declares one. */
+  /** A Nuxt module name, or the `name` from `defineNuxtPlugin` when the plugin declares one. */
   name?: string
   budgetBytes: number
-  measurement: PluginMeasurement
+  measurement: CostMeasurement
 }
 
 export interface BudgetOverride {
-  /** A plugin name, or any fragment of a plugin path. */
+  /** A plugin or module name, or any fragment of a path. */
   fragment: string
   bytes: number
 }
 
 /**
- * The threshold below which no plugin can possibly breach its budget. Used to skip
+ * The threshold below which nothing can possibly breach its budget. Used to skip
  * name resolution for plugins that are comfortably small.
  */
 export function smallestBudget(defaultBytes: number, overrides: readonly BudgetOverride[]): number {
@@ -24,7 +24,7 @@ export function smallestBudget(defaultBytes: number, overrides: readonly BudgetO
 
 export function budgetFor(path: string, name: string | undefined, defaultBytes: number, overrides: readonly BudgetOverride[]): number {
   const normalized = path.replace(/\\/g, '/')
-  // An override keyed by plugin name wins over one keyed by a path fragment.
+  // An override keyed by name wins over one keyed by a path fragment.
   const override = overrides.find(candidate => candidate.fragment === name)
     ?? overrides.find(candidate => normalized.includes(candidate.fragment))
   return override?.bytes ?? defaultBytes

--- a/packages/nuxt-dx/src/size-budget/graph.ts
+++ b/packages/nuxt-dx/src/size-budget/graph.ts
@@ -10,11 +10,18 @@ export interface ModuleWeight {
   bytes: number
 }
 
-export interface PluginMeasurement {
-  id: string
-  /** Size of the plugin file itself. */
+export interface CostTarget {
+  /** Identifies the target across the measurement; unique per target. */
+  key: string
+  /** Bundled module ids charged directly to this target. */
+  ids: readonly string[]
+}
+
+export interface CostMeasurement {
+  key: string
+  /** Size of the target's own modules. */
   ownBytes: number
-  /** Size of the modules reachable only through this plugin. */
+  /** Size of the modules reachable only through this target. */
   exclusiveBytes: number
   /** How many modules that covers, so the report can say what it left out. */
   exclusiveCount: number
@@ -24,9 +31,8 @@ export interface PluginMeasurement {
 
 interface MeasureInput {
   modules: readonly GraphModule[]
-  /** Bundled module ids of the plugins to measure. */
-  targetIds: readonly string[]
-  /** Bundle entry modules, used to discover what the app ships without any plugin. */
+  targets: readonly CostTarget[]
+  /** Bundle entry modules, used to discover what the app ships without any target. */
   entryIds: readonly string[]
   maxDependencies?: number
 }
@@ -48,37 +54,43 @@ function walk(starts: readonly string[], byId: ReadonlyMap<string, GraphModule>,
 }
 
 /**
- * Charge each plugin the weight of its own module plus every module that is reachable
- * only through it. Anything the app already reaches without passing through a plugin,
- * or that a second plugin also reaches, is shared and charged to nobody.
+ * Charge each target the weight of its own modules plus every module that is reachable
+ * only through it. Anything the app already reaches without passing through a target,
+ * or that a second target also reaches, is shared and charged to nobody.
  *
- * This is pure measurement; budgets are applied afterwards so that only the plugins
+ * A target is a group of module ids so the same attribution serves a single plugin file
+ * and a whole Nuxt module package.
+ *
+ * This is pure measurement; budgets are applied afterwards so that only the targets
  * heavy enough to matter need their name resolved.
  */
-export function measurePluginCost(input: MeasureInput): PluginMeasurement[] {
-  const { modules, targetIds, entryIds, maxDependencies = 3 } = input
+export function measureCost(input: MeasureInput): CostMeasurement[] {
+  const { modules, targets, entryIds, maxDependencies = 3 } = input
   const byId = new Map(modules.map(module => [module.id, module]))
-  const present = targetIds.filter(id => byId.has(id))
-  const targets = new Set(present)
+  const present = targets
+    .map(target => ({ key: target.key, ids: target.ids.filter(id => byId.has(id)) }))
+    .filter(target => target.ids.length > 0)
+  const owned = new Set(present.flatMap(target => target.ids))
 
-  const sharedWithApp = walk(entryIds, byId, targets)
+  const sharedWithApp = walk(entryIds, byId, owned)
 
   const owners = new Map<string, Set<string>>()
   const reachedByTarget = new Map<string, Set<string>>()
-  for (const id of present) {
-    const reached = walk(byId.get(id)!.importedIds, byId, targets)
-    reachedByTarget.set(id, reached)
+  for (const target of present) {
+    const imports = target.ids.flatMap(id => [...byId.get(id)!.importedIds])
+    const reached = walk(imports, byId, owned)
+    reachedByTarget.set(target.key, reached)
     for (const reachedId of reached) {
       const existing = owners.get(reachedId)
       if (existing)
-        existing.add(id)
-      else owners.set(reachedId, new Set([id]))
+        existing.add(target.key)
+      else owners.set(reachedId, new Set([target.key]))
     }
   }
 
-  return present.map((id) => {
+  return present.map(({ key, ids }) => {
     const exclusive: ModuleWeight[] = []
-    for (const reachedId of reachedByTarget.get(id)!) {
+    for (const reachedId of reachedByTarget.get(key)!) {
       // Imports can point outside the bundle (node builtins, externals); those cost nothing here.
       const module = byId.get(reachedId)
       if (!module || sharedWithApp.has(reachedId) || owners.get(reachedId)!.size > 1)
@@ -87,10 +99,10 @@ export function measurePluginCost(input: MeasureInput): PluginMeasurement[] {
     }
     exclusive.sort((a, b) => b.bytes - a.bytes || a.id.localeCompare(b.id))
 
-    const ownBytes = byId.get(id)!.bytes
+    const ownBytes = ids.reduce((total, id) => total + byId.get(id)!.bytes, 0)
     const exclusiveBytes = exclusive.reduce((total, module) => total + module.bytes, 0)
     return {
-      id,
+      key,
       ownBytes,
       exclusiveBytes,
       exclusiveCount: exclusive.length,

--- a/packages/nuxt-dx/src/size-budget/module-packages.ts
+++ b/packages/nuxt-dx/src/size-budget/module-packages.ts
@@ -1,0 +1,74 @@
+const NODE_MODULES = '/node_modules/'
+/** An entry named after its folder speaks for the whole folder; any other file speaks only for itself. */
+const DIRECTORY_ENTRY = /\/(?:index|module)\.[^/]+$/
+
+export interface ModuleOwner {
+  /** Module name, when Nuxt knows one. */
+  name?: string
+  /** Path prefix owning the module's bundled files. */
+  root: string
+}
+
+export interface OwnedModules {
+  owner: ModuleOwner
+  ids: string[]
+}
+
+/** Rollup ids carry a virtual prefix and a query suffix that paths on disk do not. */
+function normalize(id: string): string {
+  return id.replace(/\\/g, '/').replace(/^\0/, '').split('?')[0]!
+}
+
+/**
+ * The package directory a file inside `node_modules` belongs to. pnpm nests a second
+ * `node_modules` inside its store, so the last one wins; a scoped package keeps two segments.
+ */
+export function packageDirOf(file: string): string | undefined {
+  const path = normalize(file)
+  const marker = path.lastIndexOf(NODE_MODULES)
+  if (marker === -1)
+    return undefined
+  const segments = path.slice(marker + NODE_MODULES.length).split('/')
+  const depth = segments[0]!.startsWith('@') ? 2 : 1
+  const name = segments.slice(0, depth)
+  // A bare scope folder, or pnpm's own `.pnpm` store, names no package.
+  if (name.length < depth || !name[0] || name[0].startsWith('.'))
+    return undefined
+  return `${path.slice(0, marker)}${NODE_MODULES}${name.join('/')}`
+}
+
+/**
+ * The path prefix that owns a Nuxt module's bundled files. A published module owns its
+ * whole package; a local one owns the folder its entry sits in, or just the entry file,
+ * so `modules/analytics.ts` cannot claim the bundle cost of `modules/seo.ts` beside it.
+ */
+export function moduleRoot(entryPath: string): string {
+  const path = normalize(entryPath)
+  return packageDirOf(path)
+    ?? (DIRECTORY_ENTRY.test(path) ? path.slice(0, path.lastIndexOf('/')) : path)
+}
+
+function isUnder(id: string, root: string): boolean {
+  return id === root || id.startsWith(`${root}/`)
+}
+
+/**
+ * Assign each bundled module to the owner it sits under. The longest root wins so a module
+ * nested inside another package keeps its own files, and owners sharing a name are merged.
+ */
+export function groupByOwner(owners: readonly ModuleOwner[], moduleIds: readonly string[]): OwnedModules[] {
+  const ranked = [...owners].sort((a, b) => b.root.length - a.root.length)
+  const grouped = new Map<string, OwnedModules>()
+  for (const id of moduleIds) {
+    const path = normalize(id)
+    const owner = ranked.find(candidate => isUnder(path, candidate.root))
+    if (!owner)
+      continue
+    const key = owner.name ?? owner.root
+    const existing = grouped.get(key)
+    if (existing)
+      existing.ids.push(id)
+    else grouped.set(key, { owner, ids: [id] })
+  }
+  return [...grouped.values()]
+}

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -1,14 +1,15 @@
 import type { TreeItem } from 'consola/utils'
-import type { PluginVerdict } from './budget'
+import type { BudgetVerdict } from './budget'
 import { colors, formatTree } from 'consola/utils'
 import { formatBytes } from './size'
 
-export type BudgetScope = 'client' | 'nitro'
+export type BudgetScope = 'client' | 'nitro' | 'modules'
 
 const SCOPE = {
-  client: { noun: 'Nuxt plugin', bundle: 'client' },
-  nitro: { noun: 'Nitro plugin', bundle: 'server' },
-} as const satisfies Record<BudgetScope, { noun: string, bundle: string }>
+  client: { noun: 'Nuxt plugin', bundle: 'client', own: 'the plugin file' },
+  nitro: { noun: 'Nitro plugin', bundle: 'server', own: 'the plugin file' },
+  modules: { noun: 'Nuxt module', bundle: 'client', own: 'the module\'s own files' },
+} as const satisfies Record<BudgetScope, { noun: string, bundle: string, own: string }>
 
 /** Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a warning. */
 export function displayId(id: string, rootDir: string): string {
@@ -19,12 +20,12 @@ export function displayId(id: string, rootDir: string): string {
   return fromPackages === -1 ? relative : relative.slice(fromPackages + 'node_modules/'.length)
 }
 
-/** The key that would widen this plugin's budget: its name when it has one, otherwise its file. */
-function overrideKey(verdict: PluginVerdict, rootDir: string): string {
+/** The key that would widen this budget: the name when there is one, otherwise the file. */
+function overrideKey(verdict: BudgetVerdict, rootDir: string): string {
   return verdict.name ?? displayId(verdict.path, rootDir)
 }
 
-function overrideSnippet(over: readonly PluginVerdict[], rootDir: string): string {
+function overrideSnippet(over: readonly BudgetVerdict[], rootDir: string): string {
   const entries = over.map((verdict) => {
     // Round up to the next whole kB so the suggested budget actually clears the current size.
     const kilobytes = Math.ceil(verdict.measurement.totalBytes / 1024)
@@ -33,11 +34,11 @@ function overrideSnippet(over: readonly PluginVerdict[], rootDir: string): strin
   return `nuxtDx.sizeBudget.overridesKb = { ${entries.join(', ')} }`
 }
 
-/** Every byte charged to the plugin, so the listed sizes always sum to the reported total. */
-function breakdown(verdict: PluginVerdict, rootDir: string): TreeItem[] {
+/** Every byte charged to the target, so the listed sizes always sum to the reported total. */
+function breakdown(scope: BudgetScope, verdict: BudgetVerdict, rootDir: string): TreeItem[] {
   const { ownBytes, exclusiveBytes, exclusiveCount, heaviestDependencies } = verdict.measurement
   const rows: { bytes: number, label: string, muted: boolean }[] = [
-    { bytes: ownBytes, label: 'the plugin file', muted: true },
+    { bytes: ownBytes, label: SCOPE[scope].own, muted: true },
     ...heaviestDependencies.map(dependency => ({
       bytes: dependency.bytes,
       label: displayId(dependency.id, rootDir),
@@ -58,7 +59,7 @@ function breakdown(verdict: PluginVerdict, rootDir: string): TreeItem[] {
   }))
 }
 
-export function formatBudgetReport(scope: BudgetScope, over: readonly PluginVerdict[], rootDir: string): string {
+export function formatBudgetReport(scope: BudgetScope, over: readonly BudgetVerdict[], rootDir: string): string {
   const { noun, bundle } = SCOPE[scope]
   const lines = [`${over.length} ${noun}${over.length === 1 ? '' : 's'} over budget in the ${bundle} bundle`]
 
@@ -68,9 +69,9 @@ export function formatBudgetReport(scope: BudgetScope, over: readonly PluginVerd
     const overshoot = formatBytes(measurement.totalBytes - budgetBytes)
     lines.push(
       '',
-      `  ${name ? `${colors.bold(name)}  ${colors.dim(file)}` : colors.bold(file)}`,
+      `  ${name && name !== file ? `${colors.bold(name)}  ${colors.dim(file)}` : colors.bold(name ?? file)}`,
       `  ${formatBytes(measurement.totalBytes)} bundled, ${colors.red(`${overshoot} over`)} the ${formatBytes(budgetBytes)} budget`,
-      formatTree(breakdown(verdict, rootDir), { prefix: '    ' }).trimEnd(),
+      formatTree(breakdown(scope, verdict, rootDir), { prefix: '    ' }).trimEnd(),
     )
   }
 

--- a/packages/nuxt-dx/src/size-budget/rollup.ts
+++ b/packages/nuxt-dx/src/size-budget/rollup.ts
@@ -1,20 +1,21 @@
 import type { OutputBundle, Plugin } from 'rollup'
-import type { GraphModule, PluginMeasurement } from './graph'
+import type { CostMeasurement, GraphModule } from './graph'
 import type { BudgetScope } from './report'
-import { measurePluginCost } from './graph'
-import { matchTargetId } from './match'
+import type { BudgetTarget } from './targets'
+import { measureCost } from './graph'
 
-export interface MeasuredPlugin {
-  /** Absolute path to the plugin file, as Nuxt or Nitro resolved it. */
+export interface MeasuredTarget {
+  /** Absolute path to the plugin file or module package, as Nuxt or Nitro resolved it. */
   path: string
-  measurement: PluginMeasurement
+  name?: string
+  measurement: CostMeasurement
 }
 
 export interface SizeBudgetPluginOptions {
   scope: BudgetScope
-  /** Read lazily so plugins registered after this rollup plugin is created are included. */
-  paths: () => readonly string[]
-  onMeasured: (measured: readonly MeasuredPlugin[]) => void | Promise<void>
+  /** Read lazily so plugins and modules registered after this rollup plugin is created are included. */
+  targets: (moduleIds: readonly string[]) => readonly BudgetTarget[]
+  onMeasured: (measured: readonly MeasuredTarget[]) => void | Promise<void>
 }
 
 function collectGraph(bundle: OutputBundle, importedIdsOf: (id: string) => readonly string[]) {
@@ -32,33 +33,24 @@ function collectGraph(bundle: OutputBundle, importedIdsOf: (id: string) => reado
 }
 
 /**
- * Measures the bundled weight of each plugin once the graph is final, so the cost
+ * Measures the bundled weight of each target once the graph is final, so the cost
  * reflects post-tree-shaking bytes rather than what the source file imports on paper.
  */
 export function sizeBudgetRollupPlugin(options: SizeBudgetPluginOptions): Plugin {
   return {
     name: `nuxt-dx:size-budget:${options.scope}`,
     async generateBundle(_outputOptions, bundle) {
-      const paths = options.paths()
-      if (!paths.length)
-        return
-
       const { modules, entryIds } = collectGraph(bundle, id => this.getModuleInfo(id)?.importedIds ?? [])
-      const ids = modules.map(module => module.id)
-      const pathById = new Map<string, string>()
-      for (const path of paths) {
-        const id = matchTargetId(path, ids)
-        if (id)
-          pathById.set(id, path)
-      }
-      if (!pathById.size)
+      const targets = options.targets(modules.map(module => module.id))
+      if (!targets.length)
         return
 
-      const measurements = measurePluginCost({ modules, targetIds: [...pathById.keys()], entryIds })
-      await options.onMeasured(measurements.map(measurement => ({
-        path: pathById.get(measurement.id)!,
-        measurement,
-      })))
+      const byKey = new Map(targets.map(target => [target.key, target]))
+      const measurements = measureCost({ modules, targets, entryIds })
+      await options.onMeasured(measurements.map((measurement) => {
+        const target = byKey.get(measurement.key)!
+        return { path: target.path, name: target.name, measurement }
+      }))
     },
   }
 }

--- a/packages/nuxt-dx/src/size-budget/targets.ts
+++ b/packages/nuxt-dx/src/size-budget/targets.ts
@@ -1,0 +1,33 @@
+import type { CostTarget } from './graph'
+import type { ModuleOwner } from './module-packages'
+import { matchTargetId } from './match'
+import { groupByOwner } from './module-packages'
+
+export interface BudgetTarget extends CostTarget {
+  /** Absolute path shown in the report. */
+  path: string
+  /** Display name, when it is known before measurement. */
+  name?: string
+}
+
+/** One plugin file, one target. Paths that were tree-shaken out have nothing to charge. */
+export function pluginTargets(paths: readonly string[], moduleIds: readonly string[]): BudgetTarget[] {
+  const byId = new Map<string, BudgetTarget>()
+  for (const path of paths) {
+    const id = matchTargetId(path, moduleIds)
+    // The same file can be registered twice; charging it twice would double the graph's owners.
+    if (id && !byId.has(id))
+      byId.set(id, { key: id, path, ids: [id] })
+  }
+  return [...byId.values()]
+}
+
+/** Every bundled file under a module's package directory is charged to that module. */
+export function moduleTargets(owners: readonly ModuleOwner[], moduleIds: readonly string[]): BudgetTarget[] {
+  return groupByOwner(owners, moduleIds).map(({ owner, ids }) => ({
+    key: owner.name ?? owner.root,
+    path: owner.root,
+    name: owner.name,
+    ids,
+  }))
+}

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -1,4 +1,4 @@
-import type { PluginVerdict } from '../src/size-budget/budget'
+import type { BudgetVerdict } from '../src/size-budget/budget'
 import type { BudgetScope } from '../src/size-budget/report'
 import { stripAnsi } from 'consola/utils'
 import { describe, expect, it } from 'vitest'
@@ -18,11 +18,11 @@ describe('displayId', () => {
   })
 })
 
-const verdict: PluginVerdict = {
+const verdict: BudgetVerdict = {
   path: '/app/plugins/analytics.ts',
   budgetBytes: 20_480,
   measurement: {
-    id: '/app/plugins/analytics.ts',
+    key: '/app/plugins/analytics.ts',
     ownBytes: 1024,
     exclusiveBytes: 81_920,
     exclusiveCount: 1,
@@ -32,7 +32,7 @@ const verdict: PluginVerdict = {
 }
 
 /** Colours are terminal dressing; assert on the text underneath. */
-function report(over: PluginVerdict[], scope: BudgetScope = 'client'): string {
+function report(over: BudgetVerdict[], scope: BudgetScope = 'client'): string {
   return stripAnsi(formatBudgetReport(scope, over, '/app'))
 }
 
@@ -40,6 +40,14 @@ describe('formatBudgetReport', () => {
   it('says which bundle the budget applies to', () => {
     expect(report([verdict])).toContain('1 Nuxt plugin over budget in the client bundle')
     expect(report([verdict, verdict], 'nitro')).toContain('2 Nitro plugins over budget in the server bundle')
+  })
+
+  it('reports a Nuxt module by name without repeating it as a path', () => {
+    const module: BudgetVerdict = { ...verdict, path: '/app/node_modules/@nuxtjs/robots', name: '@nuxtjs/robots' }
+    const lines = report([module], 'modules')
+    expect(lines).toContain('1 Nuxt module over budget in the client bundle')
+    expect(lines).toContain('1 kB  the module\'s own files')
+    expect(lines).not.toContain('@nuxtjs/robots  @nuxtjs/robots')
   })
 
   it('states the overshoot, not just the total', () => {
@@ -70,7 +78,7 @@ describe('formatBudgetReport', () => {
   })
 
   it('accounts for dependencies it did not list', () => {
-    const truncated: PluginVerdict = {
+    const truncated: BudgetVerdict = {
       ...verdict,
       measurement: { ...verdict.measurement, exclusiveCount: 4, exclusiveBytes: 100_000 },
     }

--- a/packages/nuxt-dx/tests/graph.test.ts
+++ b/packages/nuxt-dx/tests/graph.test.ts
@@ -1,9 +1,13 @@
-import type { GraphModule } from '../src/size-budget/graph'
+import type { CostTarget, GraphModule } from '../src/size-budget/graph'
 import { describe, expect, it } from 'vitest'
-import { measurePluginCost } from '../src/size-budget/graph'
+import { measureCost } from '../src/size-budget/graph'
 
 function mod(id: string, bytes: number, importedIds: string[] = []): GraphModule {
   return { id, bytes, importedIds }
+}
+
+function target(id: string): CostTarget {
+  return { key: id, ids: [id] }
 }
 
 // entry -> plugins.mjs -> { analytics, tracker }
@@ -20,13 +24,13 @@ const MODULES = [
   mod('/node_modules/vue/index.mjs', 90_000, []),
 ]
 
-const TARGET_IDS = ['/app/plugins/analytics.ts', '/app/plugins/tracker.ts']
+const TARGETS = [target('/app/plugins/analytics.ts'), target('/app/plugins/tracker.ts')]
 
-function measure(modules = MODULES, targetIds = TARGET_IDS) {
-  return measurePluginCost({ modules, targetIds, entryIds: ['/app/entry.js'] })
+function measure(modules = MODULES, targets = TARGETS) {
+  return measureCost({ modules, targets, entryIds: ['/app/entry.js'] })
 }
 
-describe('measurePluginCost', () => {
+describe('measureCost', () => {
   it('charges a plugin for the modules only it pulls in', () => {
     const [analytics] = measure()
     expect(analytics.ownBytes).toBe(1000)
@@ -50,7 +54,7 @@ describe('measurePluginCost', () => {
   it('splits a dependency shared between two plugins away from both', () => {
     const modules = [...MODULES, mod('/app/plugins/extra.ts', 10, ['/node_modules/chart/index.mjs'])]
     modules[1] = mod('/build/plugins.mjs', 50, ['/app/plugins/analytics.ts', '/app/plugins/tracker.ts', '/app/plugins/extra.ts'])
-    const [analytics] = measure(modules, [...TARGET_IDS, '/app/plugins/extra.ts'])
+    const [analytics] = measure(modules, [...TARGETS, target('/app/plugins/extra.ts')])
     expect(analytics.exclusiveBytes).toBe(0)
     expect(analytics.totalBytes).toBe(1000)
   })
@@ -61,7 +65,7 @@ describe('measurePluginCost', () => {
   })
 
   it('skips targets that were tree-shaken out of the bundle', () => {
-    expect(measure(MODULES, [...TARGET_IDS, '/app/plugins/gone.ts'])).toHaveLength(2)
+    expect(measure(MODULES, [...TARGETS, target('/app/plugins/gone.ts')])).toHaveLength(2)
   })
 
   it('ignores imports that never landed in the bundle', () => {
@@ -70,7 +74,7 @@ describe('measurePluginCost', () => {
       mod('/app/plugins/a.ts', 10, ['node:crypto', '/node_modules/x/index.mjs']),
       mod('/node_modules/x/index.mjs', 30, ['external-package']),
     ]
-    const [a] = measure(modules, ['/app/plugins/a.ts'])
+    const [a] = measure(modules, [target('/app/plugins/a.ts')])
     expect(a.totalBytes).toBe(40)
     expect(a.heaviestDependencies).toEqual([{ id: '/node_modules/x/index.mjs', bytes: 30 }])
   })
@@ -82,7 +86,43 @@ describe('measurePluginCost', () => {
       mod('/node_modules/x/index.mjs', 30, ['/node_modules/y/index.mjs']),
       mod('/node_modules/y/index.mjs', 40, ['/node_modules/x/index.mjs']),
     ]
-    const [a] = measure(modules, ['/app/plugins/a.ts'])
+    const [a] = measure(modules, [target('/app/plugins/a.ts')])
     expect(a.totalBytes).toBe(80)
+  })
+})
+
+// entry -> plugins.mjs -> { robots runtime, sitemap runtime }, both packages also carry a util file
+const PACKAGES = [
+  mod('/app/entry.js', 100, ['/build/plugins.mjs']),
+  mod('/build/plugins.mjs', 50, ['/node_modules/robots/dist/plugin.mjs', '/node_modules/sitemap/dist/plugin.mjs']),
+  mod('/node_modules/robots/dist/plugin.mjs', 400, ['/node_modules/robots/dist/util.mjs', '/node_modules/ufo/index.mjs']),
+  mod('/node_modules/robots/dist/util.mjs', 600, ['/node_modules/parser/index.mjs']),
+  mod('/node_modules/sitemap/dist/plugin.mjs', 300, ['/node_modules/ufo/index.mjs']),
+  mod('/node_modules/parser/index.mjs', 50_000, []),
+  mod('/node_modules/ufo/index.mjs', 9000, []),
+]
+
+const PACKAGE_TARGETS: CostTarget[] = [
+  { key: 'robots', ids: ['/node_modules/robots/dist/plugin.mjs', '/node_modules/robots/dist/util.mjs'] },
+  { key: 'sitemap', ids: ['/node_modules/sitemap/dist/plugin.mjs'] },
+]
+
+describe('measureCost with grouped targets', () => {
+  it('charges a package for every file it ships', () => {
+    const [robots] = measureCost({ modules: PACKAGES, targets: PACKAGE_TARGETS, entryIds: ['/app/entry.js'] })
+    expect(robots.ownBytes).toBe(1000)
+    expect(robots.totalBytes).toBe(51_000)
+  })
+
+  it('charges neither package for a dependency both reach', () => {
+    const measured = measureCost({ modules: PACKAGES, targets: PACKAGE_TARGETS, entryIds: ['/app/entry.js'] })
+    const charged = measured.flatMap(entry => entry.heaviestDependencies.map(dep => dep.id))
+    expect(charged).not.toContain('/node_modules/ufo/index.mjs')
+    expect(measured[1]!.totalBytes).toBe(300)
+  })
+
+  it('does not charge a package for the files of a sibling target', () => {
+    const [robots] = measureCost({ modules: PACKAGES, targets: PACKAGE_TARGETS, entryIds: ['/app/entry.js'] })
+    expect(robots.heaviestDependencies.map(dep => dep.id)).toEqual(['/node_modules/parser/index.mjs'])
   })
 })

--- a/packages/nuxt-dx/tests/module-packages.test.ts
+++ b/packages/nuxt-dx/tests/module-packages.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { groupByOwner, moduleRoot, packageDirOf } from '../src/size-budget/module-packages'
+
+describe('packageDirOf', () => {
+  it('finds the package a dependency file ships from', () => {
+    expect(packageDirOf('/app/node_modules/ufo/dist/index.mjs')).toBe('/app/node_modules/ufo')
+  })
+
+  it('keeps both segments of a scoped package', () => {
+    expect(packageDirOf('/app/node_modules/@nuxtjs/robots/dist/module.mjs')).toBe('/app/node_modules/@nuxtjs/robots')
+  })
+
+  it('resolves past the pnpm store to the real package folder', () => {
+    expect(packageDirOf('/app/node_modules/.pnpm/@nuxtjs+robots@5.5.4_magicast@0.3.5/node_modules/@nuxtjs/robots/dist/runtime/plugin.js'))
+      .toBe('/app/node_modules/.pnpm/@nuxtjs+robots@5.5.4_magicast@0.3.5/node_modules/@nuxtjs/robots')
+  })
+
+  it('picks the nested copy when a package bundles its own dependencies', () => {
+    expect(packageDirOf('/app/node_modules/a/node_modules/b/index.js')).toBe('/app/node_modules/a/node_modules/b')
+  })
+
+  it('refuses the pnpm store itself', () => {
+    expect(packageDirOf('/app/node_modules/.pnpm/ufo@1.5.4/node_modules')).toBeUndefined()
+  })
+
+  it('refuses a bare scope folder', () => {
+    expect(packageDirOf('/app/node_modules/@nuxtjs')).toBeUndefined()
+  })
+
+  it('has no package for project files', () => {
+    expect(packageDirOf('/app/modules/analytics/index.ts')).toBeUndefined()
+  })
+
+  it('reads windows paths and rollup ids', () => {
+    expect(packageDirOf('\0C:\\app\\node_modules\\ufo\\dist\\index.mjs?v=1')).toBe('C:/app/node_modules/ufo')
+  })
+})
+
+describe('moduleRoot', () => {
+  it('is the whole package for a published module', () => {
+    expect(moduleRoot('/app/node_modules/.pnpm/@nuxtjs+robots@5.5.4/node_modules/@nuxtjs/robots/dist/module.mjs'))
+      .toBe('/app/node_modules/.pnpm/@nuxtjs+robots@5.5.4/node_modules/@nuxtjs/robots')
+  })
+
+  it('is the folder for a local module written as a directory', () => {
+    expect(moduleRoot('/app/modules/analytics/index.ts')).toBe('/app/modules/analytics')
+    expect(moduleRoot('/app/modules/analytics/module.ts')).toBe('/app/modules/analytics')
+  })
+
+  it('is the file alone for a single-file local module, so it cannot claim its siblings', () => {
+    expect(moduleRoot('/app/modules/analytics.ts')).toBe('/app/modules/analytics.ts')
+  })
+})
+
+const OWNERS = [
+  { name: 'robots', root: '/app/node_modules/@nuxtjs/robots' },
+  { name: 'analytics', root: '/app/modules/analytics.ts' },
+]
+
+describe('groupByOwner', () => {
+  it('collects every bundled file under a package', () => {
+    const [robots] = groupByOwner(OWNERS, [
+      '/app/node_modules/@nuxtjs/robots/dist/runtime/plugin.js',
+      '/app/node_modules/@nuxtjs/robots/dist/runtime/util.js',
+      '/app/node_modules/ufo/dist/index.mjs',
+    ])
+    expect(robots!.ids).toHaveLength(2)
+  })
+
+  it('leaves files no module owns unattributed', () => {
+    expect(groupByOwner(OWNERS, ['/app/node_modules/ufo/dist/index.mjs'])).toEqual([])
+  })
+
+  it('does not let a package claim a sibling with a longer name', () => {
+    expect(groupByOwner(OWNERS, ['/app/node_modules/@nuxtjs/robots-extra/dist/index.mjs'])).toEqual([])
+  })
+
+  it('matches a single-file module against itself', () => {
+    const [analytics] = groupByOwner(OWNERS, ['/app/modules/analytics.ts', '/app/modules/other.ts'])
+    expect(analytics!.ids).toEqual(['/app/modules/analytics.ts'])
+  })
+
+  it('gives a nested package to the module that ships it', () => {
+    const owners = [
+      { name: 'outer', root: '/app/node_modules/outer' },
+      { name: 'inner', root: '/app/node_modules/outer/node_modules/inner' },
+    ]
+    const grouped = groupByOwner(owners, ['/app/node_modules/outer/node_modules/inner/index.js'])
+    expect(grouped).toEqual([{ owner: owners[1], ids: ['/app/node_modules/outer/node_modules/inner/index.js'] }])
+  })
+
+  it('merges two entries for the same module name', () => {
+    const owners = [
+      { name: 'robots', root: '/app/node_modules/@nuxtjs/robots' },
+      { name: 'robots', root: '/app/modules/robots' },
+    ]
+    const grouped = groupByOwner(owners, ['/app/node_modules/@nuxtjs/robots/index.js', '/app/modules/robots/index.js'])
+    expect(grouped).toHaveLength(1)
+    expect(grouped[0]!.ids).toHaveLength(2)
+  })
+
+  it('matches rollup ids carrying a query', () => {
+    const [robots] = groupByOwner(OWNERS, ['/app/node_modules/@nuxtjs/robots/dist/runtime/plugin.js?v=abc'])
+    expect(robots!.ids).toEqual(['/app/node_modules/@nuxtjs/robots/dist/runtime/plugin.js?v=abc'])
+  })
+})

--- a/packages/nuxt-dx/tests/targets.test.ts
+++ b/packages/nuxt-dx/tests/targets.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { moduleTargets, pluginTargets } from '../src/size-budget/targets'
+
+describe('pluginTargets', () => {
+  it('matches a plugin path to its bundled id', () => {
+    expect(pluginTargets(['/app/plugins/analytics'], ['/app/plugins/analytics.ts', '/app/entry.js']))
+      .toEqual([{ key: '/app/plugins/analytics.ts', path: '/app/plugins/analytics', ids: ['/app/plugins/analytics.ts'] }])
+  })
+
+  it('drops plugins that never landed in the bundle', () => {
+    expect(pluginTargets(['/app/plugins/gone.ts'], ['/app/entry.js'])).toEqual([])
+  })
+
+  it('charges a plugin registered twice only once', () => {
+    expect(pluginTargets(['/app/plugins/a.ts', '/app/plugins/a'], ['/app/plugins/a.ts'])).toHaveLength(1)
+  })
+})
+
+describe('moduleTargets', () => {
+  const owners = [{ name: '@nuxtjs/robots', root: '/app/node_modules/@nuxtjs/robots' }]
+
+  it('charges a module for the package it ships from', () => {
+    expect(moduleTargets(owners, ['/app/node_modules/@nuxtjs/robots/dist/runtime/plugin.js', '/app/entry.js']))
+      .toEqual([{
+        key: '@nuxtjs/robots',
+        path: '/app/node_modules/@nuxtjs/robots',
+        name: '@nuxtjs/robots',
+        ids: ['/app/node_modules/@nuxtjs/robots/dist/runtime/plugin.js'],
+      }])
+  })
+
+  it('skips a module that bundled nothing', () => {
+    expect(moduleTargets(owners, ['/app/entry.js'])).toEqual([])
+  })
+
+  it('falls back to the package path when the module declares no name', () => {
+    const [target] = moduleTargets([{ root: '/app/modules/analytics' }], ['/app/modules/analytics/index.ts'])
+    expect(target!.key).toBe('/app/modules/analytics')
+    expect(target!.name).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Size budgets could only answer "which plugin is heavy". Nobody could answer the question people actually ask: I installed five modules, which one added 80 kB to my client bundle?

`measurePluginCost` is now `measureCost`, taking targets as *groups* of bundled module ids rather than one id each. A plugin is a group of one; a Nuxt module is every bundled file shipping from its package directory. The attribution rule is unchanged: a target is charged its own bytes plus everything reachable only through it, and anything the app already reaches, or that a second target also reaches, is charged to nobody.

Mapping bundled files back to a module needed two things the config does not give you directly. `_installedModules[].entryPath` is usually a bare specifier (`@nuxtjs/i18n`), so it is resolved through `resolveModule` and then `realpathSync`, because vite resolves through symlinks and a pnpm module's bundled ids sit under `.pnpm/<pkg>@<version>/node_modules/<pkg>` rather than under the link. `packageDirOf` takes the last `node_modules/` segment so the store path lands on the real package, keeping both segments of a scoped name. A local module is owned by the folder its entry sits in, or by the entry file alone when it is a single file, so `modules/a.ts` cannot claim `modules/b.ts`.

Real output from a fixture app with `@nuxtjs/i18n`, `@nuxtjs/robots` and `nuxt-og-image` installed, at `modulesKb: 5`:

```
[nuxt-dx]  WARN  2 Nuxt modules over budget in the client bundle

  @nuxtjs/i18n
  57.2 kB bundled, 52.2 kB over the 5 kB budget
    ├─48.3 kB  the module's own files
    ├─ 6.1 kB  @intlify/shared/dist/shared.mjs
    ├─ 2.5 kB  h3/dist/index.mjs
    └─  276 B  virtual:nuxt:node_modules%2F.cache%2Fnuxt%2F.nuxt%2Fi18n-options.mjs

  nuxt-site-config
  5.2 kB bundled, 252 B over the 5 kB budget
    ├─2.7 kB  the module's own files
    ├─2.3 kB  site-config-stack/dist/index.mjs
    └─ 219 B  virtual:nuxt:node_modules%2F.cache%2Fnuxt%2F.nuxt%2Fnuxt-site-config%2Fi18n-plugin-deps.mjs

  Defer heavy imports with `await import()`, or allow the size:
    nuxtDx.sizeBudget.overridesKb = { '@nuxtjs/i18n': 58, 'nuxt-site-config': 6 }
```

Exclusive attribution is visible in that fixture. With i18n alone installed, i18n is charged 95.9 kB; adding og-image drops it to 57.2 kB because `nuxt/dist/app/composables/asyncData.js` and `cookie-es` are now reached by both and belong to neither. `nuxt-site-config` was never installed directly, it arrived as a dependency of another module, and it is charged like any other.

Config gains `modulesKb` (default 50, `false` to disable). `overridesKb` already matched by name before path, so a module name works as an override key with no extra machinery. The report reuses `formatBudgetReport` unchanged apart from a per-scope label for the own-bytes row.

### 🧪 Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` in `packages/nuxt-dx`: all pass, 72 tests.
- New unit tests cover the path to package mapping (pnpm store paths, scoped packages, nested copies, windows separators, rollup virtual prefixes and queries), owner grouping, target building, and grouped-target measurement.
- Real build: a throwaway Nuxt 4.5.2 app in a temp dir with `@nuxtjs/i18n`, `@nuxtjs/robots` and `nuxt-og-image` installed from npm, running `nuxt build` against the packed tarball of this branch. Output above. A rolldown build (vite 8) was what caught that `entryPath` is a specifier rather than a path, which unit tests could not have shown.
- Plugin budgets re-verified on the same real build after the refactor: `pluginsKb: 5` reported `nuxt:router` at 6.5 kB and `i18n:plugin` at 6.3 kB, still named from `defineNuxtPlugin`.
