### PR TITLE
feat(nuxt-dx): ignore accepted module budgets

### DIFF
--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -142,6 +142,8 @@ Every bundled file that ships from a module's own package is charged to that mod
 
 Modules are reported by the name they declare in their own `meta`, which is also the key an override takes. Modules you never installed yourself show up too, `nuxt-site-config` above arrived as a dependency of another module, and it is charged like any other.
 
+Add a known expensive module to `ignoreModules` when its absolute size is accepted. The report and regression check still measure it, while local builds skip its budget warning.
+
 ## The size budget report
 
 Reporting is off until you ask for it. With `report: true`, every build writes what it measured to `.nuxt/dx/size-budget.json`, whether or not anything breached a budget. It is the input to the regression check below, and it is readable on its own: one entry per Nuxt plugin, Nitro plugin, and installed Nuxt module, with the bytes broken down the same way the warning breaks them down.
@@ -299,6 +301,9 @@ export default defineNuxtConfig({
       nitroPluginsKb: 50,
       // kB budget per Nuxt module in the client bundle, `false` to disable
       modulesKb: 50,
+      // skip absolute budget enforcement for these exact Nuxt module names;
+      // reports and regression checks still include them
+      ignoreModules: ['@nuxt/ui'],
       // raise or lower the budget for individual plugins and modules,
       // keyed by plugin name, module name, or any fragment of the path
       overridesKb: {

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-dx",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Experimental Nuxt diagnostics: dev error overlay and plugin and module bundle size budgets.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -32,6 +32,8 @@ export interface SizeBudgetOptions {
    * @default 50
    */
   modulesKb?: number | false
+  /** Nuxt module names excluded from absolute budget enforcement. Reports still measure them. */
+  ignoreModules?: string[]
   /** Per-target kilobyte budgets, keyed by plugin name, module name, or any fragment of the path. */
   overridesKb?: Record<string, number>
   /**
@@ -67,6 +69,7 @@ interface ResolvedBudgets {
   client: number | undefined
   nitro: number | undefined
   modules: number | undefined
+  ignoredModules: ReadonlySet<string>
   overrides: BudgetOverride[]
   fail: boolean
 }
@@ -98,6 +101,7 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
     client: resolve(options.pluginsKb, 20, 'pluginsKb'),
     nitro: resolve(options.nitroPluginsKb, 50, 'nitroPluginsKb'),
     modules: resolve(options.modulesKb, 50, 'modulesKb'),
+    ignoredModules: new Set(options.ignoreModules),
     overrides,
     fail: options.fail ?? false,
   }
@@ -119,7 +123,8 @@ async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefin
 function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean) {
   const threshold = smallestBudget(defaultBytes, budgets.overrides)
   return async (measured: readonly MeasuredTarget[]) => {
-    const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold)
+    const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold
+      && !(scope === 'modules' && entry.name !== undefined && budgets.ignoredModules.has(entry.name)))
     if (!candidates.length)
       return
 

--- a/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/enforced/module.ts
+++ b/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/enforced/module.ts
@@ -1,0 +1,11 @@
+import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'fixture-enforced-module',
+  },
+  setup() {
+    const resolver = createResolver(import.meta.url)
+    addPlugin(resolver.resolve('./runtime/plugin'))
+  },
+})

--- a/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/enforced/runtime/plugin.ts
+++ b/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/enforced/runtime/plugin.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(() => ({
+  provide: {
+    fixtureEnforcedModule: 'measured',
+  },
+}))

--- a/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/expensive/module.ts
+++ b/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/expensive/module.ts
@@ -1,0 +1,11 @@
+import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'fixture-expensive-module',
+  },
+  setup() {
+    const resolver = createResolver(import.meta.url)
+    addPlugin(resolver.resolve('./runtime/plugin'))
+  },
+})

--- a/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/expensive/runtime/plugin.ts
+++ b/packages/nuxt-dx/tests/fixtures/ignore-modules/modules/expensive/runtime/plugin.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(() => ({
+  provide: {
+    fixtureExpensiveModule: 'measured',
+  },
+}))

--- a/packages/nuxt-dx/tests/fixtures/ignore-modules/nuxt.config.ts
+++ b/packages/nuxt-dx/tests/fixtures/ignore-modules/nuxt.config.ts
@@ -1,0 +1,16 @@
+export default defineNuxtConfig({
+  compatibilityDate: '2026-08-11',
+  future: {
+    compatibilityVersion: 5,
+  },
+  modules: ['../../../src/module', './modules/expensive/module', './modules/enforced/module'],
+  nuxtDx: {
+    report: true,
+    sizeBudget: {
+      pluginsKb: false,
+      nitroPluginsKb: false,
+      modulesKb: 0,
+      ignoreModules: ['fixture-expensive-module'],
+    },
+  },
+})

--- a/packages/nuxt-dx/tests/ignore-modules.test.ts
+++ b/packages/nuxt-dx/tests/ignore-modules.test.ts
@@ -1,0 +1,27 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+const packageRoot = new URL('..', import.meta.url)
+const fixture = 'tests/fixtures/ignore-modules'
+
+describe('ignoreModules', () => {
+  it('keeps an ignored module in the report without warning', async () => {
+    const result = await execFileAsync('pnpm', ['exec', 'nuxt', 'build', fixture], {
+      cwd: packageRoot,
+      env: { ...process.env, NO_COLOR: '1' },
+      maxBuffer: 20 * 1024 * 1024,
+    })
+    const output = `${result.stdout}\n${result.stderr}`
+    const report = JSON.parse(await readFile(new URL(`${fixture}/.nuxt/dx/size-budget.json`, packageRoot), 'utf8'))
+    const ignored = report.entries.find((entry: { name?: string }) => entry.name === 'fixture-expensive-module')
+    const enforced = report.entries.find((entry: { name?: string }) => entry.name === 'fixture-enforced-module')
+
+    expect(ignored.totalBytes).toBeGreaterThan(0)
+    expect(enforced.totalBytes).toBeGreaterThan(0)
+    expect(output).not.toContain('fixture-expensive-module')
+    expect(output).toContain('fixture-enforced-module')
+  }, 60_000)
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A tight `modulesKb` budget currently warns on modules whose baseline cost the app already accepts. `ignoreModules` exempts exact module names from absolute enforcement. JSON reports and regression comparisons still include them.
