### PR TITLE
feat(dx): diff size budgets between two builds

### DIFF
--- a/.github/actions/nuxt-dx-budget/action.yml
+++ b/.github/actions/nuxt-dx-budget/action.yml
@@ -1,0 +1,90 @@
+name: Nuxt DX size budget
+description: Diff this build's size budget report against the base branch, summarise what moved, and fail when a plugin or module grows past the threshold.
+
+inputs:
+  report-path:
+    description: Report this build wrote, relative to working-directory. Enable `nuxtDx.report` to produce it.
+    required: false
+    default: .nuxt/dx/size-budget.json
+  threshold-kb:
+    description: Growth allowed for a single target, never cumulative, before this fails.
+    required: false
+    default: '10'
+  artifact-name:
+    description: Artifact this uploads the report to, and reads the baseline back from.
+    required: false
+    default: nuxt-dx-size-budget
+  base-branch:
+    description: Branch whose last successful run of this workflow holds the baseline. Defaults to the pull request base, then the repository default branch.
+    required: false
+    default: ''
+  working-directory:
+    description: Directory the app was built in.
+    required: false
+    default: .
+  github-token:
+    description: 'Token used to list workflow runs and download the baseline artifact. Needs `actions: read`.'
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    # The baseline is the report the last green run on the base branch left behind, so
+    # nothing is rebuilt here and no baseline file is committed to the repository.
+    - name: Find the baseline run
+      id: baseline
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        WORKFLOW: ${{ github.workflow }}
+        BASE_BRANCH: ${{ inputs.base-branch || github.event.pull_request.base.ref || github.event.repository.default_branch }}
+        REPORT_PATH: ${{ inputs.report-path }}
+      run: |
+        set -euo pipefail
+        echo "report-file=$(basename "$REPORT_PATH")" >> "$GITHUB_OUTPUT"
+        run_id=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch "$BASE_BRANCH" \
+          --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' || true)
+        echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+        if [ -z "$run_id" ]; then
+          echo "No successful run of \"$WORKFLOW\" on $BASE_BRANCH yet, so this build has no baseline."
+        else
+          echo "Taking the baseline from run $run_id on $BASE_BRANCH."
+        fi
+
+    # Missing or expired artifacts are normal on a first run, so a failed download is
+    # reported as no baseline rather than as a broken pull request.
+    - name: Download the baseline report
+      if: steps.baseline.outputs.run-id != ''
+      continue-on-error: true
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/nuxt-dx-baseline
+        run-id: ${{ steps.baseline.outputs.run-id }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: Compare against the baseline
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        BASE_REPORT: ${{ runner.temp }}/nuxt-dx-baseline/${{ steps.baseline.outputs.report-file }}
+        HEAD_REPORT: ${{ inputs.report-path }}
+        THRESHOLD_KB: ${{ inputs.threshold-kb }}
+      run: |
+        set -uo pipefail
+        npx --no-install nuxt-dx compare "$BASE_REPORT" "$HEAD_REPORT" \
+          --threshold-kb "$THRESHOLD_KB" --allow-missing-base | tee -a "$GITHUB_STEP_SUMMARY"
+        exit "${PIPESTATUS[0]}"
+
+    # Uploaded even when the comparison failed, so the next run on this branch still has
+    # something to measure against.
+    - name: Keep this report as the next baseline
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.working-directory }}/${{ inputs.report-path }}
+        if-no-files-found: error
+        retention-days: 30

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -24,8 +24,8 @@ Status: experimental. APIs may change before the first release.
 - 🚨 **Client error overlay:** Vue warnings, Vue errors, console errors, uncaught errors, and unhandled rejections in one badge, and a strict production no-op.
 - 💧 **Hydration mismatches, decoded:** counted separately and read back as component, source file, and the two values that disagreed.
 - 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
-- 📦 **Size budgets:** warn when a Nuxt plugin, a Nitro plugin, or an installed Nuxt module drags too much JavaScript into the bundle, so you can answer which of your modules cost you 80 kB.
-- 🔍 **Exclusive attribution and overrides:** each plugin and module is charged only for what it alone pulls in, with budgets keyed by plugin name, module name, or path fragment.
+- 📦 **Size budgets with exclusive attribution:** warn when a Nuxt plugin, a Nitro plugin, or an installed Nuxt module drags too much JavaScript into the bundle, each charged only for what it alone pulls in, with budgets keyed by plugin name, module name, or path fragment.
+- 📈 **Regression diffs:** every build writes a machine-readable report of what each plugin and module costs, and `nuxt-dx compare` diffs two of them so the pull request that quietly adds 40 kB fails instead of landing.
 
 ## Installation
 
@@ -142,6 +142,127 @@ Every bundled file that ships from a module's own package is charged to that mod
 
 Modules are reported by the name they declare in their own `meta`, which is also the key an override takes. Modules you never installed yourself show up too, `nuxt-site-config` above arrived as a dependency of another module, and it is charged like any other.
 
+## The size budget report
+
+Every build writes what it measured to `.nuxt/dx/size-budget.json`, whether or not anything breached a budget. It is the input to the regression check below, and it is readable on its own: one entry per Nuxt plugin, Nitro plugin, and installed Nuxt module, with the bytes broken down the same way the warning breaks them down.
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "scope": "client",
+      "path": "app/plugins/analytics.client.ts",
+      "ownBytes": 182,
+      "exclusiveBytes": 7626,
+      "totalBytes": 7808
+    },
+    {
+      "scope": "modules",
+      "name": "fixture-telemetry",
+      "path": "modules/telemetry",
+      "ownBytes": 12834,
+      "exclusiveBytes": 0,
+      "totalBytes": 12834
+    },
+    {
+      "scope": "nitro",
+      "path": "server/plugins/audit.ts",
+      "ownBytes": 117,
+      "exclusiveBytes": 6423,
+      "totalBytes": 6540
+    }
+  ]
+}
+```
+
+`scope` is `client` for a Nuxt app plugin, `nitro` for a Nitro plugin, and `modules` for an installed Nuxt module. Paths are relative to the app root so two checkouts of the same repository agree on them. Modules carry the name they declare; plugins are keyed by path, since a plugin's declared name is only read for the plugins close enough to their budget to need it.
+
+Only the scopes you left enabled are measured, so `pluginsKb: false` also drops plugins from the report. The client bundle is only built by `nuxi build`, so a `nuxi dev` run writes the Nitro plugins alone.
+
+## Catching regressions
+
+An absolute budget catches a bundle that is already too big. It says nothing about the pull request that takes a healthy 12 kB plugin to 48 kB. `nuxt-dx compare` reads the report from two builds and fails when anything grew past a threshold:
+
+```bash
+nuxt-dx compare base/.nuxt/dx/size-budget.json .nuxt/dx/size-budget.json
+```
+
+```md
+### Bundle size budget
+
+53.6 kB to 72.1 kB, **+18.5 kB** across 5 targets.
+
+**1 target grew past the 10 kB threshold:** `app/plugins/analytics.client.ts` +35.7 kB.
+
+| Target | Scope | Base | Head | Change |
+| --- | --- | --- | --- | --- |
+| `app/plugins/analytics.client.ts` | Nuxt plugin | 7.6 kB | 43.3 kB | +35.7 kB |
+| `app/plugins/consent.client.ts` | Nuxt plugin | 0 B | 170 B | +170 B (new) |
+| `app/plugins/legacy.client.ts` | Nuxt plugin | 159 B | 0 B | -159 B (gone) |
+| `fixture-telemetry` | Nuxt module | 12.5 kB | 3.9 kB | -8.6 kB |
+| `modules/telemetry/runtime/plugin.ts` | Nuxt plugin | 12.5 kB | 3.9 kB | -8.6 kB |
+```
+
+Markdown goes to stdout so it can be redirected straight into a job summary; the pass or fail line goes to stderr so a local run still reads as one. Targets that held still are counted rather than listed.
+
+`--threshold-kb` sets how much a single target may grow before this fails, defaulting to 10. Each target is judged on its own, so a 40 kB regression is caught even when an unrelated cleanup makes the totals look flat. Exit code 1 means something grew past the threshold, 2 means a report could not be read, and 0 means you are clear.
+
+### In GitHub Actions
+
+Check out both commits, build both, and diff the two reports. Nothing is stored between runs, so there is no baseline file to go stale, and `$GITHUB_STEP_SUMMARY` needs no permissions and works on pull requests from forks.
+
+```yaml
+name: Size budget
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  size-budget:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the pull request
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check out the base commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.0
+        with:
+          path: .base
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.2.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Build the base commit
+        working-directory: .base
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Build the pull request
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Compare
+        run: >
+          pnpm exec nuxt-dx compare
+          .base/.nuxt/dx/size-budget.json
+          .nuxt/dx/size-budget.json
+          >> "$GITHUB_STEP_SUMMARY"
+```
+
+The diff lands in the job summary either way; the step only fails when something grew past the threshold. Raise the bar for a pull request that legitimately ships something big by passing `--threshold-kb`.
+
 ## Configuring budgets
 
 ```ts
@@ -161,6 +282,8 @@ export default defineNuxtConfig({
         '@nuxtjs/i18n': 80,
         'server/plugins/queue': 120,
       },
+      // where the machine-readable report is written, relative to the app root
+      reportPath: '.nuxt/dx/size-budget.json',
       // throw instead of warning
       fail: false,
     },

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -25,7 +25,7 @@ Status: experimental. APIs may change before the first release.
 - 💧 **Hydration mismatches, decoded:** counted separately and read back as component, source file, and the two values that disagreed.
 - 🤖 **Agent handoff:** copy a route-scoped report with source files attached, ready to paste at a coding agent.
 - 📦 **Size budgets with exclusive attribution:** warn when a Nuxt plugin, a Nitro plugin, or an installed Nuxt module drags too much JavaScript into the bundle, each charged only for what it alone pulls in, with budgets keyed by plugin name, module name, or path fragment.
-- 📈 **Regression diffs:** every build writes a machine-readable report of what each plugin and module costs, and `nuxt-dx compare` diffs two of them so the pull request that quietly adds 40 kB fails instead of landing.
+- 📈 **Regression diffs:** opt into a machine-readable report of what each plugin and module costs, then diff two builds with `nuxt-dx compare` or the bundled GitHub action, so the pull request that quietly adds 40 kB fails instead of landing.
 
 ## Installation
 
@@ -144,7 +144,16 @@ Modules are reported by the name they declare in their own `meta`, which is also
 
 ## The size budget report
 
-Every build writes what it measured to `.nuxt/dx/size-budget.json`, whether or not anything breached a budget. It is the input to the regression check below, and it is readable on its own: one entry per Nuxt plugin, Nitro plugin, and installed Nuxt module, with the bytes broken down the same way the warning breaks them down.
+Reporting is off until you ask for it. With `report: true`, every build writes what it measured to `.nuxt/dx/size-budget.json`, whether or not anything breached a budget. It is the input to the regression check below, and it is readable on its own: one entry per Nuxt plugin, Nitro plugin, and installed Nuxt module, with the bytes broken down the same way the warning breaks them down.
+
+```ts
+export default defineNuxtConfig({
+  nuxtDx: {
+    // or `{ path: 'ci/size-budget.json' }` to write it somewhere else
+    report: true,
+  },
+})
+```
 
 ```json
 {
@@ -191,7 +200,11 @@ nuxt-dx compare base/.nuxt/dx/size-budget.json .nuxt/dx/size-budget.json
 ```md
 ### Bundle size budget
 
