### PR TITLE
feat(cloudflare): expand deployment safeguards

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -12,6 +12,7 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 - Preview URLs disabled unless explicitly enabled
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
+- Workers Caching explicitly disabled by default; opt-in requires a version-sharing decision
 - Source-map upload when the Nitro build emits maps; explicit `false` is preserved
 - Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
 - Version metadata is skipped when `CF_VERSION_METADATA` already names another binding
@@ -29,6 +30,7 @@ export default defineNuxtConfig({
 
   nuxtCloudflare: {
     requiredSecrets: ['NUXT_SESSION_PASSWORD'],
+    workersCache: { _tag: 'enabled', crossVersion: false },
   },
 
   nitro: {
@@ -55,6 +57,8 @@ export default defineNuxtConfig({
 
 Cloudflare KV requires TTLs of at least 60 seconds.
 
+Workers Caching is separate from Nitro's KV-backed cache. Enabling it lets Cloudflare serve responses without invoking the Worker. Keep `crossVersion: false` for deploy isolation; choose `true` only when stale responses across deployments are acceptable and a purge path exists. An authored `nitro.cloudflare.wrangler.cache` block is preserved unless `nuxtCloudflare.workersCache` is set.
+
 ## Doctor
 
 Audit Wrangler's effective configuration, including generated config redirects and named environments:
@@ -67,7 +71,7 @@ pnpm nuxt-cloudflare doctor --strict --allow-warning source-maps-disabled
 
 The CLI reads Wrangler config through Wrangler itself, so JSON, JSONC, TOML, environments, upward lookup, and Nitro generated-config redirects follow deployment semantics. It separately inspects root authoring format. Existing TOML remains supported and receives non-blocking guidance because Cloudflare recommends JSONC for new projects. Shadowed root configs warn because they can silently drift.
 
-Errors cover blanket Worker-first assets, malformed selective asset patterns, missing `nodejs_compat`, malformed compatibility dates, secret names duplicated across `vars` and `secrets.required`, queue platform-limit violations, and unflattened generated environments. Warnings cover secret-looking variable names, telemetry gaps, stale dates, `keep_vars`, public endpoints, preview URLs, missing DLQs, and project policy. Secret values are never included.
+Errors cover blanket Worker-first assets, malformed selective asset patterns, missing `nodejs_compat`, malformed compatibility dates, secret names duplicated across `vars` and `secrets.required`, queue platform-limit violations, and unflattened generated environments. Warnings cover secret-looking variable names, telemetry gaps, stale dates, implicit or cross-version Workers Caching, `keep_vars`, public endpoints, preview URLs, missing DLQs, and project policy. Secret values are never included.
 
 Normal mode fails errors. `--strict` also fails warnings. Intentional exceptions remain visible and may be listed with `--allow-warning`. Module builds use the equivalent policy:
 

--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -7,11 +7,14 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 ## Defaults
 
 - Cloudflare module preset, generated Wrangler config, and Node compatibility
-- Static assets always bypass the Worker. Any `assets.run_worker_first` declaration fails the build and `doctor`
+- Static assets remain asset first by default. Blanket `assets.run_worker_first: true` fails the build and `doctor`; narrow route-pattern arrays remain available for intentional middleware and skew recovery
 - Workers Logs sampled at 10%, traces at 1%, both overridable
+- Preview URLs disabled unless explicitly enabled
+- `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
 - Source-map upload when the Nitro build emits maps; explicit `false` is preserved
-- `secrets.required` names only, with plaintext secret-looking `vars` rejected
+- Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
+- Version metadata is skipped when `CF_VERSION_METADATA` already names another binding
 - Raw `cloudflare-kv-binding` on Nitro's `cache` mount upgraded to a 30-day physical expiry
 - Final generated Wrangler config audited after production Nitro compiles
 - Complete defaults and diagnostics applied to every named Wrangler environment
@@ -59,19 +62,39 @@ Audit Wrangler's effective configuration, including generated config redirects a
 ```sh
 pnpm nuxt-cloudflare doctor
 pnpm nuxt-cloudflare doctor --env production --json
+pnpm nuxt-cloudflare doctor --strict --allow-warning source-maps-disabled
 ```
 
-Errors include worker-first assets, missing `nodejs_compat`, malformed compatibility dates, and secret-looking plaintext variables. Diagnostics report secret names only.
+The CLI reads Wrangler config through Wrangler itself, so JSON, JSONC, TOML, environments, upward lookup, and Nitro generated-config redirects follow deployment semantics. It separately inspects root authoring format. Existing TOML remains supported and receives non-blocking guidance because Cloudflare recommends JSONC for new projects. Shadowed root configs warn because they can silently drift.
+
+Errors cover blanket Worker-first assets, malformed selective asset patterns, missing `nodejs_compat`, malformed compatibility dates, secret names duplicated across `vars` and `secrets.required`, queue platform-limit violations, and unflattened generated environments. Warnings cover secret-looking variable names, telemetry gaps, stale dates, `keep_vars`, public endpoints, preview URLs, missing DLQs, and project policy. Secret values are never included.
+
+Normal mode fails errors. `--strict` also fails warnings. Intentional exceptions remain visible and may be listed with `--allow-warning`. Module builds use the equivalent policy:
+
+`nodejs_compat` is required by default because this is a Nuxt module. Use `--node-compat ignore` only when auditing a non-Nuxt companion Worker, such as a redirect-only Worker.
+
+```ts
+export default defineNuxtConfig({
+  nuxtCloudflare: {
+    doctor: {
+      _tag: 'strict',
+      allowedWarnings: ['source-maps-disabled'],
+    },
+  },
+})
+```
 
 Recommended CI sequence:
 
 ```sh
 pnpm nuxt build
-pnpm nuxt-cloudflare doctor
-pnpm wrangler types --check
-pnpm wrangler deploy --strict --dry-run --outdir .wrangler-dist
-pnpm wrangler check startup
+pnpm nuxt-cloudflare doctor --strict
+pnpm wrangler types --check --config .output/server/wrangler.json
+pnpm wrangler deploy --strict --dry-run --config .output/server/wrangler.json --outdir .wrangler-dist
+pnpm wrangler check startup --config .output/server/wrangler.json
 ```
+
+Pass the final generated config explicitly to `types` and `check startup`; Nitro's `.wrangler/deploy/config.json` redirect does not apply to those commands.
 
 ## Runtime primitives
 
@@ -89,6 +112,29 @@ await retryIdempotentD1Write({
 ```
 
 One `first-primary` session is cached per request and binding. D1 already retries read-only queries. Write retries require an explicit safety tag. `lock-only` retries SQLite lock contention; `replay-safe` also permits classified transient network and reset failures.
+
+### D1 parameter plans
+
+```ts
+import {
+  assertD1BoundParameters,
+  chunkD1Items,
+  defineD1ParameterPlan,
+} from '@harlan-zw/nuxt-cloudflare/d1'
+
+const siteIdPlan = defineD1ParameterPlan({
+  parametersPerItem: 1,
+  reservedParameters: 2,
+})
+
+for (const ids of chunkD1Items(siteIds, siteIdPlan)) {
+  const query = db.select().from(sites).where(inArray(sites.id, ids))
+  assertD1BoundParameters(query.toSQL().params)
+  await query
+}
+```
+
+D1 allows 100 bound parameters per statement, including each statement inside `db.batch()`. The parsed opaque plan rejects fractions, non-finite values, negative reservations, forged runtime plans, and budgets that cannot fit one item. `parametersPerItem` supports multi-row inserts; `reservedParameters` accounts for fixed binds and deliberate headroom. `assertD1BoundParameters` verifies the final ORM output in regression tests. Chunk execution, ordering, transaction boundaries, and result merging remain explicit at the call site.
 
 ### Bindings
 

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -2,8 +2,9 @@
 import process from 'node:process'
 import { defineCommand, runMain } from 'citty'
 import { resolve } from 'pathe'
-import { diagnoseWranglerConfig, formatWranglerDiagnostics } from '../wrangler'
-import { readProjectWranglerConfig } from '../wrangler-reader'
+import { evaluateWranglerDiagnostics, parseWranglerAllowedWarnings } from '../diagnostics'
+import { diagnoseWranglerProject } from '../doctor'
+import { formatWranglerDiagnostics } from '../wrangler'
 
 const doctor = defineCommand({
   meta: { name: 'doctor', description: 'Audit the effective Wrangler configuration' },
@@ -13,21 +14,48 @@ const doctor = defineCommand({
     'env': { type: 'string', description: 'Wrangler environment' },
     'json': { type: 'boolean', description: 'Print JSON diagnostics', default: false },
     'max-compatibility-age': { type: 'string', description: 'Compatibility date policy in days', default: '90' },
+    'node-compat': { type: 'string', description: 'Node compatibility policy: required or ignore', default: 'required' },
+    'public-var': { type: 'string', description: 'Comma-separated public var names exempt from secret-name heuristics' },
+    'strict': { type: 'boolean', description: 'Fail on warnings as well as errors', default: false },
+    'allow-warning': { type: 'string', description: 'Comma-separated warning codes allowed in strict mode' },
   },
   run({ args }) {
     const cwd = resolve(args.cwd)
-    const loaded = readProjectWranglerConfig({ cwd, config: args.config, environment: args.env })
-    const diagnostics = diagnoseWranglerConfig(loaded.config, {
-      compatibilityMaxAgeDays: Number(args['max-compatibility-age']),
+    const compatibilityMaxAgeDays = Number(args['max-compatibility-age'])
+    if (!Number.isSafeInteger(compatibilityMaxAgeDays) || compatibilityMaxAgeDays < 1)
+      throw new TypeError('--max-compatibility-age must be a positive integer')
+    if (args['node-compat'] !== 'required' && args['node-compat'] !== 'ignore')
+      throw new TypeError('--node-compat must be required or ignore')
+    const publicVarNames = args['public-var']?.split(',').map(value => value.trim()).filter(Boolean)
+    const result = diagnoseWranglerProject({
+      cwd,
+      config: args.config,
+      environment: args.env,
+      compatibilityMaxAgeDays,
+      publicVarNames,
+      requireNodeCompat: args['node-compat'] === 'required',
     })
-    const payload = { configPath: loaded.path, diagnostics }
+    const allowedWarnings = parseWranglerAllowedWarnings(args['allow-warning'])
+    const policy = args.strict
+      ? { _tag: 'strict' as const, allowedWarnings }
+      : { _tag: 'advisory' as const }
+    const outcome = evaluateWranglerDiagnostics(result.diagnostics, policy)
+    const payload = {
+      configPath: result.configPath,
+      diagnostics: result.diagnostics,
+      outcome: outcome._tag,
+      ...(outcome._tag === 'failed' ? { reason: outcome.reason } : {}),
+      schemaVersion: outcome.schemaVersion,
+      sourceConfigPaths: result.sourceConfigPaths,
+      strict: args.strict,
+    }
     if (args.json)
       process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`)
-    else if (diagnostics.length === 0)
-      process.stdout.write(`Cloudflare config valid: ${loaded.path ?? 'inline/default'}\n`)
+    else if (result.diagnostics.length === 0)
+      process.stdout.write(`Cloudflare config valid: ${result.configPath ?? 'inline/default'}\n`)
     else
-      process.stdout.write(`${formatWranglerDiagnostics(diagnostics)}\n`)
-    if (diagnostics.some(diagnostic => diagnostic._tag === 'error'))
+      process.stdout.write(`${formatWranglerDiagnostics(result.diagnostics)}\n`)
+    if (outcome._tag === 'failed')
       process.exitCode = 1
   },
 })
@@ -35,7 +63,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.1',
+    version: '0.0.2',
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/d1.ts
+++ b/packages/nuxt-cloudflare/src/d1.ts
@@ -2,6 +2,22 @@ export type D1WriteSafety
   = | { _tag: 'lock-only' }
     | { _tag: 'replay-safe' }
 
+export const D1_MAX_BOUND_PARAMETERS = 100
+
+const D1_PARAMETER_PLAN = Symbol('@harlan-zw/nuxt-cloudflare:d1-parameter-plan')
+
+export interface D1ParameterPlanInput {
+  parametersPerItem: number
+  reservedParameters: number
+}
+
+export interface D1ParameterPlan {
+  readonly [D1_PARAMETER_PLAN]: true
+  readonly itemsPerStatement: number
+  readonly parametersPerItem: number
+  readonly reservedParameters: number
+}
+
 export type D1Consistency
   = | { _tag: 'first-primary' }
     | { _tag: 'first-unconstrained' }
@@ -59,12 +75,77 @@ function parseMaxAttempts(value: number | undefined): number {
   return attempts
 }
 
+function parseParameterCount(name: string, value: number, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum)
+    throw new TypeError(`D1 ${name} must be an integer greater than or equal to ${minimum}`)
+  return value
+}
+
+export function defineD1ParameterPlan(input: D1ParameterPlanInput): D1ParameterPlan {
+  const parametersPerItem = parseParameterCount('parametersPerItem', input.parametersPerItem, 1)
+  const reservedParameters = parseParameterCount(
+    'reservedParameters',
+    input.reservedParameters,
+    0,
+  )
+  const itemsPerStatement = Math.floor(
+    (D1_MAX_BOUND_PARAMETERS - reservedParameters) / parametersPerItem,
+  )
+  if (itemsPerStatement < 1)
+    throw new TypeError('D1 parameter budget cannot fit one item')
+  return Object.freeze({
+    [D1_PARAMETER_PLAN]: true as const,
+    itemsPerStatement,
+    parametersPerItem,
+    reservedParameters,
+  })
+}
+
+export function chunkD1Items<T>(items: readonly T[], plan: D1ParameterPlan): T[][] {
+  if (plan?.[D1_PARAMETER_PLAN] !== true)
+    throw new TypeError('D1 parameter plan must come from defineD1ParameterPlan')
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += plan.itemsPerStatement)
+    chunks.push(items.slice(index, index + plan.itemsPerStatement))
+  return chunks
+}
+
+export function assertD1BoundParameters(parameters: readonly unknown[]): void {
+  if (!Array.isArray(parameters))
+    throw new TypeError('D1 bound parameters must be an array')
+  if (parameters.length > D1_MAX_BOUND_PARAMETERS) {
+    throw new RangeError(
+      `D1 statement has ${parameters.length} bound parameters; maximum is ${D1_MAX_BOUND_PARAMETERS}`,
+    )
+  }
+}
+
 export function classifyD1RetryError(error: unknown): D1RetryErrorKind {
-  const message = error instanceof Error ? error.message : String(error)
-  if (/busy|locked/i.test(message))
+  const messages: string[] = []
+  const seen = new WeakSet<object>()
+  let current: unknown = error
+  while (current !== undefined && current !== null) {
+    if (typeof current !== 'object') {
+      messages.push(String(current))
+      break
+    }
+    if (seen.has(current))
+      break
+    seen.add(current)
+    if (current instanceof Error)
+      messages.push(current.message)
+    else if ('message' in current && typeof current.message === 'string')
+      messages.push(current.message)
+    current = 'cause' in current ? current.cause : undefined
+  }
+  if (messages.some(message => /busy|locked/i.test(message)))
     return { _tag: 'lock' }
-  if (TRANSIENT_D1_SIGNALS.some(signal => message.includes(signal)))
+  if (messages.some((message) => {
+    const normalized = message.toLowerCase()
+    return TRANSIENT_D1_SIGNALS.some(signal => normalized.includes(signal.toLowerCase()))
+  })) {
     return { _tag: 'transient' }
+  }
   return { _tag: 'permanent' }
 }
 
@@ -97,7 +178,7 @@ export async function retryIdempotentD1Write<T>(options: RetryIdempotentD1WriteO
   let lastError: unknown
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const outcome = await options.run().then(
+    const outcome = await Promise.resolve().then(options.run).then(
       value => ({ _tag: 'ok' as const, value }),
       error => ({ _tag: 'error' as const, error }),
     )

--- a/packages/nuxt-cloudflare/src/diagnostics.ts
+++ b/packages/nuxt-cloudflare/src/diagnostics.ts
@@ -1,0 +1,114 @@
+import type { WranglerDiagnostic, WranglerDiagnosticCode } from './wrangler'
+import { existsSync } from 'node:fs'
+import { dirname, extname, resolve } from 'pathe'
+import { WRANGLER_DIAGNOSTIC_CODES } from './wrangler'
+
+export type WranglerDiagnosticPolicy
+  = | { _tag: 'advisory' }
+    | { _tag: 'strict', allowedWarnings?: readonly WranglerDiagnosticCode[] }
+
+export type WranglerDoctorOutcome
+  = | {
+    _tag: 'passed'
+    blockingDiagnostics: readonly []
+    diagnostics: readonly WranglerDiagnostic[]
+    schemaVersion: 1
+  }
+  | {
+    _tag: 'failed'
+    blockingDiagnostics: readonly WranglerDiagnostic[]
+    diagnostics: readonly WranglerDiagnostic[]
+    reason: 'errors' | 'strict-warnings'
+    schemaVersion: 1
+  }
+
+const WRANGLER_SOURCE_CONFIG_NAMES = [
+  'wrangler.json',
+  'wrangler.jsonc',
+  'wrangler.toml',
+] as const
+
+export function discoverWranglerSourceConfigs(cwd: string, explicitConfig?: string): string[] {
+  if (explicitConfig) {
+    const path = resolve(cwd, explicitConfig)
+    return existsSync(path) ? [path] : []
+  }
+  let directory = resolve(cwd)
+  while (true) {
+    const paths = WRANGLER_SOURCE_CONFIG_NAMES
+      .map(name => resolve(directory, name))
+      .filter(path => existsSync(path))
+    if (paths.length > 0)
+      return paths
+    const parent = dirname(directory)
+    if (parent === directory)
+      return []
+    directory = parent
+  }
+}
+
+export function diagnoseWranglerSourceConfigs(paths: readonly string[]): WranglerDiagnostic[] {
+  const diagnostics = paths.flatMap((path): WranglerDiagnostic[] => extname(path) === '.toml'
+    ? [{
+        _tag: 'info',
+        code: 'wrangler-jsonc-preferred',
+        message: 'Cloudflare recommends wrangler.jsonc for new projects; TOML remains supported.',
+        sourcePath: path,
+      }]
+    : [])
+  if (paths.length > 1) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'wrangler-config-shadowed',
+      message: 'Multiple root Wrangler configs exist. Keep one wrangler.jsonc source of truth to prevent silent precedence drift.',
+      sourcePath: paths[0]!,
+    })
+  }
+  return diagnostics
+}
+
+export function isWranglerDiagnosticBlocking(
+  diagnostic: WranglerDiagnostic,
+  policy: WranglerDiagnosticPolicy,
+): boolean {
+  if (diagnostic._tag === 'error')
+    return true
+  return diagnostic._tag === 'warning'
+    && policy._tag === 'strict'
+    && !new Set(policy.allowedWarnings ?? []).has(diagnostic.code)
+}
+
+export function parseWranglerAllowedWarnings(value: string | undefined): WranglerDiagnosticCode[] {
+  if (!value)
+    return []
+  const knownCodes = new Set<string>(WRANGLER_DIAGNOSTIC_CODES)
+  return value.split(',').map(part => part.trim()).filter(Boolean).map((code) => {
+    if (!knownCodes.has(code))
+      throw new TypeError(`Unknown Wrangler diagnostic code: ${code}`)
+    return code as WranglerDiagnosticCode
+  })
+}
+
+export function evaluateWranglerDiagnostics(
+  diagnostics: readonly WranglerDiagnostic[],
+  policy: WranglerDiagnosticPolicy,
+): WranglerDoctorOutcome {
+  const blockingDiagnostics = diagnostics.filter(diagnostic => isWranglerDiagnosticBlocking(diagnostic, policy))
+  if (blockingDiagnostics.length === 0) {
+    return {
+      _tag: 'passed',
+      blockingDiagnostics: [],
+      diagnostics,
+      schemaVersion: 1,
+    }
+  }
+  return {
+    _tag: 'failed',
+    blockingDiagnostics,
+    diagnostics,
+    reason: blockingDiagnostics.some(diagnostic => diagnostic._tag === 'error')
+      ? 'errors'
+      : 'strict-warnings',
+    schemaVersion: 1,
+  }
+}

--- a/packages/nuxt-cloudflare/src/doctor.ts
+++ b/packages/nuxt-cloudflare/src/doctor.ts
@@ -1,0 +1,50 @@
+import type { WranglerDiagnostic, WranglerDiagnosticOptions } from './wrangler'
+import type { ReadProjectWranglerOptions } from './wrangler-reader'
+import { diagnoseWranglerSourceConfigs, discoverWranglerSourceConfigs } from './diagnostics'
+import { diagnoseWranglerConfig } from './wrangler'
+import { readProjectWranglerConfig } from './wrangler-reader'
+
+export interface DiagnoseWranglerProjectOptions extends ReadProjectWranglerOptions, WranglerDiagnosticOptions {}
+
+export interface WranglerProjectDiagnostics {
+  configPath: string | undefined
+  diagnostics: WranglerDiagnostic[]
+  sourceConfigPaths: string[]
+}
+
+export function diagnoseWranglerProject(options: DiagnoseWranglerProjectOptions): WranglerProjectDiagnostics {
+  const sourceConfigPaths = discoverWranglerSourceConfigs(options.cwd, options.config)
+  const loaded = readProjectWranglerConfig(options)
+  if (loaded._tag === 'invalid') {
+    return {
+      configPath: loaded.path,
+      diagnostics: [{
+        _tag: 'error',
+        code: 'wrangler-config-unreadable',
+        message: 'Wrangler could not read the effective config. Build Nuxt again or run Wrangler locally for validation details.',
+        sourcePath: loaded.path ?? 'wrangler config',
+      }, ...diagnoseWranglerSourceConfigs(sourceConfigPaths)],
+      sourceConfigPaths,
+    }
+  }
+  if (!loaded.path && sourceConfigPaths.length === 0) {
+    return {
+      configPath: undefined,
+      diagnostics: [{
+        _tag: 'error',
+        code: 'wrangler-config-missing',
+        message: 'No authored or generated Wrangler config exists. Build Nuxt before running doctor.',
+        sourcePath: options.cwd,
+      }],
+      sourceConfigPaths,
+    }
+  }
+  return {
+    configPath: loaded.path,
+    diagnostics: [
+      ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated }),
+      ...diagnoseWranglerSourceConfigs(sourceConfigPaths),
+    ],
+    sourceConfigPaths,
+  }
+}

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -1,6 +1,7 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { Nitro } from 'nitropack/types'
 import type { WranglerDiagnosticPolicy } from './diagnostics'
+import type { WorkersCachePolicy } from './wrangler'
 import { defineNuxtModule, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import {
@@ -30,6 +31,7 @@ export interface ModuleOptions {
   sourceMaps?: boolean
   tracesSampleRate?: number
   versionMetadataBinding?: string
+  workersCache?: WorkersCachePolicy
 }
 
 interface NitroStorageMount extends Record<string, unknown> {
@@ -66,6 +68,7 @@ export function configureNitroCloudflare(
     tracesSampleRate: options.tracesSampleRate,
     uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? nuxtServerSourceMaps ?? false,
     versionMetadataBinding: options.versionMetadataBinding,
+    workersCache: options.workersCache,
   })
 
   if (options.kvCache === false)

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -1,7 +1,13 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { Nitro } from 'nitropack/types'
+import type { WranglerDiagnosticPolicy } from './diagnostics'
 import { defineNuxtModule, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
+import {
+  diagnoseWranglerSourceConfigs,
+  discoverWranglerSourceConfigs,
+  evaluateWranglerDiagnostics,
+} from './diagnostics'
 import {
   applyCloudflareDefaults,
   diagnoseWranglerConfig,
@@ -13,6 +19,7 @@ export interface ModuleOptions {
   enabled?: boolean
   compatibilityDate?: string
   compatibilityMaxAgeDays?: number
+  doctor?: WranglerDiagnosticPolicy
   kvCache?: false | {
     binding: string
     defaultTtl?: number
@@ -78,7 +85,7 @@ export function configureNitroCloudflare(
   }
 }
 
-async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions): Promise<void> {
+async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions, rootDir: string): Promise<void> {
   const path = resolve(nitro.options.output.serverDir, 'wrangler.json')
   const result = await readWranglerJsonFile(path)
   if (result._tag === 'missing')
@@ -86,16 +93,25 @@ async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions
   if (result._tag === 'invalid')
     throw new Error(`[nuxt-cloudflare] Generated Wrangler config is invalid: ${result.reason}`)
 
-  const diagnostics = diagnoseWranglerConfig(result.config, {
-    compatibilityMaxAgeDays: options.compatibilityMaxAgeDays,
-    publicVarNames: options.publicVarNames,
-  })
-  const warnings = diagnostics.filter(diagnostic => diagnostic._tag === 'warning')
-  const errors = diagnostics.filter(diagnostic => diagnostic._tag === 'error')
+  const diagnostics = [
+    ...diagnoseWranglerConfig(result.config, {
+      compatibilityMaxAgeDays: options.compatibilityMaxAgeDays,
+      generated: true,
+      publicVarNames: options.publicVarNames,
+    }),
+    ...diagnoseWranglerSourceConfigs(discoverWranglerSourceConfigs(rootDir)),
+  ]
+  const policy = options.doctor ?? { _tag: 'advisory' }
+  const outcome = evaluateWranglerDiagnostics(diagnostics, policy)
+  const blocking = new Set(outcome.blockingDiagnostics)
+  const warnings = diagnostics.filter(diagnostic => diagnostic._tag === 'warning' && !blocking.has(diagnostic))
+  const information = diagnostics.filter(diagnostic => diagnostic._tag === 'info')
+  if (information.length > 0)
+    logger.info(formatWranglerDiagnostics(information))
   if (warnings.length > 0)
     logger.warn(formatWranglerDiagnostics(warnings))
-  if (errors.length > 0)
-    throw new Error(`[nuxt-cloudflare]\n${formatWranglerDiagnostics(errors)}`)
+  if (outcome._tag === 'failed')
+    throw new Error(`[nuxt-cloudflare]\n${formatWranglerDiagnostics(outcome.blockingDiagnostics)}`)
 }
 
 export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void {
@@ -114,7 +130,7 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   })
   if (!nuxt.options.dev) {
     nuxt.hook('nitro:init', (nitro) => {
-      nitro.hooks.hook('compiled', () => auditGeneratedWranglerConfig(nitro, options))
+      nitro.hooks.hook('compiled', () => auditGeneratedWranglerConfig(nitro, options, nuxt.options.rootDir))
     })
   }
 }
@@ -128,6 +144,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     enabled: true,
     compatibilityMaxAgeDays: 90,
+    doctor: { _tag: 'advisory' },
     logsSampleRate: 0.1,
     tracesSampleRate: 0.01,
     versionMetadataBinding: 'CF_VERSION_METADATA',

--- a/packages/nuxt-cloudflare/src/wrangler-reader.ts
+++ b/packages/nuxt-cloudflare/src/wrangler-reader.ts
@@ -9,16 +9,73 @@ export interface ReadProjectWranglerOptions {
   environment?: string
 }
 
-export interface ProjectWranglerConfig {
-  config: WranglerConfigInput
-  path: string | undefined
+export type ProjectWranglerConfig
+  = | {
+    _tag: 'loaded'
+    config: WranglerConfigInput
+    generated: boolean
+    path: string | undefined
+  }
+  | {
+    _tag: 'invalid'
+    generated: boolean
+    path: string | undefined
+    reason: string
+  }
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+type Attempt<T>
+  = | { _tag: 'loaded', value: T }
+    | { _tag: 'invalid', reason: string }
+
+function attempt<T>(run: () => T): Attempt<T> {
+  try {
+    return { _tag: 'loaded', value: run() }
+  }
+  catch (error) {
+    return { _tag: 'invalid', reason: errorMessage(error) }
+  }
+}
+
+function findUpFile(cwd: string, relativePath: string): string | undefined {
+  let directory = resolve(cwd)
+  while (true) {
+    const candidate = resolve(directory, relativePath)
+    if (existsSync(candidate))
+      return candidate
+    const parent = dirname(directory)
+    if (parent === directory)
+      return undefined
+    directory = parent
+  }
+}
+
+function findUpWranglerConfig(cwd: string): string | undefined {
+  let directory = resolve(cwd)
+  while (true) {
+    for (const name of ['wrangler.json', 'wrangler.jsonc', 'wrangler.toml']) {
+      const candidate = resolve(directory, name)
+      if (existsSync(candidate))
+        return candidate
+    }
+    const parent = dirname(directory)
+    if (parent === directory)
+      return undefined
+    directory = parent
+  }
 }
 
 function resolveNitroDeployConfig(cwd: string): string | undefined {
-  const redirectPath = resolve(cwd, '.wrangler/deploy/config.json')
-  if (!existsSync(redirectPath))
+  const redirectPath = findUpFile(cwd, '.wrangler/deploy/config.json')
+  if (!redirectPath)
     return undefined
-
+  const redirectProjectDirectory = dirname(dirname(dirname(redirectPath)))
+  const authoredConfigPath = findUpWranglerConfig(cwd)
+  if (authoredConfigPath && dirname(authoredConfigPath) !== redirectProjectDirectory)
+    return undefined
   const parsed: unknown = JSON.parse(readFileSync(redirectPath, 'utf8'))
   if (!parsed || typeof parsed !== 'object' || !('configPath' in parsed) || typeof parsed.configPath !== 'string')
     throw new Error(`Invalid Nitro deploy config: ${redirectPath}`)
@@ -27,19 +84,40 @@ function resolveNitroDeployConfig(cwd: string): string | undefined {
 
 /** Wrangler owns JSONC/TOML parsing, validation, and environment flattening. */
 export function readProjectWranglerConfig(options: ReadProjectWranglerOptions): ProjectWranglerConfig {
+  const redirect = attempt(() => options.config ? undefined : resolveNitroDeployConfig(options.cwd))
+  if (redirect._tag === 'invalid') {
+    return {
+      _tag: 'invalid',
+      generated: false,
+      path: findUpFile(options.cwd, '.wrangler/deploy/config.json')
+        ?? resolve(options.cwd, '.wrangler/deploy/config.json'),
+      reason: redirect.reason,
+    }
+  }
+  const generatedConfigPath = redirect.value
   const configPath = options.config
     ? resolve(options.cwd, options.config)
-    : resolveNitroDeployConfig(options.cwd)
-  const config = unstable_readConfig({
+    : generatedConfigPath
+  const loaded = attempt(() => unstable_readConfig({
     config: configPath,
     env: options.environment,
     script: resolve(options.cwd, '__nuxt-cloudflare-doctor.mjs'),
   }, {
     hideWarnings: true,
     useRedirectIfAvailable: false,
-  })
+  }))
+  if (loaded._tag === 'invalid') {
+    return {
+      _tag: 'invalid',
+      generated: generatedConfigPath !== undefined,
+      path: configPath,
+      reason: loaded.reason,
+    }
+  }
   return {
-    config,
-    path: config.configPath,
+    _tag: 'loaded',
+    config: loaded.value,
+    generated: generatedConfigPath !== undefined,
+    path: loaded.value.configPath,
   }
 }

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -25,10 +25,15 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   compatibility_date?: string
   compatibility_flags?: string[]
   env?: Record<string, WranglerConfigInput>
+  keep_vars?: boolean
   observability?: WranglerObservabilityInput
+  preview_urls?: boolean
   queues?: {
     consumers?: Array<Record<string, unknown>>
+    producers?: Array<Record<string, unknown>>
   }
+  route?: string | Record<string, unknown>
+  routes?: Array<string | Record<string, unknown>>
   secrets?: {
     required?: string[]
   }
@@ -49,29 +54,56 @@ export interface CloudflareDefaultOptions {
   versionMetadataBinding?: string
 }
 
+export const WRANGLER_DIAGNOSTIC_CODES = [
+  'assets-worker-first',
+  'assets-worker-first-pattern-invalid',
+  'compatibility-date-missing',
+  'compatibility-date-invalid',
+  'durable-object-binding-inactive',
+  'durable-object-lifecycle-mixed',
+  'durable-object-lifecycle-unmanaged',
+  'generated-config-has-env',
+  'keep-vars-enabled',
+  'missing-nodejs-compat',
+  'nodejs-compat-version-implicit',
+  'observability-disabled',
+  'observability-sampling-implicit',
+  'observability-sampling-out-of-range',
+  'plaintext-secret-var',
+  'preview-urls-public',
+  'queue-dlq-missing',
+  'queue-retries-above-policy',
+  'queue-retries-out-of-range',
+  'queue-retry-delay-out-of-range',
+  'secret-declared-as-var',
+  'source-maps-disabled',
+  'stale-compatibility-date',
+  'traces-disabled',
+  'version-metadata-missing',
+  'workers-dev-enabled',
+  'workers-dev-implicit',
+  'wrangler-config-shadowed',
+  'wrangler-config-missing',
+  'wrangler-config-unreadable',
+  'wrangler-jsonc-preferred',
+] as const
+
+export type WranglerDiagnosticCode = typeof WRANGLER_DIAGNOSTIC_CODES[number]
+
 export interface WranglerDiagnostic {
-  _tag: 'error' | 'warning'
-  code:
-    | 'assets-worker-first'
-    | 'compatibility-date-missing'
-    | 'compatibility-date-invalid'
-    | 'missing-nodejs-compat'
-    | 'observability-disabled'
-    | 'plaintext-secret-var'
-    | 'queue-retries-excessive'
-    | 'secret-declared-as-var'
-    | 'source-maps-disabled'
-    | 'stale-compatibility-date'
-    | 'version-metadata-missing'
-    | 'workers-dev-enabled'
+  _tag: 'error' | 'info' | 'warning'
+  code: WranglerDiagnosticCode
   message: string
-  path: string
+  configPath?: string
+  sourcePath?: string
 }
 
 export interface WranglerDiagnosticOptions {
   compatibilityMaxAgeDays?: number
+  generated?: boolean
   now?: Date
   publicVarNames?: readonly string[]
+  requireNodeCompat?: boolean
 }
 
 export type WranglerJsonFileResult
@@ -82,6 +114,7 @@ export type WranglerJsonFileResult
 const SECRET_NAME_RE = /(?:^|_)(?:API_?KEY|AUTH_TOKEN|CLIENT_SECRET|CREDENTIALS?|DATABASE_URL|DB_URL|ENCRYPTION_KEY|KEY|PASSWORD|PRIVATE_KEY|SECRET|SIGNING_KEY|TOKEN)(?:_|$)/i
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+const NODEJS_COMPAT_V2_DATE = new Date('2024-09-23T00:00:00.000Z')
 
 function unique(values: readonly string[]): string[] {
   return [...new Set(values)]
@@ -98,8 +131,79 @@ function parseDateOnly(value: string): Date | undefined {
   return Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value ? undefined : date
 }
 
-function hasOwn(value: object, key: PropertyKey): boolean {
-  return Object.hasOwn(value, key)
+function parsedCompatibilityDateBeforeV2(value: string | undefined): boolean {
+  const parsed = value && parseDateOnly(value)
+  return Boolean(parsed && parsed < NODEJS_COMPAT_V2_DATE)
+}
+
+const WRANGLER_BINDING_CATEGORIES = [
+  'data_blobs',
+  'durable_objects',
+  'kv_namespaces',
+  'send_email',
+  'd1_databases',
+  'vectorize',
+  'ai_search_namespaces',
+  'ai_search',
+  'websearch',
+  'agent_memory',
+  'hyperdrive',
+  'r2_buckets',
+  'logfwdr',
+  'services',
+  'analytics_engine_datasets',
+  'text_blobs',
+  'browser',
+  'ai',
+  'images',
+  'stream',
+  'media',
+  'version_metadata',
+  'unsafe',
+  'vars',
+  'wasm_modules',
+  'dispatch_namespaces',
+  'mtls_certificates',
+  'workflows',
+  'pipelines',
+  'secrets_store_secrets',
+  'artifacts',
+  'ratelimits',
+  'assets',
+  'unsafe_hello_world',
+  'flagship',
+] as const
+
+function addBindingNames(names: Set<string>, value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => {
+      if (isRecord(entry) && typeof entry.binding === 'string')
+        names.add(entry.binding)
+    })
+    return
+  }
+  if (!isRecord(value))
+    return
+  if (Array.isArray(value.bindings)
+    && value.bindings.every(binding => isRecord(binding) && typeof binding.name === 'string')) {
+    value.bindings.forEach(binding => names.add((binding as { name: string }).name))
+    return
+  }
+  if (typeof value.binding === 'string') {
+    names.add(value.binding)
+    return
+  }
+  Object.entries(value).forEach(([name, binding]) => {
+    if (binding !== undefined)
+      names.add(name)
+  })
+}
+
+function collectBindingNames(config: WranglerConfigInput): Set<string> {
+  const names = new Set(config.secrets?.required ?? [])
+  WRANGLER_BINDING_CATEGORIES.forEach(category => addBindingNames(names, config[category]))
+  addBindingNames(names, config.queues?.producers)
+  return names
 }
 
 export function applyCloudflareDefaults(
@@ -110,7 +214,7 @@ export function applyCloudflareDefaults(
   const environments = config.env && Object.fromEntries(
     Object.entries(config.env).map(([name, environment]) => [name, applyEnvironmentDefaults(environment, {
       ...options,
-      requiredSecrets: root.secrets?.required,
+      requiredSecrets: options.requiredSecrets,
     }, root)]),
   )
   return environments ? { ...root, env: environments } : root
@@ -129,6 +233,17 @@ function applyEnvironmentDefaults(
   const traces = config.observability?.traces
   const inheritedTraces = inherited.observability?.traces
   const uploadSourceMaps = config.upload_source_maps ?? inherited.upload_source_maps ?? options.uploadSourceMaps ?? true
+  const previewUrls = config.preview_urls ?? inherited.preview_urls ?? false
+  const workersDev = config.workers_dev
+    ?? inherited.workers_dev
+    ?? ((config.route !== undefined || (config.routes?.length ?? 0) > 0) ? false : undefined)
+  const versionMetadataBinding = options.versionMetadataBinding ?? 'CF_VERSION_METADATA'
+  const localBindingNames = collectBindingNames(config)
+  const versionMetadata = config.version_metadata
+    ?? (inherited.version_metadata && !localBindingNames.has(inherited.version_metadata.binding)
+      ? inherited.version_metadata
+      : undefined)
+    ?? (localBindingNames.has(versionMetadataBinding) ? undefined : { binding: versionMetadataBinding })
 
   return {
     ...config,
@@ -154,9 +269,9 @@ function applyEnvironmentDefaults(
     },
     ...(requiredSecrets.length > 0 ? { secrets: { ...config.secrets, required: requiredSecrets } } : {}),
     upload_source_maps: uploadSourceMaps,
-    version_metadata: config.version_metadata ?? inherited.version_metadata ?? {
-      binding: options.versionMetadataBinding ?? 'CF_VERSION_METADATA',
-    },
+    ...(versionMetadata ? { version_metadata: versionMetadata } : {}),
+    preview_urls: previewUrls,
+    ...(workersDev === undefined ? {} : { workers_dev: workersDev }),
   }
 }
 
@@ -166,33 +281,134 @@ function diagnoseEnvironment(
   diagnostics: WranglerDiagnostic[],
   publicVarNames: ReadonlySet<string>,
 ): void {
-  if (config.assets && hasOwn(config.assets, 'run_worker_first')) {
+  const workerFirst: unknown = config.assets?.run_worker_first
+  if (workerFirst === true) {
     diagnostics.push({
       _tag: 'error',
       code: 'assets-worker-first',
-      message: 'Remove assets.run_worker_first. Static assets must bypass the Worker.',
-      path: `${prefix}assets.run_worker_first`,
+      message: 'Replace blanket Worker-first routing with false or a narrow route-pattern array.',
+      configPath: `${prefix}assets.run_worker_first`,
+    })
+  }
+  else if (Array.isArray(workerFirst)) {
+    const invalidPatternIndex = workerFirst.findIndex(
+      pattern => typeof pattern !== 'string' || !/^(?:!\/|\/)/.test(pattern),
+    )
+    if (invalidPatternIndex !== -1) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'assets-worker-first-pattern-invalid',
+        message: 'Selective Worker-first patterns must begin with / or !/.',
+        configPath: `${prefix}assets.run_worker_first.${invalidPatternIndex}`,
+      })
+    }
+  }
+  else if (workerFirst !== undefined && workerFirst !== false) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'assets-worker-first-pattern-invalid',
+      message: 'assets.run_worker_first must be false or an array of route patterns.',
+      configPath: `${prefix}assets.run_worker_first`,
+    })
+  }
+
+  const durableObjectExports = isRecord(config.exports)
+    ? Object.entries(config.exports).filter(([, value]) => isRecord(value) && value.type === 'durable-object')
+    : []
+  const migrations = Array.isArray(config.migrations) ? config.migrations : []
+  if (durableObjectExports.length > 0 && migrations.length > 0) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'durable-object-lifecycle-mixed',
+      message: 'Durable Object declarative exports and legacy migrations are mutually exclusive.',
+      configPath: `${prefix}exports`,
+    })
+  }
+  const durableObjects = isRecord(config.durable_objects) ? config.durable_objects : undefined
+  const bindings = Array.isArray(durableObjects?.bindings) ? durableObjects.bindings : []
+  const localClassNames = bindings.flatMap((binding) => {
+    if (!isRecord(binding) || typeof binding.script_name === 'string' || typeof binding.class_name !== 'string')
+      return []
+    return [binding.class_name]
+  })
+  const inactiveExportedClassNames = new Set(durableObjectExports.flatMap(([name, value]) => {
+    if (!isRecord(value) || value.state === undefined || value.state === 'created')
+      return []
+    return [name]
+  }))
+  if (localClassNames.some(className => inactiveExportedClassNames.has(className))) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'durable-object-binding-inactive',
+      message: 'A Durable Object binding may target only an active declarative export with state created or omitted.',
+      configPath: `${prefix}durable_objects.bindings`,
+    })
+  }
+  const exportedClassNames = new Set(durableObjectExports.map(([name]) => name))
+  const migratedClassNames = new Set<string>()
+  for (const migration of migrations) {
+    if (!isRecord(migration))
+      continue
+    for (const key of ['new_classes', 'new_sqlite_classes'] as const) {
+      if (Array.isArray(migration[key])) {
+        for (const className of migration[key]) {
+          if (typeof className === 'string') {
+            migratedClassNames.add(className)
+          }
+        }
+      }
+    }
+    if (Array.isArray(migration.renamed_classes)) {
+      for (const rename of migration.renamed_classes) {
+        if (!isRecord(rename))
+          continue
+        if (typeof rename.from === 'string')
+          migratedClassNames.delete(rename.from)
+        if (typeof rename.to === 'string')
+          migratedClassNames.add(rename.to)
+      }
+    }
+    if (Array.isArray(migration.transferred_classes)) {
+      for (const transfer of migration.transferred_classes) {
+        if (isRecord(transfer) && typeof transfer.to === 'string')
+          migratedClassNames.add(transfer.to)
+      }
+    }
+    if (Array.isArray(migration.deleted_classes)) {
+      for (const className of migration.deleted_classes) {
+        if (typeof className === 'string') {
+          migratedClassNames.delete(className)
+        }
+      }
+    }
+  }
+  if (localClassNames.some(className => !exportedClassNames.has(className) && !migratedClassNames.has(className))) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'durable-object-lifecycle-unmanaged',
+      message: 'Every locally defined Durable Object needs a declarative export or a legacy migration history.',
+      configPath: `${prefix}durable_objects.bindings`,
     })
   }
 
   const requiredSecrets = new Set(config.secrets?.required ?? [])
   for (const name of Object.keys(config.vars ?? {})) {
-    const path = `${prefix}vars.${name}`
+    const configPath = `${prefix}vars.${name}`
     if (requiredSecrets.has(name)) {
       diagnostics.push({
         _tag: 'error',
         code: 'secret-declared-as-var',
         message: `Remove ${name} from vars; it is declared as a required encrypted secret.`,
-        path,
+        configPath,
       })
       continue
     }
     if (!publicVarNames.has(name) && !/^(?:NUXT_)?PUBLIC_/i.test(name) && SECRET_NAME_RE.test(name)) {
       diagnostics.push({
-        _tag: 'error',
+        _tag: 'warning',
         code: 'plaintext-secret-var',
         message: `Move secret-looking variable ${name} to an encrypted Worker secret.`,
-        path,
+        configPath,
       })
     }
   }
@@ -200,12 +416,37 @@ function diagnoseEnvironment(
   const consumers = config.queues?.consumers ?? []
   consumers.forEach((consumer, index) => {
     const retries = consumer.max_retries
-    if (typeof retries === 'number' && retries > 10) {
+    const retryDelay = consumer.retry_delay
+    if (typeof retries === 'number' && (!Number.isSafeInteger(retries) || retries < 0 || retries > 100)) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'queue-retries-out-of-range',
+        message: 'Queue consumer max_retries must be an integer between 0 and 100.',
+        configPath: `${prefix}queues.consumers.${index}.max_retries`,
+      })
+    }
+    else if (typeof retries === 'number' && retries > 3) {
       diagnostics.push({
         _tag: 'warning',
-        code: 'queue-retries-excessive',
-        message: `Queue consumer retries ${retries} times; verify this is intentional and backed by a DLQ.`,
-        path: `${prefix}queues.consumers.${index}.max_retries`,
+        code: 'queue-retries-above-policy',
+        message: `Queue consumer retries ${retries} times, above Cloudflare's default of 3. Verify the work is replay-safe.`,
+        configPath: `${prefix}queues.consumers.${index}.max_retries`,
+      })
+    }
+    if (typeof consumer.dead_letter_queue !== 'string' || consumer.dead_letter_queue.length === 0) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'queue-dlq-missing',
+        message: 'Configure a dead-letter queue or explicitly allow this warning for intentionally lossy work.',
+        configPath: `${prefix}queues.consumers.${index}.dead_letter_queue`,
+      })
+    }
+    if (typeof retryDelay === 'number' && (!Number.isSafeInteger(retryDelay) || retryDelay < 0 || retryDelay > 86_400)) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'queue-retry-delay-out-of-range',
+        message: 'Queue consumer retry_delay must be between 0 and 86400 seconds.',
+        configPath: `${prefix}queues.consumers.${index}.retry_delay`,
       })
     }
   })
