### PR TITLE
fix(nuxt-cloudflare): make cache isolation explicit

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -58,7 +58,7 @@ export default defineNuxtConfig({
 
 Cloudflare KV requires TTLs of at least 60 seconds.
 
-Workers Caching is separate from Nitro's KV-backed cache. Enabling it lets Cloudflare serve responses without invoking the Worker. Keep `crossVersion: false` for deploy isolation; choose `true` only when stale responses across deployments are acceptable and a purge path exists. An authored `nitro.cloudflare.wrangler.cache` block is preserved unless `nuxtCloudflare.workersCache` is set.
+Workers Caching is separate from Nitro's KV-backed cache. Enabling it lets Cloudflare serve responses without invoking the Worker. Keep `crossVersion: false` for deploy isolation; choose `true` only when stale responses across deployments are acceptable and a purge path exists. An authored `nitro.cloudflare.wrangler.cache` block is preserved unless `nuxtCloudflare.workersCache` is set; omitted `cross_version_cache` is normalized to `false`.
 
 Smart Placement moves fetch handlers only when Cloudflare measures a faster location near upstream services. Assets-first delivery remains close to the user. Queue handlers, RPC methods, and named entrypoints are unaffected. An authored region, host, or hostname placement overrides the smart default.
 

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -63,7 +63,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.3',
+    version: '0.0.4',
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -162,6 +162,14 @@ function resolveWorkersCachePolicy(policy: WorkersCachePolicy): WranglerWorkersC
   return { enabled: true, cross_version_cache: policy.crossVersion }
 }
 
+function resolveAuthoredWorkersCache(
+  cache: WranglerWorkersCacheInput | undefined,
+): WranglerWorkersCacheInput {
+  if (!cache)
+    return resolveWorkersCachePolicy({ _tag: 'disabled' })
+  return { ...cache, cross_version_cache: cache.cross_version_cache ?? false }
+}
+
 const WRANGLER_BINDING_CATEGORIES = [
   'data_blobs',
   'durable_objects',
@@ -255,7 +263,7 @@ function applyEnvironmentDefaults(
   const compatibilityFlags = unique([...(config.compatibility_flags ?? inherited.compatibility_flags ?? []), 'nodejs_compat'])
   const cache = options.workersCache
     ? resolveWorkersCachePolicy(options.workersCache)
-    : config.cache ?? inherited.cache ?? resolveWorkersCachePolicy({ _tag: 'disabled' })
+    : resolveAuthoredWorkersCache(config.cache ?? inherited.cache)
   const requiredSecrets = unique([...(config.secrets?.required ?? []), ...(options.requiredSecrets ?? [])])
   const logs = config.observability?.logs
   const inheritedLogs = inherited.observability?.logs

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -43,6 +43,12 @@ describe('applyCloudflareDefaults', () => {
     }).cache).toEqual({ enabled: true, cross_version_cache: false })
   })
 
+  it('makes version isolation explicit for an enabled Workers Cache', () => {
+    expect(applyCloudflareDefaults({
+      cache: { enabled: true },
+    }).cache).toEqual({ enabled: true, cross_version_cache: false })
+  })
+
   it('lets an explicit module policy replace authored Workers Caching config', () => {
     expect(applyCloudflareDefaults({
       cache: { enabled: true, cross_version_cache: true },


### PR DESCRIPTION
## Summary

- normalize authored Workers Caching to `cross_version_cache: false` when omitted
- retain explicit cross-version opt-in
- release as 0.0.4

## Verification

- 107 tests pass
- fixture production build and doctor pass
- lint and typecheck pass
- package tarball verified