-53.6 kB to 72.1 kB, **+18.5 kB** across 5 targets.
+- **Nuxt plugins** 34.7 kB to 61.8 kB, **+27.1 kB**
+- **Nitro plugins** 6.4 kB to 6.4 kB, **+0 B**
+- **Nuxt modules** 12.5 kB to 3.9 kB, **-8.6 kB**
+
+Scopes are totalled separately, since a Nuxt module is charged for the plugins it ships.
 
 **1 target grew past the 10 kB threshold:** `app/plugins/analytics.client.ts` +35.7 kB.
 
@@ -204,64 +217,75 @@ nuxt-dx compare base/.nuxt/dx/size-budget.json .nuxt/dx/size-budget.json
 | `modules/telemetry/runtime/plugin.ts` | Nuxt plugin | 12.5 kB | 3.9 kB | -8.6 kB |
 ```
 
-Markdown goes to stdout so it can be redirected straight into a job summary; the pass or fail line goes to stderr so a local run still reads as one. Targets that held still are counted rather than listed.
+Markdown goes to stdout so it can be redirected straight into a job summary; the pass or fail line goes to stderr so a local run still reads as one. Targets that held still are counted rather than listed. Each scope is totalled on its own and the scopes are never added together, since the plugin a module ships is charged to the plugin and to the module both.
 
-`--threshold-kb` sets how much a single target may grow before this fails, defaulting to 10. Each target is judged on its own, so a 40 kB regression is caught even when an unrelated cleanup makes the totals look flat. Exit code 1 means something grew past the threshold, 2 means a report could not be read, and 0 means you are clear.
+`--threshold-kb` sets how much a single target may grow before this fails, defaulting to 10. **The threshold is per target, never cumulative:** twelve plugins each gaining 9 kB pass a 10 kB threshold, while the one plugin that gains 11 kB does not. This is aimed at the change that lands in one place, and reading the scope totals is how you catch a wide, shallow drift.
 
-### In GitHub Actions
+`--allow-missing-base` reports that there was no baseline and passes, rather than failing. Exit code 1 means something grew past the threshold, 2 means a report could not be read, and 0 means you are clear.
 
-Check out both commits, build both, and diff the two reports. Nothing is stored between runs, so there is no baseline file to go stale, and `$GITHUB_STEP_SUMMARY` needs no permissions and works on pull requests from forks.
+## GitHub Actions
+
+The comparison runs after your existing build step, in the job you already have. Nothing is rebuilt for it, since your build already wrote the report.
+
+First, turn the report on:
+
+```ts
+export default defineNuxtConfig({
+  nuxtDx: {
+    report: true,
+  },
+})
+```
+
+Then add the action to the workflow that builds your app:
 
 ```yaml
-name: Size budget
+name: CI
 
-on: pull_request
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read
+  # the action lists workflow runs and downloads the baseline report from one
+  actions: read
 
 jobs:
-  size-budget:
+  build:
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out the pull request
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.0
-        with:
-          persist-credentials: false
-
-      - name: Check out the base commit
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.0
-        with:
-          path: .base
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha }}
-
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.0
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.2.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
         with:
           node-version: 24
           cache: pnpm
 
-      - name: Build the base commit
-        working-directory: .base
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
 
-      - name: Build the pull request
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
-
-      - name: Compare
-        run: >
-          pnpm exec nuxt-dx compare
-          .base/.nuxt/dx/size-budget.json
-          .nuxt/dx/size-budget.json
-          >> "$GITHUB_STEP_SUMMARY"
+      - uses: harlan-zw/harlan-nuxt/.github/actions/nuxt-dx-budget@main
+        with:
+          report-path: .nuxt/dx/size-budget.json
+          threshold-kb: 10
 ```
 
-The diff lands in the job summary either way; the step only fails when something grew past the threshold. Raise the bar for a pull request that legitimately ships something big by passing `--threshold-kb`.
+The baseline is the report left behind by the last successful run of the same workflow on the base branch, downloaded from that run's artifact. Every run uploads its own report, so a green run on `main` becomes the baseline for the pull requests that follow. Nothing is committed to your repository, so there is no baseline file to go stale or to conflict on every pull request.
+
+A run with no baseline says so in the job summary and passes. That covers the first ever run, a branch whose artifact has passed its retention window, and a workflow that has never been green on the base branch. A missing baseline never fails a pull request.
+
+The diff goes to `$GITHUB_STEP_SUMMARY`, which needs no write permissions and works on pull requests from forks. The step fails only when a target grew past the threshold.
+
+| Input | Default | |
+| --- | --- | --- |
+| `report-path` | `.nuxt/dx/size-budget.json` | Report your build wrote, relative to `working-directory` |
+| `threshold-kb` | `10` | Growth allowed for a single target |
+| `artifact-name` | `nuxt-dx-size-budget` | Artifact the report is uploaded to and read back from |
+| `base-branch` | pull request base, then the default branch | Branch the baseline comes from |
+| `working-directory` | `.` | Directory the app was built in |
+| `github-token` | `${{ github.token }}` | Needs `actions: read` |
 
 ## Configuring budgets
 
@@ -282,11 +306,11 @@ export default defineNuxtConfig({
         '@nuxtjs/i18n': 80,
         'server/plugins/queue': 120,
       },
-      // where the machine-readable report is written, relative to the app root
-      reportPath: '.nuxt/dx/size-budget.json',
       // throw instead of warning
       fail: false,
     },
+    // write the measurements to JSON for `nuxt-dx compare`, off by default
+    report: false,
   },
 })
 ```

--- a/packages/nuxt-dx/build.config.ts
+++ b/packages/nuxt-dx/build.config.ts
@@ -2,6 +2,6 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
   failOnWarn: false,
-  entries: ['src/module'],
+  entries: ['src/module', 'src/cli/index'],
   externals: ['#app', '#imports'],
 })

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -73,6 +73,7 @@
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:",
-    "vue": "catalog:"
+    "vue": "catalog:",
+    "yaml": "catalog:"
   }
 }

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -31,6 +31,9 @@
   },
   "main": "./dist/module.mjs",
   "types": "./dist/types.d.mts",
+  "bin": {
+    "nuxt-dx": "dist/cli/index.mjs"
+  },
   "files": [
     "dist"
   ],
@@ -53,6 +56,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
+    "citty": "catalog:",
     "consola": "catalog:",
     "oxc-parser": "catalog:",
     "oxc-walker": "catalog:"

--- a/packages/nuxt-dx/src/cli/index.ts
+++ b/packages/nuxt-dx/src/cli/index.ts
@@ -13,17 +13,26 @@ import { fileURLToPath } from 'node:url'
 import { defineCommand, runMain } from 'citty'
 import { colors } from 'consola/utils'
 import { diffSnapshots } from '../size-budget/diff'
-import { formatDiffMarkdown, formatDiffVerdict } from '../size-budget/diff-report'
+import { formatDiffMarkdown, formatDiffVerdict, formatMissingBaselineMarkdown } from '../size-budget/diff-report'
 import { kilobytesToBytes } from '../size-budget/size'
 import { parseSnapshot } from '../size-budget/snapshot'
 
 /** A target growing by more than this fails the comparison. */
 const DEFAULT_THRESHOLD_KB = 10
 