@@ -215,7 +456,7 @@ function diagnosePolicy(
   config: WranglerConfigInput,
   prefix: string,
   diagnostics: WranglerDiagnostic[],
-  options: Required<Pick<WranglerDiagnosticOptions, 'compatibilityMaxAgeDays' | 'now'>>,
+  options: Required<Pick<WranglerDiagnosticOptions, 'compatibilityMaxAgeDays' | 'now' | 'requireNodeCompat'>>,
   publicVarNames: ReadonlySet<string>,
 ): void {
   const compatibilityDate = config.compatibility_date
@@ -225,7 +466,7 @@ function diagnosePolicy(
       _tag: 'error',
       code: 'compatibility-date-missing',
       message: 'Set an explicit compatibility_date.',
-      path: `${prefix}compatibility_date`,
+      configPath: `${prefix}compatibility_date`,
     })
   }
   else {
@@ -235,7 +476,7 @@ function diagnosePolicy(
         _tag: 'error',
         code: 'compatibility-date-invalid',
         message: 'compatibility_date must be a real YYYY-MM-DD date.',
-        path: `${prefix}compatibility_date`,
+        configPath: `${prefix}compatibility_date`,
       })
     }
     else if ((options.now.getTime() - parsed.getTime()) / MILLISECONDS_PER_DAY > options.compatibilityMaxAgeDays) {
@@ -243,17 +484,29 @@ function diagnosePolicy(
         _tag: 'warning',
         code: 'stale-compatibility-date',
         message: `compatibility_date is older than the ${options.compatibilityMaxAgeDays}-day project policy. Review compatibility flags before advancing it.`,
-        path: `${prefix}compatibility_date`,
+        configPath: `${prefix}compatibility_date`,
       })
     }
   }
 
