### PR TITLE
feat(nuxt-dx): refine default budgets

### DIFF
--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -296,11 +296,11 @@ export default defineNuxtConfig({
   nuxtDx: {
     sizeBudget: {
       // kB budget per Nuxt app plugin in the client bundle, `false` to disable
-      pluginsKb: 20,
+      pluginsKb: 30,
       // kB budget per Nitro plugin in the server bundle, `false` to disable
-      nitroPluginsKb: 50,
+      nitroPluginsKb: 75,
       // kB budget per Nuxt module in the client bundle, `false` to disable
-      modulesKb: 50,
+      modulesKb: 100,
       // skip absolute budget enforcement for these exact Nuxt module names;
       // reports and regression checks still include them
       ignoreModules: ['@nuxt/ui'],

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-dx",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Experimental Nuxt diagnostics: dev error overlay and plugin and module bundle size budgets.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -19,17 +19,17 @@ import { moduleTargets, pluginTargets } from './size-budget/targets'
 export interface SizeBudgetOptions {
   /**
    * Kilobyte budget for each Nuxt app plugin in the client bundle. `false` disables the check.
-   * @default 20
+   * @default 30
    */
   pluginsKb?: number | false
   /**
    * Kilobyte budget for each Nitro plugin in the server bundle. `false` disables the check.
-   * @default 50
+   * @default 75
    */
   nitroPluginsKb?: number | false
   /**
    * Kilobyte budget for each Nuxt module in the client bundle. `false` disables the check.
-   * @default 50
+   * @default 100
    */
   modulesKb?: number | false
   /** Nuxt module names excluded from absolute budget enforcement. Reports still measure them. */
@@ -98,9 +98,9 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
   }
 
   return {
-    client: resolve(options.pluginsKb, 20, 'pluginsKb'),
-    nitro: resolve(options.nitroPluginsKb, 50, 'nitroPluginsKb'),
-    modules: resolve(options.modulesKb, 50, 'modulesKb'),
+    client: resolve(options.pluginsKb, 30, 'pluginsKb'),
+    nitro: resolve(options.nitroPluginsKb, 75, 'nitroPluginsKb'),
+    modules: resolve(options.modulesKb, 100, 'modulesKb'),
     ignoredModules: new Set(options.ignoreModules),
     overrides,
     fail: options.fail ?? false,

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -28,6 +28,11 @@ function overrideSnippet(over: readonly BudgetVerdict[], rootDir: string): strin
   return `nuxtDx.sizeBudget.overridesKb = { ${entries.join(', ')} }`
 }
 
+function ignoreModulesSnippet(over: readonly BudgetVerdict[]): string | undefined {
+  const names = over.flatMap(verdict => verdict.name === undefined ? [] : [`'${verdict.name}'`])
+  return names.length ? `nuxtDx.sizeBudget.ignoreModules = [${names.join(', ')}]` : undefined
+}
+
 /** Every byte charged to the target, so the listed sizes always sum to the reported total. */
 function breakdown(scope: BudgetScope, verdict: BudgetVerdict, rootDir: string): TreeItem[] {
   const { ownBytes, exclusiveBytes, exclusiveCount, heaviestDependencies } = verdict.measurement
@@ -74,5 +79,13 @@ export function formatBudgetReport(scope: BudgetScope, over: readonly BudgetVerd
     colors.dim('  Defer heavy imports with `await import()`, or allow the size:'),
     `    ${colors.cyan(overrideSnippet(over, rootDir))}`,
   )
+  const ignoreSnippet = scope === 'modules' ? ignoreModulesSnippet(over) : undefined
+  if (ignoreSnippet) {
+    lines.push(
+      '',
+      colors.dim('  Keep accepted modules in reports without absolute warnings:'),
+      `    ${colors.cyan(ignoreSnippet)}`,
+    )
+  }
   return lines.join('\n')
 }

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -68,6 +68,13 @@ describe('formatBudgetReport', () => {
     expect(report([{ ...verdict, name: 'analytics' }])).toContain('nuxtDx.sizeBudget.overridesKb = { \'analytics\': 81 }')
   })
 
+  it('suggests ignoring an accepted module without removing it from reports', () => {
+    const module: BudgetVerdict = { ...verdict, path: '/app/node_modules/@nuxtjs/robots', name: '@nuxtjs/robots' }
+    const lines = report([module], 'modules')
+    expect(lines).toContain('Keep accepted modules in reports without absolute warnings:')
+    expect(lines).toContain('nuxtDx.sizeBudget.ignoreModules = [\'@nuxtjs/robots\']')
+  })
+
   it('falls back to a path key when the plugin is unnamed', () => {
     expect(report([verdict])).toContain('{ \'plugins/analytics.ts\': 81 }')
   })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Reports from eleven real site builds put normal client plugins below 30 kB and normal Nitro plugins below 75 kB. The defaults now use 30 kB for client plugins, 75 kB for Nitro plugins, and 100 kB for modules. Clear outliers still warn.

Module warnings now suggest `ignoreModules` when the module cost is accepted. Ignored modules remain in JSON reports and regression comparisons.