-async function readSnapshot(path: string): Promise<SizeBudgetSnapshot> {
-  const source = await readFile(path, 'utf-8').catch(() => {
-    throw new Error(`Cannot read ${path}. Build the app first; the report is written to .nuxt/dx/size-budget.json.`)
+/** Undefined only when the file is absent, which the baseline is allowed to be. */
+async function readSource(path: string): Promise<string | undefined> {
+  return await readFile(path, 'utf-8').catch((error: unknown) => {
+    if ((error as { code?: string }).code === 'ENOENT')
+      return undefined
+    throw new Error(`Cannot read ${path}: ${error instanceof Error ? error.message : String(error)}`)
   })
+}
+
+async function readSnapshot(path: string): Promise<SizeBudgetSnapshot> {
+  const source = await readSource(path)
+  if (source === undefined)
+    throw new Error(`No report at ${path}. Build the app with \`nuxtDx.report\` enabled first.`)
   return parseSnapshot(source, path)
 }
 
@@ -42,13 +51,21 @@ const compare = defineCommand({
   args: {
     'base': { type: 'positional', description: 'Report from the build you are comparing against', required: true },
     'head': { type: 'positional', description: 'Report from the build you are checking', required: true },
-    'threshold-kb': { type: 'string', description: 'Growth allowed per target before this fails', default: String(DEFAULT_THRESHOLD_KB) },
+    'threshold-kb': { type: 'string', description: 'Growth allowed for a single target, never cumulative, before this fails', default: String(DEFAULT_THRESHOLD_KB) },
+    'allow-missing-base': { type: 'boolean', description: 'Report that there is no baseline and pass, instead of failing', default: false },
   },
   async run({ args }) {
     try {
       const threshold = thresholdBytes(args['threshold-kb'])
-      const [base, head] = await Promise.all([readSnapshot(args.base), readSnapshot(args.head)])
-      const diff = diffSnapshots(base, head, threshold)
+      const baseSource = await readSource(args.base)
+      if (baseSource === undefined && args['allow-missing-base']) {
+        process.stdout.write(`${formatMissingBaselineMarkdown(args.base)}\n`)
+        process.stderr.write(`${colors.yellow(`… no baseline report at ${args.base}, nothing compared`)}\n`)
+        return
+      }
+      if (baseSource === undefined)
+        throw new Error(`No report at ${args.base}. Pass --allow-missing-base to treat a missing baseline as a pass.`)
+      const diff = diffSnapshots(parseSnapshot(baseSource, args.base), await readSnapshot(args.head), threshold)
       // Markdown on stdout so it can be redirected straight into a step summary,
       // the verdict on stderr so a local run still reads as a pass or a fail.
       process.stdout.write(`${formatDiffMarkdown(diff)}\n`)

--- a/packages/nuxt-dx/src/cli/index.ts
+++ b/packages/nuxt-dx/src/cli/index.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * `nuxt-dx` reads the size budget reports two builds wrote and says what moved.
+ * Absolute budgets catch a bundle that is already too big; this catches the pull
+ * request that quietly added 40 kB to one that was fine.
+ */
+import type { CommandDef } from 'citty'
+import type { SizeBudgetSnapshot } from '../size-budget/snapshot'
+import { realpathSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { defineCommand, runMain } from 'citty'
+import { colors } from 'consola/utils'
+import { diffSnapshots } from '../size-budget/diff'
+import { formatDiffMarkdown, formatDiffVerdict } from '../size-budget/diff-report'
+import { kilobytesToBytes } from '../size-budget/size'
+import { parseSnapshot } from '../size-budget/snapshot'
+
+/** A target growing by more than this fails the comparison. */
+const DEFAULT_THRESHOLD_KB = 10
+
+async function readSnapshot(path: string): Promise<SizeBudgetSnapshot> {
+  const source = await readFile(path, 'utf-8').catch(() => {
+    throw new Error(`Cannot read ${path}. Build the app first; the report is written to .nuxt/dx/size-budget.json.`)
+  })
+  return parseSnapshot(source, path)
+}
+
+function thresholdBytes(raw: string): number {
+  const kilobytes = Number(raw)
+  if (!Number.isFinite(kilobytes) || kilobytes < 0)
+    throw new Error(`--threshold-kb expects a non-negative number of kilobytes, received "${raw}".`)
+  return kilobytesToBytes(kilobytes)
+}
+
+const compare = defineCommand({
+  meta: {
+    name: 'compare',
+    description: 'Diff two size budget reports, failing when a plugin or module grows past the threshold',
+  },
+  args: {
+    'base': { type: 'positional', description: 'Report from the build you are comparing against', required: true },
+    'head': { type: 'positional', description: 'Report from the build you are checking', required: true },
+    'threshold-kb': { type: 'string', description: 'Growth allowed per target before this fails', default: String(DEFAULT_THRESHOLD_KB) },
+  },
+  async run({ args }) {
+    try {
+      const threshold = thresholdBytes(args['threshold-kb'])
+      const [base, head] = await Promise.all([readSnapshot(args.base), readSnapshot(args.head)])
+      const diff = diffSnapshots(base, head, threshold)
+      // Markdown on stdout so it can be redirected straight into a step summary,
+      // the verdict on stderr so a local run still reads as a pass or a fail.
+      process.stdout.write(`${formatDiffMarkdown(diff)}\n`)
+      process.stderr.write(`${formatDiffVerdict(diff)}\n`)
+      if (diff.breaches.length)
+        process.exitCode = 1
+    }
+    catch (error) {
+      process.stderr.write(`${colors.red('✖')} ${error instanceof Error ? error.message : String(error)}\n`)
+      // Distinct from a breach: nothing was compared, so nothing was proven.
+      process.exitCode = 2
+    }
+  },
+})
+
+const main: CommandDef = defineCommand({
+  meta: {
+    name: 'nuxt-dx',
+    description: 'Bundle size budget tooling for Nuxt plugins, Nitro plugins and Nuxt modules',
+  },
+  subCommands: { compare },
+})
+
+export { main }
+
+/** True only when this file is the process entry (the `nuxt-dx` bin), not when imported. */
+function isCliEntry(): boolean {
+  const invoked = process.argv[1]
+  if (!invoked)
+    return false
+  try {
+    // realpath both sides so the package manager's `.bin/nuxt-dx` symlink resolves to the dist file.
+    return realpathSync(invoked) === realpathSync(fileURLToPath(import.meta.url))
+  }
+  catch {
+    return false
+  }
+}
+
+if (isCliEntry())
+  await runMain(main)

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -13,7 +13,7 @@ import { extractPluginName } from './size-budget/plugin-name'
 import { formatBudgetReport } from './size-budget/report'
 import { sizeBudgetRollupPlugin } from './size-budget/rollup'
 import { kilobytesToBytes } from './size-budget/size'
-import { createSnapshotWriter, SNAPSHOT_FILE } from './size-budget/snapshot'
+import { createSnapshotWriter, resolveReportPath } from './size-budget/snapshot'
 import { moduleTargets, pluginTargets } from './size-budget/targets'
 
 export interface SizeBudgetOptions {
@@ -35,15 +35,18 @@ export interface SizeBudgetOptions {
   /** Per-target kilobyte budgets, keyed by plugin name, module name, or any fragment of the path. */
   overridesKb?: Record<string, number>
   /**
-   * Where the machine-readable report is written, relative to the app root.
-   * @default '.nuxt/dx/size-budget.json'
-   */
-  reportPath?: string
-  /**
    * Fail the build instead of warning.
    * @default false
    */
   fail?: boolean
+}
+
+export interface ReportOptions {
+  /**
+   * Where the report is written, relative to the app root.
+   * @default '.nuxt/dx/size-budget.json'
+   */
+  path?: string
 }
 
 export interface ModuleOptions {
@@ -52,6 +55,12 @@ export interface ModuleOptions {
   sourceRoot?: string
   /** Warn when a plugin's or module's exclusive import graph exceeds a bundle size budget. */
   sizeBudget?: SizeBudgetOptions | false
+  /**
+   * Write what the size budgets measured to a JSON file, for `nuxt-dx compare` to diff
+   * against another build. Nothing is written unless you ask for it.
+   * @default false
+   */
+  report?: boolean | ReportOptions
 }
 
 interface ResolvedBudgets {
@@ -170,13 +179,18 @@ function installedModuleOwners(nuxt: Nuxt): ModuleOwner[] {
   return owners
 }
 
-function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
+function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined): void {
   const budgets = resolveBudgets(options)
   const clientBudget = budgets.client
   const nitroBudget = budgets.nitro
   const moduleBudget = budgets.modules
 
-  const writeSnapshot = createSnapshotWriter(resolve(nuxt.options.rootDir, options.reportPath ?? SNAPSHOT_FILE), nuxt.options.rootDir)
+  if (reportPath !== undefined && clientBudget === undefined && nitroBudget === undefined && moduleBudget === undefined)
+    logger.warn('`nuxtDx.report` is on, but every size budget is disabled, so there is nothing to measure.')
+
+  const writeSnapshot = reportPath === undefined
+    ? undefined
+    : createSnapshotWriter(resolve(nuxt.options.rootDir, reportPath), nuxt.options.rootDir)
   /**
    * Every measurement is recorded, then judged. The report covers the whole build so
    * a later run can diff it, and it is written before the verdict so a failing budget
@@ -185,7 +199,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
   const onMeasured = (scope: BudgetScope, defaultBytes: number, named: boolean) => {
     const report = reporter(scope, defaultBytes, budgets, nuxt, named)
     return async (measured: readonly MeasuredTarget[]) => {
-      await writeSnapshot(scope, measured)
+      await writeSnapshot?.(scope, measured)
       await report(measured)
     }
   }
@@ -250,8 +264,11 @@ export default defineNuxtModule<ModuleOptions>({
     if (!options.enabled)
       return
 
+    const reportPath = resolveReportPath(options.report)
     if (options.sizeBudget !== false)
-      setupSizeBudget(options.sizeBudget ?? {}, nuxt)
+      setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath)
+    else if (reportPath !== undefined)
+      logger.warn('`nuxtDx.report` is on, but `nuxtDx.sizeBudget` is `false`, so there is nothing to measure.')
 
     if (!nuxt.options.dev)
       return

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,11 +1,11 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { BudgetOverride, BudgetVerdict } from './size-budget/budget'
 import type { ModuleOwner } from './size-budget/module-packages'
-import type { BudgetScope } from './size-budget/report'
 import type { MeasuredTarget } from './size-budget/rollup'
+import type { BudgetScope } from './size-budget/scope'
 import { realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { isAbsolute } from 'node:path'
+import { isAbsolute, resolve } from 'node:path'
 import { addPlugin, createResolver, defineNuxtModule, resolveModule, useLogger } from '@nuxt/kit'
 import { budgetFor, smallestBudget } from './size-budget/budget'
 import { moduleRoot } from './size-budget/module-packages'
@@ -13,6 +13,7 @@ import { extractPluginName } from './size-budget/plugin-name'
 import { formatBudgetReport } from './size-budget/report'
 import { sizeBudgetRollupPlugin } from './size-budget/rollup'
 import { kilobytesToBytes } from './size-budget/size'
+import { createSnapshotWriter, SNAPSHOT_FILE } from './size-budget/snapshot'
 import { moduleTargets, pluginTargets } from './size-budget/targets'
 
 export interface SizeBudgetOptions {
@@ -33,6 +34,11 @@ export interface SizeBudgetOptions {
   modulesKb?: number | false
   /** Per-target kilobyte budgets, keyed by plugin name, module name, or any fragment of the path. */
   overridesKb?: Record<string, number>
+  /**
+   * Where the machine-readable report is written, relative to the app root.
+   * @default '.nuxt/dx/size-budget.json'
+   */
+  reportPath?: string
   /**
    * Fail the build instead of warning.
    * @default false
@@ -170,6 +176,20 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
   const nitroBudget = budgets.nitro
   const moduleBudget = budgets.modules
 
+  const writeSnapshot = createSnapshotWriter(resolve(nuxt.options.rootDir, options.reportPath ?? SNAPSHOT_FILE), nuxt.options.rootDir)
+  /**
+   * Every measurement is recorded, then judged. The report covers the whole build so
+   * a later run can diff it, and it is written before the verdict so a failing budget
+   * still leaves the artifact behind.
+   */
+  const onMeasured = (scope: BudgetScope, defaultBytes: number, named: boolean) => {
+    const report = reporter(scope, defaultBytes, budgets, nuxt, named)
+    return async (measured: readonly MeasuredTarget[]) => {
+      await writeSnapshot(scope, measured)
+      await report(measured)
+    }
+  }
+
   // `app:resolve` runs before the client build, and holds every plugin including module-registered ones.
   let appPluginPaths: string[] = []
   if (clientBudget !== undefined) {
@@ -188,7 +208,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
         plugins?.push(sizeBudgetRollupPlugin({
           scope: 'client',
           targets: ids => pluginTargets(appPluginPaths, ids),
-          onMeasured: reporter('client', clientBudget, budgets, nuxt, true),
+          onMeasured: onMeasured('client', clientBudget, true),
         }))
       }
       if (moduleBudget !== undefined) {
@@ -196,7 +216,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
           scope: 'modules',
           // Read at bundle time: modules keep installing while the config is assembled.
           targets: ids => moduleTargets(installedModuleOwners(nuxt), ids),
-          onMeasured: reporter('modules', moduleBudget, budgets, nuxt, false),
+          onMeasured: onMeasured('modules', moduleBudget, false),
         }))
       }
     })
@@ -210,7 +230,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt): void {
           scope: 'nitro',
           // Nitro plugins have no name concept, so they are always identified by path.
           targets: ids => pluginTargets(nitro.options.plugins, ids),
-          onMeasured: reporter('nitro', nitroBudget, budgets, nuxt, false),
+          onMeasured: onMeasured('nitro', nitroBudget, false),
         }))
       })
     })

--- a/packages/nuxt-dx/src/size-budget/diff-report.ts
+++ b/packages/nuxt-dx/src/size-budget/diff-report.ts
@@ -1,0 +1,75 @@
+import type { EntryChange, SnapshotDiff } from './diff'
+import { colors } from 'consola/utils'
+import { SCOPE } from './scope'
+import { formatBytes, formatDelta } from './size'
+
+const SUFFIX: Partial<Record<EntryChange['kind'], string>> = {
+  added: ' (new)',
+  removed: ' (gone)',
+}
+
+/** A label is a file path or a package name; either can hold the character that ends a cell. */
+function cell(text: string): string {
+  return text.replaceAll('|', '\\|')
+}
+
+function row(change: EntryChange): string {
+  const columns = [
+    `\`${cell(change.label)}\``,
+    SCOPE[change.scope].noun,
+    formatBytes(change.baseBytes),
+    formatBytes(change.headBytes),
+    `${formatDelta(change.deltaBytes)}${SUFFIX[change.kind] ?? ''}`,
+  ]
+  return `| ${columns.join(' | ')} |`
+}
+
+function summary(diff: SnapshotDiff): string {
+  const { baseTotalBytes, headTotalBytes, totalDeltaBytes, changes } = diff
+  const moved = changes.filter(change => change.kind !== 'unchanged').length
+  return `${formatBytes(baseTotalBytes)} to ${formatBytes(headTotalBytes)}, **${formatDelta(totalDeltaBytes)}** across ${moved} target${moved === 1 ? '' : 's'}.`
+}
+
+function verdict(diff: SnapshotDiff): string {
+  const { breaches, thresholdBytes } = diff
+  const limit = formatBytes(thresholdBytes)
+  if (!breaches.length)
+    return `No target grew past the ${limit} threshold.`
+  const named = breaches.map(change => `\`${cell(change.label)}\` ${formatDelta(change.deltaBytes)}`).join(', ')
+  return `**${breaches.length} target${breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold:** ${named}.`
+}
+
+/**
+ * The diff as GitHub-flavoured markdown, ready to append to a step summary. Unchanged
+ * targets are counted rather than listed: a report of forty plugins that all held still
+ * is noise around the one that did not.
+ */
+export function formatDiffMarkdown(diff: SnapshotDiff): string {
+  const lines = ['### Bundle size budget', '']
+  if (!diff.changes.length)
+    return [...lines, 'Neither build measured a plugin, a Nitro plugin or a Nuxt module.'].join('\n')
+
+  const moved = diff.changes.filter(change => change.kind !== 'unchanged')
+  lines.push(summary(diff), '', verdict(diff), '')
+  if (moved.length) {
+    lines.push(
+      '| Target | Scope | Base | Head | Change |',
+      '| --- | --- | --- | --- | --- |',
+      ...moved.map(row),
+      '',
+    )
+  }
+
+  const unchanged = diff.changes.length - moved.length
+  lines.push(`<sub>${unchanged} target${unchanged === 1 ? '' : 's'} unchanged. Each target is charged its own bundled bytes plus every module it alone pulls in, so a plugin shipped by a module is counted under both.</sub>`)
+  return lines.join('\n')
+}
+
+/** One coloured line for the terminal, so a local run says what happened without reading markdown. */
+export function formatDiffVerdict(diff: SnapshotDiff): string {
+  const limit = formatBytes(diff.thresholdBytes)
+  if (!diff.breaches.length)
+    return colors.green(`✔ nothing grew past the ${limit} threshold`) + colors.dim(` (${formatDelta(diff.totalDeltaBytes)} in total)`)
+  const named = diff.breaches.map(change => `${change.label} ${formatDelta(change.deltaBytes)}`).join(', ')
+  return colors.red(`✖ ${diff.breaches.length} target${diff.breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold: `) + named
+}