-  if (!config.compatibility_flags?.includes('nodejs_compat')) {
+  if (options.requireNodeCompat && !config.compatibility_flags?.includes('nodejs_compat')) {
     diagnostics.push({
       _tag: 'error',
       code: 'missing-nodejs-compat',
       message: 'Add nodejs_compat to compatibility_flags.',
-      path: `${prefix}compatibility_flags`,
+      configPath: `${prefix}compatibility_flags`,
+    })
+  }
+  if (options.requireNodeCompat
+    && parsedCompatibilityDateBeforeV2(compatibilityDate)
+    && config.compatibility_flags?.includes('nodejs_compat')
+    && !config.compatibility_flags.includes('nodejs_compat_v2')
+    && !config.compatibility_flags.includes('no_nodejs_compat_v2')) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'nodejs-compat-version-implicit',
+      message: 'Before 2024-09-23, choose nodejs_compat_v2 or no_nodejs_compat_v2 explicitly.',
+      configPath: `${prefix}compatibility_flags`,
     })
   }
   if (config.observability?.enabled !== true) {
@@ -261,15 +514,51 @@ function diagnosePolicy(
       _tag: 'warning',
       code: 'observability-disabled',
       message: 'Enable Workers observability.',
-      path: `${prefix}observability.enabled`,
+      configPath: `${prefix}observability.enabled`,
     })
