### PR TITLE
fix(cloudflare): respect Nuxt server source maps

### DIFF
--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -43,7 +43,11 @@ export interface NitroCloudflareShape {
 const logger = useLogger('nuxt-cloudflare')
 const cacheDriverPath = resolve(import.meta.dirname, import.meta.url.endsWith('.ts') ? 'storage.ts' : 'storage.mjs')
 
-export function configureNitroCloudflare(nitro: NitroCloudflareShape, options: ModuleOptions): void {
+export function configureNitroCloudflare(
+  nitro: NitroCloudflareShape,
+  options: ModuleOptions,
+  nuxtServerSourceMaps?: boolean,
+): void {
   nitro.preset ??= 'cloudflare-module'
   nitro.cloudflare ??= {}
   nitro.cloudflare.deployConfig = true
@@ -53,7 +57,7 @@ export function configureNitroCloudflare(nitro: NitroCloudflareShape, options: M
     logsSampleRate: options.logsSampleRate,
     requiredSecrets: options.requiredSecrets,
     tracesSampleRate: options.tracesSampleRate,
-    uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap !== false,
+    uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? nuxtServerSourceMaps ?? false,
     versionMetadataBinding: options.versionMetadataBinding,
   })
 
@@ -98,9 +102,15 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   if (!options.enabled)
     return
 
-  configureNitroCloudflare(nuxt.options.nitro as NitroCloudflareShape, options)
+  const configure = () => configureNitroCloudflare(
+    nuxt.options.nitro as NitroCloudflareShape,
+    options,
+    Boolean(nuxt.options.sourcemap.server),
+  )
+
+  configure()
   nuxt.hook('modules:done', () => {
-    configureNitroCloudflare(nuxt.options.nitro as NitroCloudflareShape, options)
+    configure()
   })
   if (!nuxt.options.dev) {
     nuxt.hook('nitro:init', (nitro) => {

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -3,13 +3,13 @@ import type { NitroCloudflareShape } from '../src/module'
 import { describe, expect, it } from 'vitest'
 import { configureNitroCloudflare, setupCloudflareModule } from '../src/module'
 
-function nuxtWithCapturedHooks(dev: boolean): { hooks: string[], nuxt: Nuxt } {
+function nuxtWithCapturedHooks(dev: boolean, serverSourceMaps = false): { hooks: string[], nuxt: Nuxt } {
   const hooks: string[] = []
   const nuxt = {
     hook(name: string) {
       hooks.push(name)
     },
-    options: { dev, nitro: {} },
+    options: { dev, nitro: {}, sourcemap: { server: serverSourceMaps } },
   } as unknown as Nuxt
   return { hooks, nuxt }
 }
@@ -59,5 +59,16 @@ describe('setupCloudflareModule', () => {
     setupCloudflareModule({ enabled: true }, nuxt)
 
     expect(hooks).toEqual(['modules:done', 'nitro:init'])
+  })
+
+  it('uses Nuxt server source maps as the upload policy', () => {
+    const disabled = nuxtWithCapturedHooks(false, false)
+    const enabled = nuxtWithCapturedHooks(false, true)
+
+    setupCloudflareModule({ enabled: true }, disabled.nuxt)
+    setupCloudflareModule({ enabled: true }, enabled.nuxt)
+
+    expect(disabled.nuxt.options.nitro.cloudflare?.wrangler?.upload_source_maps).toBe(false)
+    expect(enabled.nuxt.options.nitro.cloudflare?.wrangler?.upload_source_maps).toBe(true)
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt leaves `nitro.sourceMap` unset when `sourcemap.server` is false. Read the Nuxt setting before enabling Wrangler source map uploads, while preserving explicit module and Nitro overrides.