--- a/packages/nuxt-dx/src/size-budget/diff-report.ts
+++ b/packages/nuxt-dx/src/size-budget/diff-report.ts
@@ -24,19 +24,36 @@ function row(change: EntryChange): string {
   return `| ${columns.join(' | ')} |`
 }
 
-function summary(diff: SnapshotDiff): string {
-  const { baseTotalBytes, headTotalBytes, totalDeltaBytes, changes } = diff
-  const moved = changes.filter(change => change.kind !== 'unchanged').length
-  return `${formatBytes(baseTotalBytes)} to ${formatBytes(headTotalBytes)}, **${formatDelta(totalDeltaBytes)}** across ${moved} target${moved === 1 ? '' : 's'}.`
+/** One line per scope. Scopes overlap, so there is no honest single number to lead with. */
+function summary(diff: SnapshotDiff): string[] {
+  const lines = diff.scopeTotals.map(({ scope, baseBytes, headBytes, deltaBytes }) =>
+    `- **${SCOPE[scope].noun}s** ${formatBytes(baseBytes)} to ${formatBytes(headBytes)}, **${formatDelta(deltaBytes)}**`)
+  if (diff.scopeTotals.length > 1)
+    lines.push('', 'Scopes are totalled separately, since a Nuxt module is charged for the plugins it ships.')
+  return lines
 }
 
 function verdict(diff: SnapshotDiff): string {
   const { breaches, thresholdBytes } = diff
   const limit = formatBytes(thresholdBytes)
   if (!breaches.length)
-    return `No target grew past the ${limit} threshold.`
+    return `No single target grew past the ${limit} threshold.`
   const named = breaches.map(change => `\`${cell(change.label)}\` ${formatDelta(change.deltaBytes)}`).join(', ')
   return `**${breaches.length} target${breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold:** ${named}.`
+}
+
+/**
+ * Nothing to compare against, which is the normal state of the first run on a branch and
+ * of a branch whose baseline artifact has expired. Said out loud rather than passed over.
+ */
+export function formatMissingBaselineMarkdown(path: string): string {
+  return [
+    '### Bundle size budget',
+    '',
+    `No baseline report was found at \`${path}\`, so there is nothing to compare this build against.`,
+    '',
+    'This run leaves its own report behind, which the next one can measure against.',
+  ].join('\n')
 }
 
 /**
@@ -50,7 +67,7 @@ export function formatDiffMarkdown(diff: SnapshotDiff): string {
     return [...lines, 'Neither build measured a plugin, a Nitro plugin or a Nuxt module.'].join('\n')
 
   const moved = diff.changes.filter(change => change.kind !== 'unchanged')
-  lines.push(summary(diff), '', verdict(diff), '')
+  lines.push(...summary(diff), '', verdict(diff), '')
   if (moved.length) {
     lines.push(
       '| Target | Scope | Base | Head | Change |',
@@ -61,15 +78,17 @@ export function formatDiffMarkdown(diff: SnapshotDiff): string {
   }
 
   const unchanged = diff.changes.length - moved.length
-  lines.push(`<sub>${unchanged} target${unchanged === 1 ? '' : 's'} unchanged. Each target is charged its own bundled bytes plus every module it alone pulls in, so a plugin shipped by a module is counted under both.</sub>`)
+  lines.push(`<sub>${unchanged} target${unchanged === 1 ? '' : 's'} unchanged. Each target is charged its own bundled bytes plus every module it alone pulls in, and the threshold applies to each target on its own rather than to the total.</sub>`)
   return lines.join('\n')
 }
 
 /** One coloured line for the terminal, so a local run says what happened without reading markdown. */
 export function formatDiffVerdict(diff: SnapshotDiff): string {
   const limit = formatBytes(diff.thresholdBytes)
-  if (!diff.breaches.length)
-    return colors.green(`✔ nothing grew past the ${limit} threshold`) + colors.dim(` (${formatDelta(diff.totalDeltaBytes)} in total)`)
+  if (!diff.breaches.length) {
+    const moved = diff.changes.filter(change => change.kind !== 'unchanged').length
+    return colors.green(`✔ no target grew past the ${limit} threshold`) + colors.dim(` (${moved} target${moved === 1 ? '' : 's'} changed size)`)
+  }
   const named = diff.breaches.map(change => `${change.label} ${formatDelta(change.deltaBytes)}`).join(', ')
   return colors.red(`✖ ${diff.breaches.length} target${diff.breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold: `) + named
 }

--- a/packages/nuxt-dx/src/size-budget/diff.ts
+++ b/packages/nuxt-dx/src/size-budget/diff.ts
@@ -1,0 +1,88 @@
+import type { BudgetScope } from './scope'
+import type { SizeBudgetSnapshot, SnapshotEntry } from './snapshot'
+import { entryKey } from './snapshot'
+
+export type ChangeKind = 'added' | 'removed' | 'grown' | 'shrunk' | 'unchanged'
+
+export interface EntryChange {
+  key: string
+  scope: BudgetScope
+  /** How the target is named in the report: its name when it has one, otherwise its path. */
+  label: string
+  kind: ChangeKind
+  /** Total bundled bytes in the base build; zero when the target is new. */
+  baseBytes: number
+  /** Total bundled bytes in the head build; zero when the target is gone. */
+  headBytes: number
+  deltaBytes: number
+}
+
+export interface SnapshotDiff {
+  /** Every target in either build, biggest growth first. */
+  changes: EntryChange[]
+  /** Bytes attributed across every target, which counts a module's own plugin under both scopes. */
+  baseTotalBytes: number
+  headTotalBytes: number
+  totalDeltaBytes: number
+  /** The growth a single target is allowed before the diff fails. */
+  thresholdBytes: number
+  /** Targets that grew past the threshold, biggest first. */
+  breaches: EntryChange[]
+}
+
+function label(entry: SnapshotEntry): string {
+  return entry.name ?? entry.path
+}
+
+function kindOf(base: SnapshotEntry | undefined, head: SnapshotEntry | undefined, deltaBytes: number): ChangeKind {
+  if (!base)
+    return 'added'
+  if (!head)
+    return 'removed'
+  if (deltaBytes > 0)
+    return 'grown'
+  return deltaBytes < 0 ? 'shrunk' : 'unchanged'
+}
+
+function total(entries: readonly SnapshotEntry[]): number {
+  return entries.reduce((sum, entry) => sum + entry.totalBytes, 0)
+}
+
+/**
+ * Pairs two reports by target identity and charges the difference. A target that
+ * disappeared counts as its whole size shrinking away, one that appeared as its whole
+ * size growing, so the per-target deltas always sum to the change in the bundle.
+ */
+export function diffSnapshots(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot, thresholdBytes: number): SnapshotDiff {
+  const baseByKey = new Map(base.entries.map(entry => [entryKey(entry), entry]))
+  const headByKey = new Map(head.entries.map(entry => [entryKey(entry), entry]))
+
+  const changes: EntryChange[] = []
+  for (const key of new Set([...baseByKey.keys(), ...headByKey.keys()])) {
+    const before = baseByKey.get(key)
+    const after = headByKey.get(key)
+    const identity = after ?? before!
+    const baseBytes = before?.totalBytes ?? 0
+    const headBytes = after?.totalBytes ?? 0
+    const deltaBytes = headBytes - baseBytes
+    changes.push({
+      key,
+      scope: identity.scope,
+      label: label(identity),
+      kind: kindOf(before, after, deltaBytes),
+      baseBytes,
+      headBytes,
+      deltaBytes,
+    })
+  }
+  changes.sort((a, b) => b.deltaBytes - a.deltaBytes || a.label.localeCompare(b.label))
+
+  return {
+    changes,
+    baseTotalBytes: total(base.entries),
+    headTotalBytes: total(head.entries),
+    totalDeltaBytes: total(head.entries) - total(base.entries),
+    thresholdBytes,
+    breaches: changes.filter(change => change.deltaBytes > thresholdBytes),
+  }
+}

--- a/packages/nuxt-dx/src/size-budget/diff.ts
+++ b/packages/nuxt-dx/src/size-budget/diff.ts
@@ -1,5 +1,6 @@
 import type { BudgetScope } from './scope'
 import type { SizeBudgetSnapshot, SnapshotEntry } from './snapshot'
+import { BUDGET_SCOPES } from './scope'
 import { entryKey } from './snapshot'
 
 export type ChangeKind = 'added' | 'removed' | 'grown' | 'shrunk' | 'unchanged'
@@ -17,13 +18,22 @@ export interface EntryChange {
   deltaBytes: number
 }
 
+export interface ScopeTotal {
+  scope: BudgetScope
+  baseBytes: number
+  headBytes: number
+  deltaBytes: number
+}
+
 export interface SnapshotDiff {
   /** Every target in either build, biggest growth first. */
   changes: EntryChange[]
-  /** Bytes attributed across every target, which counts a module's own plugin under both scopes. */
-  baseTotalBytes: number
-  headTotalBytes: number
-  totalDeltaBytes: number
+  /**
+   * One total per scope, in the order the scopes are declared. Scopes are never summed
+   * together: a Nuxt module is charged for the plugins it ships, so those bytes belong
+   * to both the module and the plugin, and adding the two would count them twice.
+   */
+  scopeTotals: ScopeTotal[]
   /** The growth a single target is allowed before the diff fails. */
   thresholdBytes: number
   /** Targets that grew past the threshold, biggest first. */
@@ -44,14 +54,28 @@ function kindOf(base: SnapshotEntry | undefined, head: SnapshotEntry | undefined
   return deltaBytes < 0 ? 'shrunk' : 'unchanged'
 }
 
-function total(entries: readonly SnapshotEntry[]): number {
-  return entries.reduce((sum, entry) => sum + entry.totalBytes, 0)
+function total(entries: readonly SnapshotEntry[], scope: BudgetScope): number {
+  return entries.reduce((sum, entry) => sum + (entry.scope === scope ? entry.totalBytes : 0), 0)
+}
+
+/**
+ * Within one scope the targets never overlap, so their deltas add up to what that scope
+ * gained or lost. Scopes measured from the same bundle do overlap, so each is totalled
+ * on its own and they are never added together.
+ */
+function scopeTotals(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot): ScopeTotal[] {
+  const present = BUDGET_SCOPES.filter(scope => [...base.entries, ...head.entries].some(entry => entry.scope === scope))
+  return present.map((scope) => {
+    const baseBytes = total(base.entries, scope)
+    const headBytes = total(head.entries, scope)
+    return { scope, baseBytes, headBytes, deltaBytes: headBytes - baseBytes }
+  })
 }
 
 /**
  * Pairs two reports by target identity and charges the difference. A target that
  * disappeared counts as its whole size shrinking away, one that appeared as its whole
- * size growing, so the per-target deltas always sum to the change in the bundle.
+ * size growing, so within a scope the per-target deltas add up to that scope's change.
  */
 export function diffSnapshots(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot, thresholdBytes: number): SnapshotDiff {
   const baseByKey = new Map(base.entries.map(entry => [entryKey(entry), entry]))
@@ -79,10 +103,10 @@ export function diffSnapshots(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot
 
   return {
     changes,
-    baseTotalBytes: total(base.entries),
-    headTotalBytes: total(head.entries),
-    totalDeltaBytes: total(head.entries) - total(base.entries),
+    scopeTotals: scopeTotals(base, head),
     thresholdBytes,
+    // Per target, never cumulative: the check is aimed at the one plugin that doubled,
+    // not at a bundle drifting up by a kilobyte in twenty places.
     breaches: changes.filter(change => change.deltaBytes > thresholdBytes),
   }
 }

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -1,15 +1,9 @@
 import type { TreeItem } from 'consola/utils'
 import type { BudgetVerdict } from './budget'
+import type { BudgetScope } from './scope'
 import { colors, formatTree } from 'consola/utils'
+import { SCOPE } from './scope'
 import { formatBytes } from './size'
-
-export type BudgetScope = 'client' | 'nitro' | 'modules'
-
-const SCOPE = {
-  client: { noun: 'Nuxt plugin', bundle: 'client', own: 'the plugin file' },
-  nitro: { noun: 'Nitro plugin', bundle: 'server', own: 'the plugin file' },
-  modules: { noun: 'Nuxt module', bundle: 'client', own: 'the module\'s own files' },
-} as const satisfies Record<BudgetScope, { noun: string, bundle: string, own: string }>
 
 /** Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a warning. */
 export function displayId(id: string, rootDir: string): string {

--- a/packages/nuxt-dx/src/size-budget/rollup.ts
+++ b/packages/nuxt-dx/src/size-budget/rollup.ts
@@ -1,6 +1,6 @@
 import type { OutputBundle, Plugin } from 'rollup'
 import type { CostMeasurement, GraphModule } from './graph'
-import type { BudgetScope } from './report'
+import type { BudgetScope } from './scope'
 import type { BudgetTarget } from './targets'
 import { measureCost } from './graph'
 

--- a/packages/nuxt-dx/src/size-budget/scope.ts
+++ b/packages/nuxt-dx/src/size-budget/scope.ts
@@ -1,0 +1,23 @@
+/** The three things a budget can be charged to, each measured off its own bundle pass. */
+export type BudgetScope = 'client' | 'nitro' | 'modules'
+
+interface ScopeMeta {
+  /** What one target of this scope is called. */
+  noun: string
+  /** The bundle the measurement came from. */
+  bundle: string
+  /** What the target's own bytes are, as opposed to what it pulls in. */
+  own: string
+}
+
+export const SCOPE = {
+  client: { noun: 'Nuxt plugin', bundle: 'client', own: 'the plugin file' },
+  nitro: { noun: 'Nitro plugin', bundle: 'server', own: 'the plugin file' },
+  modules: { noun: 'Nuxt module', bundle: 'client', own: 'the module\'s own files' },
+} as const satisfies Record<BudgetScope, ScopeMeta>
+
+export const BUDGET_SCOPES = Object.keys(SCOPE) as BudgetScope[]
+
+export function isBudgetScope(value: unknown): value is BudgetScope {
+  return typeof value === 'string' && value in SCOPE
+}

--- a/packages/nuxt-dx/src/size-budget/size.ts
+++ b/packages/nuxt-dx/src/size-budget/size.ts
@@ -13,3 +13,8 @@ export function formatBytes(bytes: number): string {
   const unit = UNITS.find(candidate => bytes >= candidate.scale) ?? UNITS[UNITS.length - 1]!
   return `${Number((bytes / unit.scale).toFixed(1))} ${unit.label}`
 }
+
+/** A change in size always carries its direction, so `0 B` never reads as a shrink. */
+export function formatDelta(bytes: number): string {
+  return `${bytes < 0 ? '-' : '+'}${formatBytes(Math.abs(bytes))}`
+}

--- a/packages/nuxt-dx/src/size-budget/snapshot.ts
+++ b/packages/nuxt-dx/src/size-budget/snapshot.ts
@@ -14,6 +14,16 @@ export const SNAPSHOT_VERSION = 1
  */
 export const SNAPSHOT_FILE = '.nuxt/dx/size-budget.json'
 
+/**
+ * The path a build should write to, or nothing when the report is off. Reporting is
+ * opt-in: a build that nobody asked for a report from writes no files.
+ */
+export function resolveReportPath(option: boolean | { path?: string } | undefined): string | undefined {
+  if (!option)
+    return undefined
+  return (option === true ? undefined : option.path) ?? SNAPSHOT_FILE
+}
+
 export interface SnapshotEntry {
   scope: BudgetScope
   /**

--- a/packages/nuxt-dx/src/size-budget/snapshot.ts
+++ b/packages/nuxt-dx/src/size-budget/snapshot.ts
@@ -1,0 +1,100 @@
+import type { MeasuredTarget } from './rollup'
+import type { BudgetScope } from './scope'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { displayId } from './report'
+import { isBudgetScope } from './scope'
+
+/** Bumped whenever the shape changes, so `compare` refuses a report it cannot read. */
+export const SNAPSHOT_VERSION = 1
+
+/**
+ * Where the report lands, relative to the app root. Not `nuxt.options.buildDir`: that
+ * moved into `node_modules/.cache` in Nuxt 4.5, which is no place to point a CI step at.
+ */
+export const SNAPSHOT_FILE = '.nuxt/dx/size-budget.json'
+
+export interface SnapshotEntry {
+  scope: BudgetScope
+  /**
+   * The module name, or the name a plugin declares. Absent for anything identified
+   * only by its file, which is every plugin whose budget was never at risk.
+   */
+  name?: string
+  /** Root-relative file or package path, so two checkouts of the same repo agree. */
+  path: string
+  /** Bytes of the target's own bundled files. */
+  ownBytes: number
+  /** Bytes of the modules reachable only through this target. */
+  exclusiveBytes: number
+  totalBytes: number
+}
+
+export interface SizeBudgetSnapshot {
+  version: number
+  entries: SnapshotEntry[]
+}
+
+/** Identity across two builds: the name when the target has one, otherwise its path. */
+export function entryKey(entry: Pick<SnapshotEntry, 'scope' | 'name' | 'path'>): string {
+  return `${entry.scope}:${entry.name ?? entry.path}`
+}
+
+function toEntry(scope: BudgetScope, target: MeasuredTarget, rootDir: string): SnapshotEntry {
+  const { ownBytes, exclusiveBytes, totalBytes } = target.measurement
+  return {
+    scope,
+    ...(target.name === undefined ? {} : { name: target.name }),
+    path: displayId(target.path, rootDir),
+    ownBytes,
+    exclusiveBytes,
+    totalBytes,
+  }
+}
+
+/**
+ * Accumulates the measurements of every scope into one file. The scopes finish at
+ * different times (the client bundle first, Nitro after it), so each pass rewrites
+ * the whole report rather than waiting for a build-wide hook that a failed budget
+ * would never reach.
+ */
+export function createSnapshotWriter(file: string, rootDir: string) {
+  const byScope = new Map<BudgetScope, SnapshotEntry[]>()
+  return async (scope: BudgetScope, measured: readonly MeasuredTarget[]): Promise<void> => {
+    byScope.set(scope, measured.map(target => toEntry(scope, target, rootDir)))
+    const entries = [...byScope.values()]
+      .flat()
+      .sort((a, b) => entryKey(a).localeCompare(entryKey(b)))
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, `${JSON.stringify({ version: SNAPSHOT_VERSION, entries } satisfies SizeBudgetSnapshot, null, 2)}\n`, 'utf-8')
+  }
+}
+
+function isEntry(value: unknown): value is SnapshotEntry {
+  if (typeof value !== 'object' || value === null)
+    return false
+  const entry = value as Record<string, unknown>
+  return isBudgetScope(entry.scope)
+    && typeof entry.path === 'string'
+    && (entry.name === undefined || typeof entry.name === 'string')
+    && ['ownBytes', 'exclusiveBytes', 'totalBytes'].every(field => typeof entry[field] === 'number')
+}
+
+/** Reads a report written by another build, which may be any file the user pointed at. */
+export function parseSnapshot(source: string, label: string): SizeBudgetSnapshot {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(source)
+  }
+  catch {
+    throw new Error(`${label} is not valid JSON.`)
+  }
+  if (typeof parsed !== 'object' || parsed === null)
+    throw new Error(`${label} is not a size budget report.`)
+  const { version, entries } = parsed as Record<string, unknown>
+  if (version !== SNAPSHOT_VERSION)
+    throw new Error(`${label} was written in format ${String(version)}, this CLI reads format ${SNAPSHOT_VERSION}. Rebuild it with a matching nuxt-dx.`)
+  if (!Array.isArray(entries) || !entries.every(isEntry))
+    throw new Error(`${label} has entries this CLI cannot read.`)
+  return { version, entries }
+}

--- a/packages/nuxt-dx/tests/action.test.ts
+++ b/packages/nuxt-dx/tests/action.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+/**
+ * The composite action consumers paste into their own workflow. It cannot be executed
+ * here, so what is asserted is the contract it makes: it parses, it pins what it runs,
+ * and it treats a missing baseline as a pass.
+ */
+const file = fileURLToPath(new URL('../../../.github/actions/nuxt-dx-budget/action.yml', import.meta.url))
+const source = readFileSync(file, 'utf-8')
+
+interface ActionStep {
+  'name'?: string
+  'uses'?: string
+  'run'?: string
+  'if'?: string
+  'continue-on-error'?: boolean
+}
+
+const action = parse(source) as {
+  inputs: Record<string, { description: string, default?: string }>
+  runs: { using: string, steps: ActionStep[] }
+}
+
+function step(name: string): ActionStep {
+  const found = action.runs.steps.find(candidate => candidate.name === name)
+  expect(found, `no step named "${name}"`).toBeDefined()
+  return found!
+}
+
+describe('nuxt-dx-budget action', () => {
+  it('is a composite action, so it drops into a job that already built the app', () => {
+    expect(action.runs.using).toBe('composite')
+    expect(action.runs.steps.some(candidate => /pnpm|npm|yarn|nuxi/.test(candidate.run ?? '') && /\bbuild\b/.test(candidate.run ?? ''))).toBe(false)
+  })
+
+  it('describes every input and gives each one a default', () => {
+    for (const [name, input] of Object.entries(action.inputs)) {
+      expect(input.description, `${name} has no description`).toBeTruthy()
+      expect(input.default, `${name} has no default`).toBeDefined()
+    }
+    expect(action.inputs['report-path']!.default).toBe('.nuxt/dx/size-budget.json')
+    expect(action.inputs['threshold-kb']!.default).toBe('10')
+  })
+
+  it('pins every action it runs to a commit, with the version it came from', () => {
+    const used = action.runs.steps.filter(candidate => candidate.uses).map(candidate => candidate.uses!)
+    expect(used.length).toBeGreaterThan(0)
+    for (const uses of used)
+      expect(uses, `${uses} is not pinned to a commit`).toMatch(/@[0-9a-f]{40}$/)
+    for (const uses of used)
+      expect(source).toMatch(new RegExp(`${uses.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} # v\\d+\\.\\d+\\.\\d+`))
+  })
+
+  it('reads the baseline from the last green run on the base branch', () => {
+    expect(step('Find the baseline run').run).toContain('gh run list')
+    expect(step('Find the baseline run').run).toContain('--status success')
+    expect(step('Download the baseline report').uses).toContain('actions/download-artifact')
+  })
+
+  it('treats a missing or expired baseline as a pass', () => {
+    expect(step('Download the baseline report')['continue-on-error']).toBe(true)
+    expect(step('Compare against the baseline').run).toContain('--allow-missing-base')
+  })
+
+  it('writes the diff to the step summary and fails on the comparison, not on tee', () => {
+    const run = step('Compare against the baseline').run!
+    expect(run).toContain('"$GITHUB_STEP_SUMMARY"')
+    expect(run).toMatch(/exit "\$\{PIPESTATUS\[0\]\}"/)
+  })
+
+  it('leaves this build\'s report behind even when the comparison failed', () => {
+    const upload = step('Keep this report as the next baseline')
+    expect(upload.uses).toContain('actions/upload-artifact')
+    expect(upload.if).toContain('!cancelled()')
+  })
+})

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -1,5 +1,5 @@
 import type { BudgetVerdict } from '../src/size-budget/budget'
-import type { BudgetScope } from '../src/size-budget/report'
+import type { BudgetScope } from '../src/size-budget/scope'
 import { stripAnsi } from 'consola/utils'
 import { describe, expect, it } from 'vitest'
 import { displayId, formatBudgetReport } from '../src/size-budget/report'

--- a/packages/nuxt-dx/tests/diff-report.test.ts
+++ b/packages/nuxt-dx/tests/diff-report.test.ts
@@ -2,7 +2,7 @@ import type { SizeBudgetSnapshot, SnapshotEntry } from '../src/size-budget/snaps
 import { stripAnsi } from 'consola/utils'
 import { describe, expect, it } from 'vitest'
 import { diffSnapshots } from '../src/size-budget/diff'
-import { formatDiffMarkdown, formatDiffVerdict } from '../src/size-budget/diff-report'
+import { formatDiffMarkdown, formatDiffVerdict, formatMissingBaselineMarkdown } from '../src/size-budget/diff-report'
 
 const KB = 1024
 
@@ -25,9 +25,24 @@ function markdown(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot, thresholdB
 }
 
 describe('formatDiffMarkdown', () => {
-  it('states the change in bundled size before anything else', () => {
+  it('leads with what each scope gained or lost', () => {
     const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })))
-    expect(report).toContain('10 kB to 50 kB, **+40 kB** across 1 target.')
+    expect(report).toContain('- **Nuxt plugins** 10 kB to 50 kB, **+40 kB**')
+  })
+
+  it('never adds two scopes together, since a module is charged for the plugins it ships', () => {
+    const plugin = entry({ scope: 'client', path: 'modules/telemetry/runtime/plugin.ts', totalBytes: 12 * KB })
+    const owner = entry({ scope: 'modules', name: 'telemetry', path: 'modules/telemetry', totalBytes: 12 * KB })
+    const report = markdown(snapshot(plugin, owner), snapshot(plugin, owner))
+    expect(report).toContain('- **Nuxt plugins** 12 kB to 12 kB, **+0 B**')
+    expect(report).toContain('- **Nuxt modules** 12 kB to 12 kB, **+0 B**')
+    expect(report).not.toContain('24 kB')
+    expect(report).toContain('Scopes are totalled separately')
+  })
+
+  it('does not explain the scope split when only one scope was measured', () => {
+    const report = markdown(snapshot(entry({ totalBytes: KB })), snapshot(entry({ totalBytes: 2 * KB })))
+    expect(report).not.toContain('Scopes are totalled separately')
   })
 
   it('names the targets that grew past the threshold', () => {
@@ -37,7 +52,12 @@ describe('formatDiffMarkdown', () => {
 
   it('says so when everything stayed within the threshold', () => {
     const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 11 * KB })))
-    expect(report).toContain('No target grew past the 10 kB threshold.')
+    expect(report).toContain('No single target grew past the 10 kB threshold.')
+  })
+
+  it('states that the threshold is per target rather than cumulative', () => {
+    const report = markdown(snapshot(entry({ totalBytes: KB })), snapshot(entry({ totalBytes: 2 * KB })))
+    expect(report).toContain('the threshold applies to each target on its own rather than to the total')
   })
 
   it('gives each changed target a row with both sizes and the change', () => {
@@ -82,14 +102,23 @@ describe('formatDiffMarkdown', () => {
   })
 })
 
+describe('formatMissingBaselineMarkdown', () => {
+  it('says which report was missing rather than reporting a false clean run', () => {
+    const report = formatMissingBaselineMarkdown('base/.nuxt/dx/size-budget.json')
+    expect(report).toContain('### Bundle size budget')
+    expect(report).toContain('No baseline report was found at `base/.nuxt/dx/size-budget.json`')
+    expect(report).not.toContain('threshold')
+  })
+})
+
 describe('formatDiffVerdict', () => {
   function verdict(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot): string {
     return stripAnsi(formatDiffVerdict(diffSnapshots(base, head, 10 * KB)))
   }
 
-  it('passes with the total change in hand', () => {
+  it('passes with a count of what moved', () => {
     const base = snapshot(entry({ totalBytes: 10 * KB }))
-    expect(verdict(base, snapshot(entry({ totalBytes: 12 * KB })))).toBe('✔ nothing grew past the 10 kB threshold (+2 kB in total)')
+    expect(verdict(base, snapshot(entry({ totalBytes: 12 * KB })))).toBe('✔ no target grew past the 10 kB threshold (1 target changed size)')
   })
 
   it('fails naming what grew', () => {

--- a/packages/nuxt-dx/tests/diff-report.test.ts
+++ b/packages/nuxt-dx/tests/diff-report.test.ts
@@ -1,0 +1,100 @@
+import type { SizeBudgetSnapshot, SnapshotEntry } from '../src/size-budget/snapshot'
+import { stripAnsi } from 'consola/utils'
+import { describe, expect, it } from 'vitest'
+import { diffSnapshots } from '../src/size-budget/diff'
+import { formatDiffMarkdown, formatDiffVerdict } from '../src/size-budget/diff-report'
+
+const KB = 1024
+
+function entry(partial: Partial<SnapshotEntry> & { totalBytes: number }): SnapshotEntry {
+  return {
+    scope: 'client',
+    path: 'app/plugins/analytics.ts',
+    ownBytes: 512,
+    exclusiveBytes: partial.totalBytes - 512,
+    ...partial,
+  }
+}
+
+function snapshot(...entries: SnapshotEntry[]): SizeBudgetSnapshot {
+  return { version: 1, entries }
+}
+
+function markdown(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot, thresholdBytes = 10 * KB): string {
+  return formatDiffMarkdown(diffSnapshots(base, head, thresholdBytes))
+}
+
+describe('formatDiffMarkdown', () => {
+  it('states the change in bundled size before anything else', () => {
+    const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })))
+    expect(report).toContain('10 kB to 50 kB, **+40 kB** across 1 target.')
+  })
+
+  it('names the targets that grew past the threshold', () => {
+    const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })))
+    expect(report).toContain('**1 target grew past the 10 kB threshold:** `app/plugins/analytics.ts` +40 kB.')
+  })
+
+  it('says so when everything stayed within the threshold', () => {
+    const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 11 * KB })))
+    expect(report).toContain('No target grew past the 10 kB threshold.')
+  })
+
+  it('gives each changed target a row with both sizes and the change', () => {
+    const base = snapshot(entry({ scope: 'modules', name: '@nuxtjs/i18n', totalBytes: 10 * KB }))
+    const head = snapshot(entry({ scope: 'modules', name: '@nuxtjs/i18n', totalBytes: 50 * KB }))
+    expect(markdown(base, head)).toContain('| `@nuxtjs/i18n` | Nuxt module | 10 kB | 50 kB | +40 kB |')
+  })
+
+  it('marks a target that appeared and one that disappeared', () => {
+    const base = snapshot(entry({ path: 'gone.ts', totalBytes: 4 * KB }))
+    const head = snapshot(entry({ path: 'new.ts', totalBytes: 4 * KB }))
+    const report = markdown(base, head)
+    expect(report).toContain('| `new.ts` | Nuxt plugin | 0 B | 4 kB | +4 kB (new) |')
+    expect(report).toContain('| `gone.ts` | Nuxt plugin | 4 kB | 0 B | -4 kB (gone) |')
+  })
+
+  it('names the bundle each scope was measured in', () => {
+    const base = snapshot(entry({ scope: 'nitro', path: 'server/plugins/queue.ts', totalBytes: KB }))
+    const head = snapshot(entry({ scope: 'nitro', path: 'server/plugins/queue.ts', totalBytes: 2 * KB }))
+    expect(markdown(base, head)).toContain('| `server/plugins/queue.ts` | Nitro plugin |')
+  })
+
+  it('counts the targets that held still instead of listing them', () => {
+    const held = snapshot(entry({ path: 'a.ts', totalBytes: KB }), entry({ path: 'b.ts', totalBytes: KB }))
+    const report = markdown(held, held)
+    expect(report).toContain('2 targets unchanged.')
+    expect(report).not.toContain('| `a.ts` |')
+  })
+
+  it('drops the table when nothing moved', () => {
+    const held = snapshot(entry({ totalBytes: KB }))
+    expect(markdown(held, held)).not.toContain('| Target |')
+  })
+
+  it('says nothing was measured when both builds are empty', () => {
+    expect(markdown(snapshot(), snapshot())).toContain('Neither build measured')
+  })
+
+  it('escapes a path that would otherwise end its cell', () => {
+    const base = snapshot(entry({ path: 'app/plugins/a|b.ts', totalBytes: KB }))
+    expect(markdown(base, snapshot())).toContain('`app/plugins/a\\|b.ts`')
+  })
+})
+
+describe('formatDiffVerdict', () => {
+  function verdict(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot): string {
+    return stripAnsi(formatDiffVerdict(diffSnapshots(base, head, 10 * KB)))
+  }
+
+  it('passes with the total change in hand', () => {
+    const base = snapshot(entry({ totalBytes: 10 * KB }))
+    expect(verdict(base, snapshot(entry({ totalBytes: 12 * KB })))).toBe('✔ nothing grew past the 10 kB threshold (+2 kB in total)')
+  })
+
+  it('fails naming what grew', () => {
+    const base = snapshot(entry({ totalBytes: 10 * KB }))
+    expect(verdict(base, snapshot(entry({ totalBytes: 50 * KB }))))
+      .toBe('✖ 1 target grew past the 10 kB threshold: app/plugins/analytics.ts +40 kB')
+  })
+})