+  }
+  else {
+    const samplingRates = [
+      ['head_sampling_rate', config.observability.head_sampling_rate],
+      ['logs.head_sampling_rate', config.observability.logs?.head_sampling_rate],
+      ['traces.head_sampling_rate', config.observability.traces?.head_sampling_rate],
+    ] as const
+    for (const [path, rate] of samplingRates) {
+      if (rate !== undefined && (!Number.isFinite(rate) || rate < 0 || rate > 1)) {
+        diagnostics.push({
+          _tag: 'error',
+          code: 'observability-sampling-out-of-range',
+          message: 'Observability sampling rates must be finite numbers between 0 and 1.',
+          configPath: `${prefix}observability.${path}`,
+        })
+      }
+    }
+    if (config.observability.traces?.enabled !== true) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'traces-disabled',
+        message: 'Enable Workers traces with an explicit sampling rate.',
+        configPath: `${prefix}observability.traces.enabled`,
+      })
+    }
+    const logsEnabled = config.observability.logs?.enabled !== false
+    const tracesEnabled = config.observability.traces?.enabled === true
+    if ((logsEnabled && config.observability.logs?.head_sampling_rate === undefined)
+      || (tracesEnabled && config.observability.traces?.head_sampling_rate === undefined)) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'observability-sampling-implicit',
+        message: 'Set explicit log and trace sampling rates; enabled telemetry otherwise defaults to 100%.',
+        configPath: `${prefix}observability`,
+      })
+    }
   }
   if (config.upload_source_maps !== true) {
     diagnostics.push({
       _tag: 'warning',
       code: 'source-maps-disabled',
       message: 'Enable upload_source_maps when the Worker build emits source maps.',
-      path: `${prefix}upload_source_maps`,
+      configPath: `${prefix}upload_source_maps`,
     })
   }
   if (!config.version_metadata?.binding) {
@@ -277,15 +566,39 @@ function diagnosePolicy(
       _tag: 'warning',
       code: 'version-metadata-missing',
       message: 'Add a version_metadata binding for deployment correlation.',
-      path: `${prefix}version_metadata`,
+      configPath: `${prefix}version_metadata`,
+    })
+  }
+  if (config.keep_vars === true) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'keep-vars-enabled',
+      message: 'keep_vars allows dashboard-managed plaintext variables to drift from source control.',
+      configPath: `${prefix}keep_vars`,
+    })
+  }
+  if (config.preview_urls === true) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'preview-urls-public',
+      message: 'Preview URLs are public unless protected by Access; their logs cannot be viewed through Workers Logs, tail, or Logpush.',
+      configPath: `${prefix}preview_urls`,
     })
   }
   if (config.workers_dev === true) {
     diagnostics.push({
       _tag: 'warning',
       code: 'workers-dev-enabled',
-      message: 'Production workers.dev exposure is enabled; verify this is intentional.',
-      path: `${prefix}workers_dev`,
+      message: 'The public workers.dev endpoint is enabled. Set workers_dev to false unless this is intentional.',
+      configPath: `${prefix}workers_dev`,
+    })
+  }
+  else if (config.workers_dev === undefined) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'workers-dev-implicit',
+      message: 'Set workers_dev explicitly; current Wrangler behavior and published defaults differ when routes are present.',
+      configPath: `${prefix}workers_dev`,
     })
   }
 
