### PR TITLE
fix(nuxt-dx): measure client budgets once

### DIFF
--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-dx",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Experimental Nuxt diagnostics: dev error overlay and plugin and module bundle size budgets.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -221,6 +221,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
       if (clientBudget !== undefined) {
         plugins?.push(sizeBudgetRollupPlugin({
           scope: 'client',
+          environment: 'client',
           targets: ids => pluginTargets(appPluginPaths, ids),
           onMeasured: onMeasured('client', clientBudget, true),
         }))
@@ -228,6 +229,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
       if (moduleBudget !== undefined) {
         plugins?.push(sizeBudgetRollupPlugin({
           scope: 'modules',
+          environment: 'client',
           // Read at bundle time: modules keep installing while the config is assembled.
           targets: ids => moduleTargets(installedModuleOwners(nuxt), ids),
           onMeasured: onMeasured('modules', moduleBudget, false),

--- a/packages/nuxt-dx/src/size-budget/rollup.ts
+++ b/packages/nuxt-dx/src/size-budget/rollup.ts
@@ -13,9 +13,15 @@ export interface MeasuredTarget {
 
 export interface SizeBudgetPluginOptions {
   scope: BudgetScope
+  /** Restrict a shared Vite plugin to one environment. Rollup builds leave this unset. */
+  environment?: string
   /** Read lazily so plugins and modules registered after this rollup plugin is created are included. */
   targets: (moduleIds: readonly string[]) => readonly BudgetTarget[]
   onMeasured: (measured: readonly MeasuredTarget[]) => void | Promise<void>
+}
+
+interface EnvironmentPlugin extends Plugin {
+  applyToEnvironment?: (environment: { name: string }) => boolean
 }
 
 function collectGraph(bundle: OutputBundle, importedIdsOf: (id: string) => readonly string[]) {
@@ -36,9 +42,12 @@ function collectGraph(bundle: OutputBundle, importedIdsOf: (id: string) => reado
  * Measures the bundled weight of each target once the graph is final, so the cost
  * reflects post-tree-shaking bytes rather than what the source file imports on paper.
  */
-export function sizeBudgetRollupPlugin(options: SizeBudgetPluginOptions): Plugin {
+export function sizeBudgetRollupPlugin(options: SizeBudgetPluginOptions): EnvironmentPlugin {
   return {
     name: `nuxt-dx:size-budget:${options.scope}`,
+    applyToEnvironment: options.environment === undefined
+      ? undefined
+      : environment => environment.name === options.environment,
     async generateBundle(_outputOptions, bundle) {
       const { modules, entryIds } = collectGraph(bundle, id => this.getModuleInfo(id)?.importedIds ?? [])
       const targets = options.targets(modules.map(module => module.id))

--- a/packages/nuxt-dx/tests/rollup.test.ts
+++ b/packages/nuxt-dx/tests/rollup.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { sizeBudgetRollupPlugin } from '../src/size-budget/rollup'
+
+describe('sizeBudgetRollupPlugin', () => {
+  it('only measures the Vite environment it targets', async () => {
+    const plugin = sizeBudgetRollupPlugin({
+      scope: 'modules',
+      environment: 'client',
+      targets: () => [],
+      onMeasured: () => {},
+    })
+    const appliesTo = Reflect.get(plugin, 'applyToEnvironment') as (environment: { name: string }) => boolean
+
+    expect(await appliesTo({ name: 'client' })).toBe(true)
+    expect(await appliesTo({ name: 'ssr' })).toBe(false)
+  })
+})


### PR DESCRIPTION
Nuxt 5 compatibility builds share Vite plugins across client and SSR environments. Limit DX client and module measurements to the client environment so warnings and reports remain accurate.

This also releases `@harlan-zw/nuxt-dx` as `0.0.3`.