--- a/packages/nuxt-dx/tests/diff.test.ts
+++ b/packages/nuxt-dx/tests/diff.test.ts
@@ -65,14 +65,29 @@ describe('diffSnapshots', () => {
     expect(diffSnapshots(base, base, KB).changes).toHaveLength(2)
   })
 
-  it('sums the per-target deltas into the change in bundled size', () => {
+  it('sums the per-target deltas into the change in that scope', () => {
     const base = snapshot(entry({ path: 'a.ts', totalBytes: 10 * KB }), entry({ path: 'b.ts', totalBytes: 10 * KB }))
     const head = snapshot(entry({ path: 'a.ts', totalBytes: 30 * KB }), entry({ path: 'c.ts', totalBytes: 5 * KB }))
     const diff = diffSnapshots(base, head, 100 * KB)
-    expect(diff.baseTotalBytes).toBe(20 * KB)
-    expect(diff.headTotalBytes).toBe(35 * KB)
-    expect(diff.totalDeltaBytes).toBe(15 * KB)
+    expect(diff.scopeTotals).toEqual([{ scope: 'client', baseBytes: 20 * KB, headBytes: 35 * KB, deltaBytes: 15 * KB }])
     expect(diff.changes.reduce((sum, change) => sum + change.deltaBytes, 0)).toBe(15 * KB)
+  })
+
+  it('totals each scope on its own, never adding scopes that count the same bytes twice', () => {
+    const plugin = entry({ scope: 'client', path: 'modules/telemetry/runtime/plugin.ts', totalBytes: 12 * KB })
+    const module = entry({ scope: 'modules', name: 'telemetry', path: 'modules/telemetry', totalBytes: 12 * KB })
+    const nitro = entry({ scope: 'nitro', path: 'server/plugins/audit.ts', totalBytes: 6 * KB })
+    const diff = diffSnapshots(snapshot(plugin, module, nitro), snapshot(plugin, module, nitro), KB)
+    expect(diff.scopeTotals.map(total => [total.scope, total.headBytes])).toEqual([
+      ['client', 12 * KB],
+      ['nitro', 6 * KB],
+      ['modules', 12 * KB],
+    ])
+  })
+
+  it('leaves out a scope neither build measured', () => {
+    const diff = diffSnapshots(snapshot(entry({ totalBytes: KB })), snapshot(entry({ totalBytes: KB })), KB)
+    expect(diff.scopeTotals.map(total => total.scope)).toEqual(['client'])
   })
 
   it('leads with the biggest growth', () => {
@@ -111,7 +126,7 @@ describe('growth threshold', () => {
     const shrinking = snapshot(entry({ path: 'a.ts', totalBytes: 100 * KB }), entry({ path: 'b.ts', totalBytes: KB }))
     const grown = snapshot(entry({ path: 'a.ts', totalBytes: KB }), entry({ path: 'b.ts', totalBytes: 40 * KB }))
     const diff = diffSnapshots(shrinking, grown, 10 * KB)
-    expect(diff.totalDeltaBytes).toBeLessThan(0)
+    expect(diff.scopeTotals[0]!.deltaBytes).toBeLessThan(0)
     expect(diff.breaches.map(change => change.label)).toEqual(['b.ts'])
   })
 })

--- a/packages/nuxt-dx/tests/diff.test.ts
+++ b/packages/nuxt-dx/tests/diff.test.ts
@@ -1,0 +1,117 @@
+import type { SizeBudgetSnapshot, SnapshotEntry } from '../src/size-budget/snapshot'
+import { describe, expect, it } from 'vitest'
+import { diffSnapshots } from '../src/size-budget/diff'
+
+function entry(partial: Partial<SnapshotEntry> & { totalBytes: number }): SnapshotEntry {
+  return {
+    scope: 'client',
+    path: 'app/plugins/analytics.ts',
+    ownBytes: 512,
+    exclusiveBytes: partial.totalBytes - 512,
+    ...partial,
+  }
+}
+
+function snapshot(...entries: SnapshotEntry[]): SizeBudgetSnapshot {
+  return { version: 1, entries }
+}
+
+const KB = 1024
+
+function changeOf(diff: ReturnType<typeof diffSnapshots>, label: string) {
+  return diff.changes.find(change => change.label === label)!
+}
+
+describe('diffSnapshots', () => {
+  it('reports a target that grew', () => {
+    const diff = diffSnapshots(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })), 20 * KB)
+    expect(changeOf(diff, 'app/plugins/analytics.ts')).toMatchObject({
+      kind: 'grown',
+      baseBytes: 10 * KB,
+      headBytes: 50 * KB,
+      deltaBytes: 40 * KB,
+    })
+  })
+
+  it('reports a target that shrank', () => {
+    const diff = diffSnapshots(snapshot(entry({ totalBytes: 50 * KB })), snapshot(entry({ totalBytes: 10 * KB })), 20 * KB)
+    expect(changeOf(diff, 'app/plugins/analytics.ts')).toMatchObject({ kind: 'shrunk', deltaBytes: -40 * KB })
+  })
+
+  it('charges a target that appeared its whole size', () => {
+    const diff = diffSnapshots(snapshot(), snapshot(entry({ totalBytes: 8 * KB })), 20 * KB)
+    expect(changeOf(diff, 'app/plugins/analytics.ts')).toMatchObject({ kind: 'added', baseBytes: 0, deltaBytes: 8 * KB })
+  })
+
+  it('credits a target that disappeared its whole size', () => {
+    const diff = diffSnapshots(snapshot(entry({ totalBytes: 8 * KB })), snapshot(), 20 * KB)
+    expect(changeOf(diff, 'app/plugins/analytics.ts')).toMatchObject({ kind: 'removed', headBytes: 0, deltaBytes: -8 * KB })
+  })
+
+  it('keeps a target that held still, marked unchanged', () => {
+    const diff = diffSnapshots(snapshot(entry({ totalBytes: 8 * KB })), snapshot(entry({ totalBytes: 8 * KB })), 20 * KB)
+    expect(changeOf(diff, 'app/plugins/analytics.ts')).toMatchObject({ kind: 'unchanged', deltaBytes: 0 })
+  })
+
+  it('pairs targets by name when they have one, so a moved package still matches', () => {
+    const base = snapshot(entry({ scope: 'modules', name: '@nuxtjs/i18n', path: 'node_modules/@nuxtjs/i18n', totalBytes: 20 * KB }))
+    const head = snapshot(entry({ scope: 'modules', name: '@nuxtjs/i18n', path: '.pnpm/@nuxtjs+i18n@10/i18n', totalBytes: 30 * KB }))
+    expect(diffSnapshots(base, head, 20 * KB).changes).toHaveLength(1)
+  })
+
+  it('keeps the same path in two scopes apart', () => {
+    const path = 'server/plugins/logger.ts'
+    const base = snapshot(entry({ path, totalBytes: KB }), entry({ scope: 'nitro', path, totalBytes: KB }))
+    expect(diffSnapshots(base, base, KB).changes).toHaveLength(2)
+  })
+
+  it('sums the per-target deltas into the change in bundled size', () => {
+    const base = snapshot(entry({ path: 'a.ts', totalBytes: 10 * KB }), entry({ path: 'b.ts', totalBytes: 10 * KB }))
+    const head = snapshot(entry({ path: 'a.ts', totalBytes: 30 * KB }), entry({ path: 'c.ts', totalBytes: 5 * KB }))
+    const diff = diffSnapshots(base, head, 100 * KB)
+    expect(diff.baseTotalBytes).toBe(20 * KB)
+    expect(diff.headTotalBytes).toBe(35 * KB)
+    expect(diff.totalDeltaBytes).toBe(15 * KB)
+    expect(diff.changes.reduce((sum, change) => sum + change.deltaBytes, 0)).toBe(15 * KB)
+  })
+
+  it('leads with the biggest growth', () => {
+    const base = snapshot(entry({ path: 'a.ts', totalBytes: 10 * KB }), entry({ path: 'b.ts', totalBytes: 10 * KB }))
+    const head = snapshot(entry({ path: 'a.ts', totalBytes: 12 * KB }), entry({ path: 'b.ts', totalBytes: 40 * KB }))
+    expect(diffSnapshots(base, head, 100 * KB).changes.map(change => change.label)).toEqual(['b.ts', 'a.ts'])
+  })
+})
+
+describe('growth threshold', () => {
+  const base = snapshot(entry({ totalBytes: 10 * KB }))
+  const head = snapshot(entry({ totalBytes: 20 * KB }))
+
+  it('passes growth that lands exactly on the threshold', () => {
+    expect(diffSnapshots(base, head, 10 * KB).breaches).toEqual([])
+  })
+
+  it('fails growth one byte past the threshold', () => {
+    expect(diffSnapshots(base, head, 10 * KB - 1).breaches).toHaveLength(1)
+  })
+
+  it('holds a new target to the same threshold', () => {
+    expect(diffSnapshots(snapshot(), head, 10 * KB).breaches).toHaveLength(1)
+    expect(diffSnapshots(snapshot(), snapshot(entry({ totalBytes: 4 * KB })), 10 * KB).breaches).toEqual([])
+  })
+
+  it('never counts a shrink as a breach', () => {
+    expect(diffSnapshots(head, base, 0).breaches).toEqual([])
+  })
+
+  it('flags any growth at all when the threshold is zero', () => {
+    expect(diffSnapshots(base, snapshot(entry({ totalBytes: 10 * KB + 1 })), 0).breaches).toHaveLength(1)
+  })
+
+  it('judges each target on its own, not on the total', () => {
+    const shrinking = snapshot(entry({ path: 'a.ts', totalBytes: 100 * KB }), entry({ path: 'b.ts', totalBytes: KB }))
+    const grown = snapshot(entry({ path: 'a.ts', totalBytes: KB }), entry({ path: 'b.ts', totalBytes: 40 * KB }))
+    const diff = diffSnapshots(shrinking, grown, 10 * KB)
+    expect(diff.totalDeltaBytes).toBeLessThan(0)
+    expect(diff.breaches.map(change => change.label)).toEqual(['b.ts'])
+  })
+})