@@ -318,7 +631,10 @@ function resolveEnvironmentPolicy(
     ...environment,
     compatibility_date: environment.compatibility_date ?? root.compatibility_date,
     compatibility_flags: environment.compatibility_flags ?? root.compatibility_flags,
+    exports: environment.exports ?? root.exports,
+    migrations: environment.migrations ?? root.migrations,
     observability: mergeObservability(root.observability, environment.observability),
+    preview_urls: environment.preview_urls ?? root.preview_urls,
     upload_source_maps: environment.upload_source_maps ?? root.upload_source_maps,
     workers_dev: environment.workers_dev ?? root.workers_dev,
   }
@@ -332,6 +648,16 @@ export function diagnoseWranglerConfig(
   const diagnosticOptions = {
     compatibilityMaxAgeDays: options.compatibilityMaxAgeDays ?? 90,
     now: options.now ?? new Date(),
+    requireNodeCompat: options.requireNodeCompat ?? true,
+  }
+
+  if (options.generated && Object.keys(config.env ?? {}).length > 0) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'generated-config-has-env',
+      message: 'Generated Wrangler config must target one flattened environment and contain no env block.',
+      configPath: 'env',
+    })
   }
 
   const publicVarNames = new Set(options.publicVarNames ?? [])
@@ -351,7 +677,11 @@ export function diagnoseWranglerConfig(
 
 export function formatWranglerDiagnostics(diagnostics: readonly WranglerDiagnostic[]): string {
   return diagnostics
-    .map(diagnostic => `${diagnostic._tag === 'error' ? 'ERROR' : 'WARN'} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`)
+    .map((diagnostic) => {
+      const location = [diagnostic.sourcePath, diagnostic.configPath].filter(Boolean).join(':')
+      const severity = diagnostic._tag === 'error' ? 'ERROR' : diagnostic._tag === 'warning' ? 'WARN' : 'INFO'
+      return `${severity} ${diagnostic.code}${location ? ` ${location}` : ''}: ${diagnostic.message}`
+    })
     .join('\n')
 }
 

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -6,6 +6,15 @@ export interface WranglerAssetsInput {
   run_worker_first?: boolean | string[]
 }
 
+export interface WranglerWorkersCacheInput {
+  enabled: boolean
+  cross_version_cache?: boolean
+}
+
+export type WorkersCachePolicy
+  = | { _tag: 'disabled' }
+    | { _tag: 'enabled', crossVersion: boolean }
+
 export interface WranglerObservabilityInput {
   enabled?: boolean
   head_sampling_rate?: number
@@ -22,6 +31,7 @@ export interface WranglerObservabilityInput {
 
 export interface WranglerConfigInput extends Record<string, unknown> {
   assets?: WranglerAssetsInput
+  cache?: WranglerWorkersCacheInput
   compatibility_date?: string
   compatibility_flags?: string[]
   env?: Record<string, WranglerConfigInput>
@@ -52,6 +62,7 @@ export interface CloudflareDefaultOptions {
   tracesSampleRate?: number
   uploadSourceMaps?: boolean
   versionMetadataBinding?: string
+  workersCache?: WorkersCachePolicy
 }
 
 export const WRANGLER_DIAGNOSTIC_CODES = [
@@ -82,6 +93,8 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'version-metadata-missing',
   'workers-dev-enabled',
   'workers-dev-implicit',
+  'workers-cache-cross-version-enabled',
+  'workers-cache-policy-implicit',
   'wrangler-config-shadowed',
   'wrangler-config-missing',
   'wrangler-config-unreadable',
@@ -134,6 +147,12 @@ function parseDateOnly(value: string): Date | undefined {
 function parsedCompatibilityDateBeforeV2(value: string | undefined): boolean {
   const parsed = value && parseDateOnly(value)
   return Boolean(parsed && parsed < NODEJS_COMPAT_V2_DATE)
+}
+
+function resolveWorkersCachePolicy(policy: WorkersCachePolicy): WranglerWorkersCacheInput {
+  if (policy._tag === 'disabled')
+    return { enabled: false, cross_version_cache: false }
+  return { enabled: true, cross_version_cache: policy.crossVersion }
 }
 
 const WRANGLER_BINDING_CATEGORIES = [
@@ -227,6 +246,9 @@ function applyEnvironmentDefaults(
 ): WranglerConfigInput {
   const compatibilityDate = config.compatibility_date ?? inherited.compatibility_date ?? options.compatibilityDate
   const compatibilityFlags = unique([...(config.compatibility_flags ?? inherited.compatibility_flags ?? []), 'nodejs_compat'])
+  const cache = options.workersCache
+    ? resolveWorkersCachePolicy(options.workersCache)
+    : config.cache ?? inherited.cache ?? resolveWorkersCachePolicy({ _tag: 'disabled' })
   const requiredSecrets = unique([...(config.secrets?.required ?? []), ...(options.requiredSecrets ?? [])])
   const logs = config.observability?.logs
   const inheritedLogs = inherited.observability?.logs
@@ -247,6 +269,7 @@ function applyEnvironmentDefaults(
 
   return {
     ...config,
+    cache,
     ...(compatibilityDate === undefined ? {} : { compatibility_date: compatibilityDate }),
     compatibility_flags: compatibilityFlags,
     observability: {
@@ -577,6 +600,22 @@ function diagnosePolicy(
       configPath: `${prefix}keep_vars`,
     })
   }
+  if (config.cache === undefined) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'workers-cache-policy-implicit',
+      message: 'Choose an explicit Workers Caching policy. Headerless 200 responses are cached for two hours when enabled.',
+      configPath: `${prefix}cache`,
+    })
+  }
+  else if (config.cache.enabled && config.cache.cross_version_cache === true) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'workers-cache-cross-version-enabled',
+      message: 'Cross-version caching can serve responses from superseded deployments until expiry or purge.',
+      configPath: `${prefix}cache.cross_version_cache`,
+    })
+  }
   if (config.preview_urls === true) {
     diagnostics.push({
       _tag: 'warning',
@@ -629,6 +668,7 @@ function resolveEnvironmentPolicy(
 ): WranglerConfigInput {
   return {
     ...environment,
+    cache: environment.cache ?? root.cache,
     compatibility_date: environment.compatibility_date ?? root.compatibility_date,
     compatibility_flags: environment.compatibility_flags ?? root.compatibility_flags,
     exports: environment.exports ?? root.exports,

--- a/packages/nuxt-cloudflare/tests/d1.test.ts
+++ b/packages/nuxt-cloudflare/tests/d1.test.ts
@@ -1,5 +1,74 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getRequestD1Session, isTransientD1Error, retryIdempotentD1Write } from '../src/d1'
+import {
+  assertD1BoundParameters,
+  chunkD1Items,
+  D1_MAX_BOUND_PARAMETERS,
+  defineD1ParameterPlan,
+  getRequestD1Session,
+  isTransientD1Error,
+  retryIdempotentD1Write,
+} from '../src/d1'
+
+describe('d1 parameter budget', () => {
+  it('derives safe IN-list and multi-row insert sizes from the 100-bind ceiling', () => {
+    expect(D1_MAX_BOUND_PARAMETERS).toBe(100)
+    expect(defineD1ParameterPlan({ parametersPerItem: 100, reservedParameters: 0 }).itemsPerStatement).toBe(1)
+    expect(defineD1ParameterPlan({ parametersPerItem: 1, reservedParameters: 2 }).itemsPerStatement).toBe(98)
+    expect(defineD1ParameterPlan({ parametersPerItem: 17, reservedParameters: 0 }).itemsPerStatement).toBe(5)
+    expect(defineD1ParameterPlan({ parametersPerItem: 8, reservedParameters: 12 }).itemsPerStatement).toBe(11)
+  })
+
+  it('chunks every item without emitting an over-budget statement', () => {
+    const items = Array.from({ length: 31 }, (_, index) => index)
+    const chunks = chunkD1Items(items, defineD1ParameterPlan({ parametersPerItem: 14, reservedParameters: 0 }))
+
+    expect(chunks.map(chunk => chunk.length)).toEqual([7, 7, 7, 7, 3])
+    expect(chunks.flat()).toEqual(items)
+    expect(chunks.every(chunk => chunk.length * 14 <= D1_MAX_BOUND_PARAMETERS)).toBe(true)
+  })
+
+  it('covers the 100-item bulk set and remove shapes used by site investigations', () => {
+    const items = Array.from({ length: 100 }, (_, index) => index)
+    const setPlan = defineD1ParameterPlan({ parametersPerItem: 4, reservedParameters: 2 })
+    const removePlan = defineD1ParameterPlan({ parametersPerItem: 1, reservedParameters: 2 })
+    const setChunks = chunkD1Items(items, setPlan)
+    const removeChunks = chunkD1Items(items, removePlan)
+
+    expect(setChunks.map(chunk => chunk.length)).toEqual([24, 24, 24, 24, 4])
+    expect(removeChunks.map(chunk => chunk.length)).toEqual([98, 2])
+    expect(setChunks.every(chunk => chunk.length * 4 + 2 <= D1_MAX_BOUND_PARAMETERS)).toBe(true)
+    expect(removeChunks.every(chunk => chunk.length + 2 <= D1_MAX_BOUND_PARAMETERS)).toBe(true)
+  })
+
+  it.each([
+    { parametersPerItem: 0, reservedParameters: 0 },
+    { parametersPerItem: 1.5, reservedParameters: 0 },
+    { parametersPerItem: Number.NaN, reservedParameters: 0 },
+    { parametersPerItem: Number.POSITIVE_INFINITY, reservedParameters: 0 },
+    { parametersPerItem: 101, reservedParameters: 0 },
+    { parametersPerItem: 1, reservedParameters: -1 },
+    { parametersPerItem: 1, reservedParameters: 100 },
+  ])('rejects an impossible parameter budget: %j', (budget) => {
+    expect(() => defineD1ParameterPlan(budget)).toThrow(TypeError)
+  })
+
+  it('returns no chunks for an empty input while retaining the parsed plan', () => {
+    const plan = defineD1ParameterPlan({ parametersPerItem: 1, reservedParameters: 0 })
+    expect(chunkD1Items([], plan)).toEqual([])
+    expect(plan.itemsPerStatement).toBe(100)
+  })
+
+  it('rejects a forged runtime plan instead of looping on an invalid size', () => {
+    expect(() => chunkD1Items([1], { itemsPerStatement: 0 } as never))
+      .toThrow(/defineD1ParameterPlan/)
+  })
+
+  it('asserts the emitted parameter count at the query boundary', () => {
+    expect(() => assertD1BoundParameters(Array.from({ length: 100 }))).not.toThrow()
+    expect(() => assertD1BoundParameters(Array.from({ length: 101 }))).toThrow(/101 bound parameters/)
+    expect(() => assertD1BoundParameters('not-an-array' as never)).toThrow(/must be an array/)
+  })
+})
 
 describe('getRequestD1Session', () => {
   it('creates one first-primary session per request and binding', () => {
@@ -38,5 +107,26 @@ describe('retryIdempotentD1Write', () => {
     await expect(retryIdempotentD1Write({ safety: { _tag: 'replay-safe' }, run })).rejects.toBe(error)
     expect(run).toHaveBeenCalledOnce()
     expect(isTransientD1Error(error)).toBe(false)
+  })
+
+  it('classifies mixed-case transient errors nested in a cause', () => {
+    expect(isTransientD1Error(new Error('wrapper', {
+      cause: new Error('D1_ERROR: NETWORK CONNECTION LOST'),
+    }))).toBe(true)
+  })
+
+  it('retries a synchronous lock failure', async () => {
+    const run = vi.fn()
+      .mockImplementationOnce(() => {
+        throw new Error('database is locked')
+      })
+      .mockResolvedValue('ok')
+
+    await expect(retryIdempotentD1Write({
+      safety: { _tag: 'lock-only' },
+      run,
+      sleep: async () => {},
+    })).resolves.toBe('ok')
+    expect(run).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/nuxt-cloudflare/tests/doctor.test.ts
+++ b/packages/nuxt-cloudflare/tests/doctor.test.ts
@@ -1,0 +1,146 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateWranglerDiagnostics,
+  isWranglerDiagnosticBlocking,
+  parseWranglerAllowedWarnings,
+} from '../src/diagnostics'
+import { diagnoseWranglerProject } from '../src/doctor'
+
+describe('diagnoseWranglerProject', () => {
+  it('warns when the authored config uses legacy TOML even if Wrangler can load it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await mkdir(join(root, 'apps/site'), { recursive: true })
+    await writeFile(join(root, 'wrangler.toml'), [
+      'compatibility_date = "2026-08-11"',
+      'compatibility_flags = ["nodejs_compat"]',
+      'workers_dev = false',
+      'upload_source_maps = true',
+      '[observability]',
+      'enabled = true',
+      '[version_metadata]',
+      'binding = "CF_VERSION_METADATA"',
+    ].join('\n'))
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: join(root, 'apps/site'), now: new Date('2026-08-11T00:00:00Z') })
+
+      expect(result.sourceConfigPaths).toEqual([join(root, 'wrangler.toml')])
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({
+        _tag: 'info',
+        code: 'wrangler-jsonc-preferred',
+        sourcePath: join(root, 'wrangler.toml'),
+      }))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('reports a missing effective config with a build-first action', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+
+    try {
+      expect(diagnoseWranglerProject({ cwd: root }).diagnostics).toContainEqual(expect.objectContaining({
+        _tag: 'error',
+        code: 'wrangler-config-missing',
+      }))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('warns when multiple root configs can drift behind Wrangler precedence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await writeFile(join(root, 'wrangler.jsonc'), '{}')
+    await writeFile(join(root, 'wrangler.toml'), 'name = "shadowed"')
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: root, now: new Date('2026-08-11T00:00:00Z') })
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'wrangler-config-shadowed',
+      }))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('never includes raw Wrangler values in an unreadable-config diagnostic', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await writeFile(join(root, 'wrangler.jsonc'), JSON.stringify({
+      compatibility_date: { token: 'SENSITIVE_ABC123' },
+    }))
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: root })
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({
+        _tag: 'error',
+        code: 'wrangler-config-unreadable',
+      }))
+      expect(JSON.stringify(result)).not.toContain('SENSITIVE_ABC123')
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})
+
+describe('isWranglerDiagnosticBlocking', () => {
+  const warning = {
+    _tag: 'warning' as const,
+    code: 'source-maps-disabled' as const,
+    message: 'Enable source maps.',
+    configPath: 'upload_source_maps',
+  }
+
+  it('blocks errors in advisory mode and all non-allowed warnings in strict mode', () => {
+    expect(isWranglerDiagnosticBlocking(warning, { _tag: 'advisory' })).toBe(false)
+    expect(isWranglerDiagnosticBlocking(warning, { _tag: 'strict' })).toBe(true)
+    expect(isWranglerDiagnosticBlocking(warning, {
+      _tag: 'strict',
+      allowedWarnings: ['source-maps-disabled'],
+    })).toBe(false)
+    expect(isWranglerDiagnosticBlocking({ ...warning, _tag: 'error' }, {
+      _tag: 'strict',
+      allowedWarnings: ['source-maps-disabled'],
+    })).toBe(true)
+  })
+
+  it('parses known CLI allowances and rejects typos', () => {
+    expect(parseWranglerAllowedWarnings('source-maps-disabled, stale-compatibility-date'))
+      .toEqual(['source-maps-disabled', 'stale-compatibility-date'])
+    expect(() => parseWranglerAllowedWarnings('source-map-disabled')).toThrow(/Unknown Wrangler diagnostic code/)
+  })
+
+  it('returns one versioned outcome for CLI and build consumers', () => {
+    const information = {
+      _tag: 'info' as const,
+      code: 'wrangler-jsonc-preferred' as const,
+      message: 'Prefer JSONC for new projects.',
+      sourcePath: 'wrangler.toml',
+    }
+    expect(evaluateWranglerDiagnostics([information], { _tag: 'strict' })).toMatchObject({
+      _tag: 'passed',
+      schemaVersion: 1,
+    })
+    expect(evaluateWranglerDiagnostics([warning], { _tag: 'advisory' })).toMatchObject({
+      _tag: 'passed',
+      schemaVersion: 1,
+    })
+    expect(evaluateWranglerDiagnostics([warning], { _tag: 'strict' })).toMatchObject({
+      _tag: 'failed',
+      reason: 'strict-warnings',
+      schemaVersion: 1,
+    })
+    expect(evaluateWranglerDiagnostics([{ ...warning, _tag: 'error' }], { _tag: 'strict' })).toMatchObject({
+      _tag: 'failed',
+      reason: 'errors',
+      schemaVersion: 1,
+    })
+  })
+})

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/nuxt.config.ts
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/nuxt.config.ts
@@ -9,7 +9,10 @@ export default defineNuxtConfig({
   }]],
   nitro: {
     cloudflare: {
-      wrangler: { name: 'nuxt-cloudflare-fixture' },
+      wrangler: {
+        name: 'nuxt-cloudflare-fixture',
+        assets: { run_worker_first: ['/pro/_nuxt/*'] },
+      },
     },
     storage: {
       cache: { driver: 'cloudflare-kv-binding', binding: 'CACHE' },

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -42,6 +42,30 @@ describe('configureNitroCloudflare', () => {
     expect(nitro.preset).toBe('cloudflare-durable')
     expect(nitro.cloudflare?.wrangler?.upload_source_maps).toBe(false)
   })
+
+  it('disables Workers Caching by default', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, {})
+
+    expect(nitro.cloudflare?.wrangler?.cache).toEqual({
+      enabled: false,
+      cross_version_cache: false,
+    })
+  })
+
+  it('supports version-isolated Workers Caching as an explicit policy', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, {
+      workersCache: { _tag: 'enabled', crossVersion: false },
+    })
+
+    expect(nitro.cloudflare?.wrangler?.cache).toEqual({
+      enabled: true,
+      cross_version_cache: false,
+    })
+  })
 })
 
 describe('setupCloudflareModule', () => {

--- a/packages/nuxt-cloudflare/tests/wrangler-reader.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler-reader.test.ts
@@ -9,6 +9,7 @@ describe('readProjectWranglerConfig', () => {
     const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-'))
     await mkdir(join(root, '.wrangler/deploy'), { recursive: true })
     await mkdir(join(root, '.output/server'), { recursive: true })
+    await mkdir(join(root, 'apps/site'), { recursive: true })
     await writeFile(join(root, '.wrangler/deploy/config.json'), JSON.stringify({
       configPath: '../../.output/server/wrangler.json',
     }))
@@ -18,9 +19,63 @@ describe('readProjectWranglerConfig', () => {
     }))
 
     try {
-      const loaded = readProjectWranglerConfig({ cwd: root })
+      const loaded = readProjectWranglerConfig({ cwd: join(root, 'apps/site') })
 
+      expect(loaded._tag).toBe('loaded')
+      if (loaded._tag !== 'loaded')
+        throw new Error(loaded.reason)
       expect(loaded.path).toBe(join(root, '.output/server/wrangler.json'))
+      expect(loaded.config.compatibility_date).toBe('2026-08-11')
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('returns an invalid artifact when a generated-config redirect is stale', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-'))
+    await mkdir(join(root, '.wrangler/deploy'), { recursive: true })
+    await writeFile(join(root, '.wrangler/deploy/config.json'), JSON.stringify({
+      configPath: '../../.output/server/wrangler.json',
+    }))
+
+    try {
+      expect(readProjectWranglerConfig({ cwd: root })).toMatchObject({
+        _tag: 'invalid',
+        generated: true,
+        path: join(root, '.output/server/wrangler.json'),
+      })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('does not follow an ancestor deploy redirect across a nested project boundary', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-'))
+    await mkdir(join(root, '.wrangler/deploy'), { recursive: true })
+    await mkdir(join(root, '.output/server'), { recursive: true })
+    await mkdir(join(root, 'apps/site'), { recursive: true })
+    await writeFile(join(root, '.wrangler/deploy/config.json'), JSON.stringify({
+      configPath: '../../.output/server/wrangler.json',
+    }))
+    await writeFile(join(root, '.output/server/wrangler.json'), JSON.stringify({
+      compatibility_date: '2025-01-01',
+    }))
+    await writeFile(join(root, 'apps/site/wrangler.jsonc'), JSON.stringify({
+      compatibility_date: '2026-08-11',
+    }))
+
+    try {
+      const loaded = readProjectWranglerConfig({ cwd: join(root, 'apps/site') })
+
+      expect(loaded).toMatchObject({
+        _tag: 'loaded',
+        generated: false,
+        path: join(root, 'apps/site/wrangler.jsonc'),
+      })
+      if (loaded._tag !== 'loaded')
+        throw new Error(loaded.reason)
       expect(loaded.config.compatibility_date).toBe('2026-08-11')
     }
     finally {

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -31,6 +31,20 @@ describe('applyCloudflareDefaults', () => {
     expect(applyCloudflareDefaults({ upload_source_maps: false })).toMatchObject({ upload_source_maps: false })
   })
 
+  it('preserves an authored Workers Caching policy', () => {
+    expect(applyCloudflareDefaults({
+      cache: { enabled: true, cross_version_cache: false },
+    }).cache).toEqual({ enabled: true, cross_version_cache: false })
+  })
+
+  it('lets an explicit module policy replace authored Workers Caching config', () => {
+    expect(applyCloudflareDefaults({
+      cache: { enabled: true, cross_version_cache: true },
+    }, {
+      workersCache: { _tag: 'disabled' },
+    }).cache).toEqual({ enabled: false, cross_version_cache: false })
+  })
+
   it('applies the complete policy to named environments', () => {
     const config = applyCloudflareDefaults({
       compatibility_date: '2026-08-11',
@@ -96,6 +110,33 @@ describe('applyCloudflareDefaults', () => {
 })
 
 describe('diagnoseWranglerConfig', () => {
+  it('warns when Workers Caching policy is implicit', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'workers-cache-policy-implicit',
+      }))
+  })
+
+  it('warns when Workers Caching is shared across deployments', () => {
+    expect(diagnoseWranglerConfig({
+      cache: { enabled: true, cross_version_cache: true },
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'workers-cache-cross-version-enabled',
+      }))
+  })
+
   it('rejects blanket Worker-first asset routing', () => {
     const diagnostics = diagnoseWranglerConfig({
       compatibility_date: '2026-08-11',

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -39,29 +39,68 @@ describe('applyCloudflareDefaults', () => {
         production: {
           compatibility_flags: ['global_fetch_strictly_public'],
           observability: { enabled: false },
+          secrets: { required: ['PRODUCTION_ONLY_SECRET'] },
         },
       },
       observability: { enabled: true },
-      secrets: { required: ['API_TOKEN'] },
+      secrets: { required: ['ROOT_ONLY_SECRET'] },
       version_metadata: { binding: 'CF_VERSION_METADATA' },
-    })
+    }, { requiredSecrets: ['MODULE_SECRET'] })
 
     expect(config.env?.production).toMatchObject({
       compatibility_date: '2026-08-11',
       compatibility_flags: ['global_fetch_strictly_public', 'nodejs_compat'],
       observability: { enabled: false },
-      secrets: { required: ['API_TOKEN'] },
+      secrets: { required: ['PRODUCTION_ONLY_SECRET', 'MODULE_SECRET'] },
       version_metadata: { binding: 'CF_VERSION_METADATA' },
     })
+    expect(config.secrets?.required).toEqual(['ROOT_ONLY_SECRET', 'MODULE_SECRET'])
+  })
+
+  it('disables workers.dev only when a production route proves reachability', () => {
+    expect(applyCloudflareDefaults({ routes: [{ pattern: 'example.com', custom_domain: true }] }))
+      .toMatchObject({ workers_dev: false })
+    expect(applyCloudflareDefaults({}).workers_dev).toBeUndefined()
+  })
+
+  it('does not create a version metadata binding that collides with an existing binding', () => {
+    expect(applyCloudflareDefaults({ vars: { CF_VERSION_METADATA: 'occupied' } }).version_metadata)
+      .toBeUndefined()
+    expect(applyCloudflareDefaults({ ai: { binding: 'CF_VERSION_METADATA' } }).version_metadata)
+      .toBeUndefined()
+  })
+
+  it.each(['wasm_modules', 'text_blobs', 'data_blobs'])(
+    'does not collide with a record-key binding in %s',
+    (category) => {
+      expect(applyCloudflareDefaults({
+        [category]: { CF_VERSION_METADATA: './binding.bin' },
+      }).version_metadata).toBeUndefined()
+    },
+  )
+
+  it('isolates version metadata collisions between root and named environments', () => {
+    const childCollision = applyCloudflareDefaults({
+      env: { production: { ai: { binding: 'CF_VERSION_METADATA' } } },
+    })
+    expect(childCollision.version_metadata).toEqual({ binding: 'CF_VERSION_METADATA' })
+    expect(childCollision.env?.production?.version_metadata).toBeUndefined()
+
+    const rootCollision = applyCloudflareDefaults({
+      ai: { binding: 'CF_VERSION_METADATA' },
+      env: { production: {} },
+    })
+    expect(rootCollision.version_metadata).toBeUndefined()
+    expect(rootCollision.env?.production?.version_metadata).toEqual({ binding: 'CF_VERSION_METADATA' })
   })
 })
 
 describe('diagnoseWranglerConfig', () => {
-  it.each([true, false, ['/api/**']])('rejects every run_worker_first declaration: %j', (runWorkerFirst) => {
+  it('rejects blanket Worker-first asset routing', () => {
     const diagnostics = diagnoseWranglerConfig({
       compatibility_date: '2026-08-11',
       compatibility_flags: ['nodejs_compat'],
-      assets: { directory: '.output/public', run_worker_first: runWorkerFirst },
+      assets: { directory: '.output/public', run_worker_first: true },
       observability: { enabled: true },
     }, { now: new Date('2026-08-11T00:00:00Z') })
 
@@ -69,6 +108,56 @@ describe('diagnoseWranglerConfig', () => {
       _tag: 'error',
       code: 'assets-worker-first',
     }))
+  })
+
+  it.each([false, ['/pro/_nuxt/*'], ['/api/*', '!/api/docs/*']])(
+    'allows asset-first or selective Worker-first routing: %j',
+    (runWorkerFirst) => {
+      const diagnostics = diagnoseWranglerConfig({
+        compatibility_date: '2026-08-11',
+        compatibility_flags: ['nodejs_compat'],
+        assets: { directory: '.output/public', run_worker_first: runWorkerFirst },
+        observability: { enabled: true },
+      }, { now: new Date('2026-08-11T00:00:00Z') })
+
+      expect(diagnostics).not.toContainEqual(expect.objectContaining({
+        code: 'assets-worker-first',
+      }))
+    },
+  )
+
+  it.each([
+    { label: 'missing leading slash', value: ['pro/_nuxt/*'] },
+    { label: 'invalid exception', value: ['!api/docs/*'] },
+    { label: 'empty pattern', value: [''] },
+    { label: 'non-string pattern', value: [42] },
+  ])(
+    'rejects an invalid selective Worker-first route pattern: $label',
+    ({ value: runWorkerFirst }) => {
+      expect(diagnoseWranglerConfig({
+        compatibility_date: '2026-08-11',
+        compatibility_flags: ['nodejs_compat'],
+        assets: { directory: '.output/public', run_worker_first: runWorkerFirst as string[] },
+        observability: { enabled: true },
+      }, { now: new Date('2026-08-11T00:00:00Z') }))
+        .toContainEqual(expect.objectContaining({
+          _tag: 'error',
+          code: 'assets-worker-first-pattern-invalid',
+        }))
+    },
+  )
+
+  it('rejects an invalid non-array Worker-first value', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      assets: { directory: '.output/public', run_worker_first: '/api/*' as never },
+      observability: { enabled: true },
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'error',
+        code: 'assets-worker-first-pattern-invalid',
+      }))
   })
 
   it('reports secret-looking vars by key without exposing their values', () => {
@@ -80,9 +169,9 @@ describe('diagnoseWranglerConfig', () => {
     }, { now: new Date('2026-08-11T00:00:00Z') })
 
     expect(diagnostics).toContainEqual(expect.objectContaining({
-      _tag: 'error',
+      _tag: 'warning',
       code: 'plaintext-secret-var',
-      path: 'vars.API_TOKEN',
+      configPath: 'vars.API_TOKEN',
     }))
     expect(JSON.stringify(diagnostics)).not.toContain('never-print-this')
   })
@@ -94,6 +183,284 @@ describe('diagnoseWranglerConfig', () => {
       observability: { enabled: true },
     }, { now: new Date('2026-08-11T00:00:00Z'), compatibilityMaxAgeDays: 90 }))
       .toContainEqual(expect.objectContaining({ _tag: 'warning', code: 'stale-compatibility-date' }))
+  })
+
+  it('surfaces defaults that expose a routed production Worker or allow dashboard var drift', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      keep_vars: true,
+      observability: {
+        enabled: true,
+        logs: { enabled: true, head_sampling_rate: 0.1 },
+        traces: { enabled: true, head_sampling_rate: 0.01 },
+      },
+      routes: [{ pattern: 'example.com', custom_domain: true }],
+      upload_source_maps: true,
+      version_metadata: { binding: 'CF_VERSION_METADATA' },
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).toContainEqual(expect.objectContaining({ code: 'keep-vars-enabled' }))
+    expect(diagnostics).toContainEqual(expect.objectContaining({ code: 'workers-dev-implicit' }))
+  })
+
+  it('surfaces trace, sampling, queue retry, and DLQ policy gaps', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      queues: { consumers: [{ queue: 'jobs', max_retries: 5 }] },
+      upload_source_maps: true,
+      version_metadata: { binding: 'CF_VERSION_METADATA' },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'traces-disabled' }),
+      expect.objectContaining({ code: 'observability-sampling-implicit' }),
+      expect.objectContaining({ code: 'queue-retries-above-policy' }),
+      expect.objectContaining({ code: 'queue-dlq-missing' }),
+    ]))
+  })
+
+  it.each([
+    ['head_sampling_rate', { head_sampling_rate: 1.1 }],
+    ['logs.head_sampling_rate', { logs: { head_sampling_rate: -0.1 } }],
+    ['traces.head_sampling_rate', { traces: { enabled: true, head_sampling_rate: Number.NaN } }],
+  ])('rejects an observability sampling rate outside 0..1 at %s', (_, observability) => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true, ...observability },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'error',
+        code: 'observability-sampling-out-of-range',
+      }))
+  })
+
+  it.each([-1, 1.5, 101])('rejects queue retry count outside the platform range: %s', (maxRetries) => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      queues: { consumers: [{ queue: 'jobs', max_retries: maxRetries }] },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'queue-retries-out-of-range' }))
+  })
+
+  it.each([-1, 1.5, 86_401])('rejects queue retry delay outside the platform range: %s', (retryDelay) => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      queues: { consumers: [{ queue: 'jobs', retry_delay: retryDelay }] },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'queue-retry-delay-out-of-range' }))
+  })
+
+  it('warns that explicitly enabled preview URLs are public and not logged', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      preview_urls: true,
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'warning', code: 'preview-urls-public' }))
+  })
+
+  it('defaults preview URLs off and preserves an explicit opt-in', () => {
+    expect(applyCloudflareDefaults({}).preview_urls).toBe(false)
+    expect(applyCloudflareDefaults({ preview_urls: true }).preview_urls).toBe(true)
+  })
+
+  it('surfaces permanent deletion risk for a terminal DLQ consumer', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      queues: {
+        consumers: [
+          { queue: 'jobs', dead_letter_queue: 'jobs-dlq' },
+          { queue: 'jobs-dlq' },
+        ],
+      },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      code: 'queue-dlq-missing',
+      configPath: 'queues.consumers.1.dead_letter_queue',
+    }))
+  })
+
+  it('rejects mixed Durable Object lifecycle models', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+      exports: { Room: { type: 'durable-object', storage: 'sqlite' } },
+      migrations: [{ tag: 'v1', new_sqlite_classes: ['Room'] }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'durable-object-lifecycle-mixed' }))
+  })
+
+  it('does not suggest mutating an existing declarative legacy-KV namespace', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+      exports: { Room: { type: 'durable-object', storage: 'legacy-kv' } },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({ _tag: 'error' }))
+  })
+
+  it.each(['deleted', 'renamed', 'transferred', 'expecting-transfer'])(
+    'rejects a binding to an inactive declarative Durable Object state: %s',
+    (state) => {
+      expect(diagnoseWranglerConfig({
+        compatibility_date: '2026-08-11',
+        compatibility_flags: ['nodejs_compat'],
+        durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+        exports: { Room: { type: 'durable-object', state } },
+        observability: { enabled: true },
+        workers_dev: false,
+      }, { now: new Date('2026-08-11T00:00:00Z') }))
+        .toContainEqual(expect.objectContaining({
+          _tag: 'error',
+          code: 'durable-object-binding-inactive',
+        }))
+    },
+  )
+
+  it('inherits root declarative Durable Object exports into named environments', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      env: {
+        production: {
+          durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+        },
+      },
+      exports: { Room: { type: 'durable-object', storage: 'sqlite' } },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      code: 'durable-object-lifecycle-unmanaged',
+      configPath: 'env.production.durable_objects.bindings',
+    }))
+  })
+
+  it('rejects locally defined Durable Objects with no lifecycle declaration', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: {
+        bindings: [
+          { name: 'LOCAL', class_name: 'Local' },
+          { name: 'REMOTE', class_name: 'Remote', script_name: 'remote-worker' },
+        ],
+      },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'durable-object-lifecycle-unmanaged' }))
+  })
+
+  it('rejects a local Durable Object missing from a non-empty migration history', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: {
+        bindings: [
+          { name: 'OLD', class_name: 'Old' },
+          { name: 'NEW', class_name: 'New' },
+        ],
+      },
+      migrations: [{ tag: 'v1', new_sqlite_classes: ['Old'] }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'durable-object-lifecycle-unmanaged' }))
+  })
+
+  it('resolves root Durable Object migrations for named environments', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      env: {
+        production: {
+          durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+        },
+      },
+      migrations: [{ tag: 'v1', new_sqlite_classes: ['Room'] }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      code: 'durable-object-lifecycle-unmanaged',
+      configPath: 'env.production.durable_objects.bindings',
+    }))
+  })
+
+  it('tracks a transferred Durable Object as active migration history', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+      migrations: [{
+        tag: 'v2',
+        transferred_classes: [{ from: 'OldRoom', from_script: 'old-worker', to: 'Room' }],
+      }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      code: 'durable-object-lifecycle-unmanaged',
+    }))
+  })
+
+  it('requires an explicit Node compatibility mode before the v2 compatibility date', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2024-09-22',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2024-09-22T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'nodejs-compat-version-implicit' }))
+
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2024-09-22',
+      compatibility_flags: ['nodejs_compat', 'no_nodejs_compat_v2'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2024-09-22T00:00:00Z') }))
+      .not
+      .toContainEqual(expect.objectContaining({ code: 'nodejs-compat-version-implicit' }))
+  })
+
+  it('rejects named environments left in a generated deployment config', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      env: { production: {} },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { generated: true, now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'generated-config-has-env' }))
   })
 
   it('audits the effective policy of named environments', () => {
@@ -114,17 +481,17 @@ describe('diagnoseWranglerConfig', () => {
     expect(diagnostics).toContainEqual(expect.objectContaining({
       _tag: 'error',
       code: 'missing-nodejs-compat',
-      path: 'env.production.compatibility_flags',
+      configPath: 'env.production.compatibility_flags',
     }))
     expect(diagnostics).toContainEqual(expect.objectContaining({
       _tag: 'warning',
       code: 'observability-disabled',
-      path: 'env.production.observability.enabled',
+      configPath: 'env.production.observability.enabled',
     }))
     expect(diagnostics).toContainEqual(expect.objectContaining({
       _tag: 'warning',
       code: 'version-metadata-missing',
-      path: 'env.production.version_metadata',
+      configPath: 'env.production.version_metadata',
     }))
   })
 
@@ -144,9 +511,9 @@ describe('diagnoseWranglerConfig', () => {
     }, { now: new Date('2026-08-11T00:00:00Z') })
 
     expect(diagnostics).toContainEqual(expect.objectContaining({
-      _tag: 'error',
+      _tag: 'warning',
       code: 'plaintext-secret-var',
-      path: `vars.${name}`,
+      configPath: `vars.${name}`,
     }))
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The old existence-only check rejected `assets.run_worker_first: [\"/pro/_nuxt/*\"]` and blocked NuxtSEO's Pro build. Accept scoped Cloudflare route patterns while still rejecting blanket `true`, make Workers Caching an explicit version-aware policy, and extend the doctor and D1 helpers from the fleet audit.