--- a/packages/nuxt-dx/tests/snapshot.test.ts
+++ b/packages/nuxt-dx/tests/snapshot.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { createSnapshotWriter, entryKey, parseSnapshot, SNAPSHOT_VERSION } from '../src/size-budget/snapshot'
+import { createSnapshotWriter, entryKey, parseSnapshot, resolveReportPath, SNAPSHOT_FILE, SNAPSHOT_VERSION } from '../src/size-budget/snapshot'
 
 function target(path: string, totalBytes: number, name?: string): MeasuredTarget {
   return {
@@ -26,6 +26,25 @@ async function writerIn(rootDir = '/app') {
   const write = createSnapshotWriter(file, rootDir)
   return { write, read: async () => parseSnapshot(await readFile(file, 'utf-8'), file) }
 }
+
+describe('resolveReportPath', () => {
+  it('writes nothing when the report was never asked for', () => {
+    expect(resolveReportPath(undefined)).toBeUndefined()
+    expect(resolveReportPath(false)).toBeUndefined()
+  })
+
+  it('takes the default path from a bare opt-in', () => {
+    expect(resolveReportPath(true)).toBe(SNAPSHOT_FILE)
+  })
+
+  it('takes a path from the object form', () => {
+    expect(resolveReportPath({ path: 'reports/size.json' })).toBe('reports/size.json')
+  })
+
+  it('falls back to the default path when the object names none', () => {
+    expect(resolveReportPath({})).toBe(SNAPSHOT_FILE)
+  })
+})
 
 describe('createSnapshotWriter', () => {
   it('writes what a build measured, keyed by identity', async () => {

--- a/packages/nuxt-dx/tests/snapshot.test.ts
+++ b/packages/nuxt-dx/tests/snapshot.test.ts
@@ -1,0 +1,94 @@
+import type { MeasuredTarget } from '../src/size-budget/rollup'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { createSnapshotWriter, entryKey, parseSnapshot, SNAPSHOT_VERSION } from '../src/size-budget/snapshot'
+
+function target(path: string, totalBytes: number, name?: string): MeasuredTarget {
+  return {
+    path,
+    name,
+    measurement: {
+      key: path,
+      ownBytes: 512,
+      exclusiveBytes: totalBytes - 512,
+      exclusiveCount: 1,
+      totalBytes,
+      heaviestDependencies: [],
+    },
+  }
+}
+
+async function writerIn(rootDir = '/app') {
+  const dir = await mkdtemp(join(tmpdir(), 'nuxt-dx-'))
+  const file = join(dir, 'dx', 'size-budget.json')
+  const write = createSnapshotWriter(file, rootDir)
+  return { write, read: async () => parseSnapshot(await readFile(file, 'utf-8'), file) }
+}
+
+describe('createSnapshotWriter', () => {
+  it('writes what a build measured, keyed by identity', async () => {
+    const { write, read } = await writerIn()
+    await write('client', [target('/app/app/plugins/analytics.ts', 20_480)])
+    expect((await read()).entries).toEqual([{
+      scope: 'client',
+      path: 'app/plugins/analytics.ts',
+      ownBytes: 512,
+      exclusiveBytes: 19_968,
+      totalBytes: 20_480,
+    }])
+  })
+
+  it('keeps a name when the target has one', async () => {
+    const { write, read } = await writerIn()
+    await write('modules', [target('/app/node_modules/@nuxtjs/i18n', 1024, '@nuxtjs/i18n')])
+    expect((await read()).entries[0]).toMatchObject({ name: '@nuxtjs/i18n', path: '@nuxtjs/i18n' })
+  })
+
+  it('collects every scope into one report as each bundle finishes', async () => {
+    const { write, read } = await writerIn()
+    await write('client', [target('/app/app/plugins/a.ts', 1024)])
+    await write('nitro', [target('/app/server/plugins/b.ts', 2048)])
+    expect((await read()).entries.map(entryKey)).toEqual(['client:app/plugins/a.ts', 'nitro:server/plugins/b.ts'])
+  })
+
+  it('replaces a scope rather than appending to it, so a rebuild never doubles up', async () => {
+    const { write, read } = await writerIn()
+    await write('client', [target('/app/app/plugins/a.ts', 1024)])
+    await write('client', [target('/app/app/plugins/a.ts', 4096)])
+    const { entries } = await read()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.totalBytes).toBe(4096)
+  })
+})
+
+describe('parseSnapshot', () => {
+  const valid = JSON.stringify({
+    version: SNAPSHOT_VERSION,
+    entries: [{ scope: 'client', path: 'a.ts', ownBytes: 1, exclusiveBytes: 2, totalBytes: 3 }],
+  })
+
+  it('accepts a report this CLI wrote', () => {
+    expect(parseSnapshot(valid, 'base.json').entries).toHaveLength(1)
+  })
+
+  it('names the file it could not read', () => {
+    expect(() => parseSnapshot('{', 'base.json')).toThrow('base.json is not valid JSON')
+  })
+
+  it('refuses a report from a different format version', () => {
+    const future = JSON.stringify({ version: SNAPSHOT_VERSION + 1, entries: [] })
+    expect(() => parseSnapshot(future, 'head.json')).toThrow(/format/)
+  })
+
+  it('refuses entries it cannot measure', () => {
+    const broken = JSON.stringify({ version: SNAPSHOT_VERSION, entries: [{ scope: 'client', path: 'a.ts' }] })
+    expect(() => parseSnapshot(broken, 'head.json')).toThrow(/cannot read/)
+  })
+
+  it('refuses a scope it does not know', () => {
+    const broken = JSON.stringify({ version: SNAPSHOT_VERSION, entries: [{ scope: 'worker', path: 'a.ts', ownBytes: 1, exclusiveBytes: 1, totalBytes: 2 }] })
+    expect(() => parseSnapshot(broken, 'head.json')).toThrow(/cannot read/)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      citty:
+        specifier: 'catalog:'
+        version: 0.2.2
       consola:
         specifier: 'catalog:'
         version: 3.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ catalogs:
     wrangler:
       specifier: ^4.120.0
       version: 4.120.0
+    yaml:
+      specifier: ^2.9.0
+      version: 2.9.0
     zod:
       specifier: ^4.4.3
       version: 4.4.3
@@ -289,6 +292,9 @@ importers:
       vue:
         specifier: 'catalog:'
         version: 3.5.41(typescript@5.9.3)
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
 
   packages/nuxt-github-sponsors:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ catalog:
   vue-router: ^5.2.0
   vue-tsc: ^3.3.9
   wrangler: ^4.120.0
+  yaml: ^2.9.0
   zod: ^4.4.3
 
 ignoredBuiltDependencies:


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The size budgets we have are absolute: they catch a bundle that is already too big, and they only fire once. They say nothing about the pull request that takes a healthy 12 kB plugin to 48 kB, which is the failure mode that actually bites. There was no way to see that drift at all.

**1. An opt-in report.** `nuxtDx.report` sits at the top level and defaults to off, so a build writes nothing unless asked:

```ts
nuxtDx: {
  sizeBudget: { pluginsKb: 20, modulesKb: 50 },
  report: true, // or { path: 'ci/size-budget.json' }
}
```

It writes one entry per Nuxt plugin, Nitro plugin, and installed Nuxt module to `.nuxt/dx/size-budget.json`, each with scope, identity, own bytes, exclusive bytes, and total bytes. Written whether or not anything breached a budget, and written before the verdict so a failing build still leaves the artifact behind. The path is resolved against the app root rather than `nuxt.options.buildDir`, which moved under `node_modules/.cache` in Nuxt 4.5 and is no place to point a CI step at. Budget warnings are untouched and still fire by default.

**2. `nuxt-dx compare <base> <head>`**, a new bin following the `cf-jobs` citty wiring. Markdown on stdout so it can be redirected into a job summary, the pass or fail line on stderr so a local run still reads as one. Exit 1 when a target grew past `--threshold-kb` (default 10), exit 2 when a report could not be read, and `--allow-missing-base` turns an absent baseline into a pass.

**3. A first-party composite action** at `.github/actions/nuxt-dx-budget/`, which runs after the consumer's own build step in the job they already have. It does not build anything: their CI just built the app, so recomputing it would double their CI time for a number they already have.

```yaml
- run: pnpm build
- uses: harlan-zw/harlan-nuxt/.github/actions/nuxt-dx-budget@main
  with:
    report-path: .nuxt/dx/size-budget.json
    threshold-kb: 10
```

The baseline is the report left behind by the last successful run of the same workflow on the base branch, downloaded from that run's artifact with `actions/download-artifact` and a `run-id`. Every run uploads its own report, so a green run on `main` becomes the baseline for the pull requests that follow, and nothing is committed to the consumer's repository. A missing or expired baseline is reported in the step summary and passes, never failing a pull request. Third-party actions are pinned by commit SHA with the version in a comment.

**Headline total fixed.** It summed every scope, and a Nuxt module is charged for the plugins it ships, so those bytes were counted twice. Totals are now reported per scope and never added together, the contradictory doc comment is gone, and both the report and the docs state plainly that the threshold applies per target rather than cumulatively: twelve plugins each gaining 9 kB pass a 10 kB threshold, and the scope totals are how a wide, shallow drift shows up.

Real output from the two-build fixture, exit code 1:

```md
### Bundle size budget

- **Nuxt plugins** 34.7 kB to 61.8 kB, **+27.1 kB**
- **Nitro plugins** 6.4 kB to 6.4 kB, **+0 B**
- **Nuxt modules** 12.5 kB to 3.9 kB, **-8.6 kB**

Scopes are totalled separately, since a Nuxt module is charged for the plugins it ships.

**1 target grew past the 10 kB threshold:** `app/plugins/analytics.client.ts` +35.7 kB.

| Target | Scope | Base | Head | Change |
| --- | --- | --- | --- | --- |
| `app/plugins/analytics.client.ts` | Nuxt plugin | 7.6 kB | 43.3 kB | +35.7 kB |
| `app/plugins/consent.client.ts` | Nuxt plugin | 0 B | 170 B | +170 B (new) |
| `app/plugins/legacy.client.ts` | Nuxt plugin | 159 B | 0 B | -159 B (gone) |
| `fixture-telemetry` | Nuxt module | 12.5 kB | 3.9 kB | -8.6 kB |
| `modules/telemetry/runtime/plugin.ts` | Nuxt plugin | 12.5 kB | 3.9 kB | -8.6 kB |

<sub>6 targets unchanged. Each target is charged its own bundled bytes plus every module it alone pulls in, and the threshold applies to each target on its own rather than to the total.</sub>
```

`BudgetScope` and its per-scope labels moved out of `report.ts` into `size-budget/scope.ts`, so the terminal formatter, the serialiser and the markdown formatter share one definition instead of the CLI importing the warning renderer for a noun.

Not built, per the trimmed scope: no `workflow_call` reusable workflow, no `workflow_run` commenting workflow, no committed baseline file, and no workflow added to this repository's own `.github/workflows`.

### 🧪 Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (143 tests) and `pnpm test:attw` pass in `packages/nuxt-dx`, and the whole CI sequence passes across the workspace.

Unit tests cover growth, shrink, added, removed, unchanged, identity across scopes, per-scope totals never being summed, the threshold boundary (exactly on it passes, one byte past fails), a new target held to the same threshold, a shrink never breaching, the markdown rows, the missing-baseline notice, the report path resolution for `true` / `{ path }` / `false`, and the snapshot writer and parser.

The end-to-end proof is a throwaway Nuxt 4.5 app built in a temp directory outside the repository, with its own `node_modules`, consuming the packed tarball:

- a named app plugin importing a generated table, a local Nuxt module whose runtime plugin imports its own generated table, and a Nitro plugin importing a third
- built once, report copied aside, then the analytics table grown from 120 to 700 rows, the telemetry table cut from 200 to 60, one plugin deleted, another added, and built again
- `nuxt-dx compare` run on the two real reports from the installed bin, giving the output above and exit code 1

The same fixture also proved the opt-in: with `report` unset no file is written at all, with `report: { path: 'ci/size-budget.json' }` the report lands there. `--allow-missing-base` exits 0 on an absent baseline, a missing baseline without the flag exits 2, `--threshold-kb 40` exits 0, and a non-numeric threshold exits 2.

The composite action cannot be executed locally. `tests/action.test.ts` parses its YAML and asserts the contract instead: composite, no build step of its own, every input documented and defaulted, every `uses` pinned to a 40 character commit SHA with a version comment, the baseline read from the last successful run on the base branch, `continue-on-error` on the download, `--allow-missing-base` on the compare, the summary redirect failing on the comparison rather than on `tee`, and the upload running unless the job was cancelled. That test caught a real bug on its first run: an unquoted `actions: read` inside an input description made the file invalid YAML.
