### PR TITLE
feat(nuxt-cloudflare): enable safe Workers Cache

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -12,7 +12,8 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 - Preview URLs disabled unless explicitly enabled
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
-- Workers Caching explicitly disabled by default; opt-in requires a version-sharing decision
+- Workers Caching enabled by default with per-version isolation
+- Dynamic responses default to `private, no-store`; rendered HTML is forcibly private and conflicting page route rules fail the build
 - Smart Placement enabled by default; explicit region, host, or hostname placement is preserved
 - Source-map upload when the Nitro build emits maps; explicit `false` is preserved
 - Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
@@ -31,7 +32,6 @@ export default defineNuxtConfig({
 
   nuxtCloudflare: {
     requiredSecrets: ['NUXT_SESSION_PASSWORD'],
-    workersCache: { _tag: 'enabled', crossVersion: false },
   },
 
   nitro: {
@@ -58,7 +58,17 @@ export default defineNuxtConfig({
 
 Cloudflare KV requires TTLs of at least 60 seconds.
 
-Workers Caching is separate from Nitro's KV-backed cache. Enabling it lets Cloudflare serve responses without invoking the Worker. Keep `crossVersion: false` for deploy isolation; choose `true` only when stale responses across deployments are acceptable and a purge path exists. An authored `nitro.cloudflare.wrangler.cache` block is preserved unless `nuxtCloudflare.workersCache` is set; omitted `cross_version_cache` is normalized to `false`.
+Workers Caching is separate from Nitro's KV-backed cache. It is enabled by default with `cross_version_cache: false`, so each deployment starts with an isolated cache. Dynamic Nitro responses default to `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store` unless they declare an explicit cache policy. Rendered HTML always receives those private directives; this is required because Cloudflare otherwise heuristically caches a `200` response with no cache header for two hours.
+
+HTML-capable route rules fail the build when they use `cache`, `isr`, `swr`, `Cache-Control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control`. API and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
+
+```ts
+export default defineNuxtConfig({
+  nuxtCloudflare: {
+    workersCache: { _tag: 'disabled' },
+  },
+})
+```
 
 Smart Placement moves fetch handlers only when Cloudflare measures a faster location near upstream services. Assets-first delivery remains close to the user. Queue handlers, RPC methods, and named entrypoints are unaffected. An authored region, host, or hostname placement overrides the smart default.
 

--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -60,7 +60,7 @@ Cloudflare KV requires TTLs of at least 60 seconds.
 
 Workers Caching is separate from Nitro's KV-backed cache. It is enabled by default with `cross_version_cache: false`, so each deployment starts with an isolated cache. Dynamic Nitro responses default to `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store` unless they declare an explicit cache policy. Rendered HTML always receives those private directives; this is required because Cloudflare otherwise heuristically caches a `200` response with no cache header for two hours.
 
-HTML-capable route rules fail the build when they use `cache`, `isr`, `swr`, `Cache-Control`, `CDN-Cache-Control`, or `Cloudflare-CDN-Cache-Control`. API and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
+HTML-capable route rules fail the build when they use `cache`, `isr`, `swr`, or publicly cacheable `Cache-Control`, `CDN-Cache-Control`, and `Cloudflare-CDN-Cache-Control` headers. Explicit `private` and `no-store` policies are safe. API and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
 
 ```ts
 export default defineNuxtConfig({

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",
@@ -99,6 +99,8 @@
     "@nuxt/kit": "catalog:",
     "citty": "catalog:",
     "consola": "catalog:",
+    "h3": "catalog:",
+    "nitropack": "catalog:",
     "pathe": "catalog:",
     "unstorage": "catalog:"
   },

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -63,7 +63,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.4',
+    version: '0.0.5',
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/html-cache.ts
+++ b/packages/nuxt-cloudflare/src/html-cache.ts
@@ -18,6 +18,7 @@ const CACHE_HEADER_NAMES = new Set([
   'cloudflare-cdn-cache-control',
 ])
 const CACHE_ROUTE_RULE_NAMES = ['cache', 'isr', 'swr'] as const
+const PRIVATE_CACHE_DIRECTIVE_RE = /(?:^|,)\s*(?:no-store|private)\s*(?:,|$)/i
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -27,6 +28,10 @@ function isHtmlCapableRoute(route: string): boolean {
   if (NON_HTML_EXTENSION_RE.test(route))
     return false
   return !NON_HTML_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`))
+}
+
+function isPrivateCachePolicy(value: unknown): boolean {
+  return typeof value === 'string' && PRIVATE_CACHE_DIRECTIVE_RE.test(value)
 }
 
 export function findHtmlCacheRouteRuleViolations(
@@ -54,7 +59,7 @@ export function findHtmlCacheRouteRuleViolations(
       return violations
 
     for (const name of Object.keys(value.headers)) {
-      if (CACHE_HEADER_NAMES.has(name.toLowerCase())) {
+      if (CACHE_HEADER_NAMES.has(name.toLowerCase()) && !isPrivateCachePolicy(value.headers[name])) {
         violations.push({
           _tag: 'html-cache-header',
           route,

--- a/packages/nuxt-cloudflare/src/html-cache.ts
+++ b/packages/nuxt-cloudflare/src/html-cache.ts
@@ -1,0 +1,75 @@
+export type HtmlCacheRouteRuleViolation
+  = | { _tag: 'html-cache-header', route: string, configPath: string }
+    | { _tag: 'html-cache-route-rule', route: string, configPath: string }
+
+const NON_HTML_ROUTE_PREFIXES = [
+  '/api',
+  '/_ipx',
+  '/_nuxt',
+  '/assets',
+  '/fonts',
+  '/images',
+] as const
+
+const NON_HTML_EXTENSION_RE = /\.(?:avif|css|csv|gif|ico|jpe?g|js|json|map|md|mjs|pdf|png|svg|txt|webmanifest|webp|woff2?|xml)(?:$|[?*])/i
+const CACHE_HEADER_NAMES = new Set([
+  'cache-control',
+  'cdn-cache-control',
+  'cloudflare-cdn-cache-control',
+])
+const CACHE_ROUTE_RULE_NAMES = ['cache', 'isr', 'swr'] as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isHtmlCapableRoute(route: string): boolean {
+  if (NON_HTML_EXTENSION_RE.test(route))
+    return false
+  return !NON_HTML_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`))
+}
+
+export function findHtmlCacheRouteRuleViolations(
+  routeRules: Record<string, unknown> | undefined,
+): HtmlCacheRouteRuleViolation[] {
+  if (!routeRules)
+    return []
+
+  return Object.entries(routeRules).flatMap(([route, value]) => {
+    if (!isHtmlCapableRoute(route) || !isRecord(value))
+      return []
+
+    const violations: HtmlCacheRouteRuleViolation[] = []
+    for (const name of CACHE_ROUTE_RULE_NAMES) {
+      if (value[name] !== undefined && value[name] !== false) {
+        violations.push({
+          _tag: 'html-cache-route-rule',
+          route,
+          configPath: `routeRules.${route}.${name}`,
+        })
+      }
+    }
+
+    if (!isRecord(value.headers))
+      return violations
+
+    for (const name of Object.keys(value.headers)) {
+      if (CACHE_HEADER_NAMES.has(name.toLowerCase())) {
+        violations.push({
+          _tag: 'html-cache-header',
+          route,
+          configPath: `routeRules.${route}.headers.${name}`,
+        })
+      }
+    }
+    return violations
+  })
+}
+
+export function formatHtmlCacheRouteRuleViolations(
+  violations: readonly HtmlCacheRouteRuleViolation[],
+): string {
+  return violations
+    .map(violation => `${violation.configPath}: Workers Caching requires HTML responses to remain private and no-store.`)
+    .join('\n')
+}

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -9,6 +9,7 @@ import {
   discoverWranglerSourceConfigs,
   evaluateWranglerDiagnostics,
 } from './diagnostics'
+import { findHtmlCacheRouteRuleViolations, formatHtmlCacheRouteRuleViolations } from './html-cache'
 import {
   applyCloudflareDefaults,
   diagnoseWranglerConfig,
@@ -45,12 +46,23 @@ export interface NitroCloudflareShape {
     wrangler?: import('./wrangler').WranglerConfigInput
   }
   preset?: string
+  plugins?: string[]
   sourceMap?: boolean
   storage?: Record<string, NitroStorageMount>
 }
 
 const logger = useLogger('nuxt-cloudflare')
 const cacheDriverPath = resolve(import.meta.dirname, import.meta.url.endsWith('.ts') ? 'storage.ts' : 'storage.mjs')
+const workersCachePluginPath = resolve(
+  import.meta.dirname,
+  import.meta.url.endsWith('.ts')
+    ? 'runtime/server/plugins/workers-cache.ts'
+    : 'runtime/server/plugins/workers-cache.js',
+)
+
+function resolveModuleWorkersCachePolicy(options: ModuleOptions): WorkersCachePolicy {
+  return options.workersCache ?? { _tag: 'enabled', crossVersion: false }
+}
 
 export function configureNitroCloudflare(
   nitro: NitroCloudflareShape,
@@ -68,8 +80,14 @@ export function configureNitroCloudflare(
     tracesSampleRate: options.tracesSampleRate,
     uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? nuxtServerSourceMaps ?? false,
     versionMetadataBinding: options.versionMetadataBinding,
-    workersCache: options.workersCache,
+    workersCache: resolveModuleWorkersCachePolicy(options),
   })
+
+  if (nitro.cloudflare.wrangler.cache?.enabled) {
+    nitro.plugins ??= []
+    if (!nitro.plugins.includes(workersCachePluginPath))
+      nitro.plugins.push(workersCachePluginPath)
+  }
 
   if (options.kvCache === false)
     return
@@ -131,6 +149,16 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   nuxt.hook('modules:done', () => {
     configure()
   })
+  nuxt.hook('nitro:config', (nitroConfig) => {
+    if (resolveModuleWorkersCachePolicy(options)._tag === 'disabled')
+      return
+    const violations = findHtmlCacheRouteRuleViolations(nitroConfig.routeRules)
+    if (violations.length > 0) {
+      throw new Error(
+        `[nuxt-cloudflare] HTML route rules conflict with Workers Caching:\n${formatHtmlCacheRouteRuleViolations(violations)}`,
+      )
+    }
+  })
   if (!nuxt.options.dev) {
     nuxt.hook('nitro:init', (nitro) => {
       nitro.hooks.hook('compiled', () => auditGeneratedWranglerConfig(nitro, options, nuxt.options.rootDir))
@@ -151,6 +179,7 @@ export default defineNuxtModule<ModuleOptions>({
     logsSampleRate: 0.1,
     tracesSampleRate: 0.01,
     versionMetadataBinding: 'CF_VERSION_METADATA',
+    workersCache: { _tag: 'enabled', crossVersion: false },
   },
   setup: setupCloudflareModule,
 })

--- a/packages/nuxt-cloudflare/src/runtime/server/plugins/workers-cache.ts
+++ b/packages/nuxt-cloudflare/src/runtime/server/plugins/workers-cache.ts
@@ -1,0 +1,16 @@
+import type { H3Event } from 'h3'
+import { getResponseHeader, setResponseHeader } from 'h3'
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { hasExplicitCachePolicy, withHtmlNoStoreHeaders } from '../utils/workers-cache'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:response', (response) => {
+    response.headers = withHtmlNoStoreHeaders(response.headers)
+  })
+  nitroApp.hooks.hook('beforeResponse', (event: H3Event) => {
+    if (hasExplicitCachePolicy(name => getResponseHeader(event, name)))
+      return
+    setResponseHeader(event, 'cache-control', 'private, no-store')
+    setResponseHeader(event, 'cloudflare-cdn-cache-control', 'no-store')
+  })
+})

--- a/packages/nuxt-cloudflare/src/runtime/server/utils/workers-cache.ts
+++ b/packages/nuxt-cloudflare/src/runtime/server/utils/workers-cache.ts
@@ -1,0 +1,27 @@
+const CACHE_POLICY_HEADER_NAMES = [
+  'cache-control',
+  'cdn-cache-control',
+  'cloudflare-cdn-cache-control',
+  'expires',
+] as const
+
+const HTML_CACHE_HEADER_NAMES: ReadonlySet<string> = new Set(CACHE_POLICY_HEADER_NAMES.slice(0, 3))
+
+export function hasExplicitCachePolicy(
+  getHeader: (name: string) => unknown,
+): boolean {
+  return CACHE_POLICY_HEADER_NAMES.some(name => Boolean(getHeader(name)))
+}
+
+export function withHtmlNoStoreHeaders(
+  headers: Record<string, string> = {},
+): Record<string, string> {
+  const preserved = Object.fromEntries(
+    Object.entries(headers).filter(([name]) => !HTML_CACHE_HEADER_NAMES.has(name.toLowerCase())),
+  )
+  return {
+    ...preserved,
+    'cache-control': 'private, no-store',
+    'cloudflare-cdn-cache-control': 'no-store',
+  }
+}

--- a/packages/nuxt-cloudflare/tests/html-cache.test.ts
+++ b/packages/nuxt-cloudflare/tests/html-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findHtmlCacheRouteRuleViolations,
+  formatHtmlCacheRouteRuleViolations,
+} from '../src/html-cache'
+import { hasExplicitCachePolicy, withHtmlNoStoreHeaders } from '../src/runtime/server/utils/workers-cache'
+
+describe('html cache route rules', () => {
+  it('rejects every cache mechanism on HTML-capable routes', () => {
+    const violations = findHtmlCacheRouteRuleViolations({
+      '/': { swr: 60 },
+      '/blog/**': { isr: 300 },
+      '/docs/**': {
+        headers: {
+          'Cache-Control': 'no-cache',
+          'Cloudflare-CDN-Cache-Control': 'public, max-age=3600',
+        },
+      },
+      '/shop/**': { cache: { maxAge: 60 } },
+    })
+
+    expect(violations).toEqual([
+      { _tag: 'html-cache-route-rule', route: '/', configPath: 'routeRules./.swr' },
+      { _tag: 'html-cache-route-rule', route: '/blog/**', configPath: 'routeRules./blog/**.isr' },
+      { _tag: 'html-cache-header', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cache-Control' },
+      { _tag: 'html-cache-header', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control' },
+      { _tag: 'html-cache-route-rule', route: '/shop/**', configPath: 'routeRules./shop/**.cache' },
+    ])
+    expect(formatHtmlCacheRouteRuleViolations(violations)).toContain('routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control')
+  })
+
+  it('allows cache rules on API and static asset routes', () => {
+    expect(findHtmlCacheRouteRuleViolations({
+      '/api/**': { cache: { maxAge: 60 } },
+      '/_nuxt/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/fonts/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/sitemap.xml': { headers: { 'cache-control': 'public, max-age=60' } },
+    })).toEqual([])
+  })
+})
+
+describe('html response cache safety', () => {
+  it('distinguishes explicit response policies from heuristic caching', () => {
+    const headers = new Map<string, string>()
+    expect(hasExplicitCachePolicy(name => headers.get(name))).toBe(false)
+    headers.set('cloudflare-cdn-cache-control', 'public, max-age=60')
+    expect(hasExplicitCachePolicy(name => headers.get(name))).toBe(true)
+  })
+
+  it('replaces every cache header with an explicit no-store policy', () => {
+    expect(withHtmlNoStoreHeaders({
+      'Cache-Control': 'public, max-age=3600',
+      'CDN-Cache-Control': 'public, max-age=3600',
+      'Cloudflare-CDN-Cache-Control': 'public, max-age=3600',
+      'x-test': 'preserved',
+    })).toEqual({
+      'cache-control': 'private, no-store',
+      'cloudflare-cdn-cache-control': 'no-store',
+      'x-test': 'preserved',
+    })
+  })
+})

--- a/packages/nuxt-cloudflare/tests/html-cache.test.ts
+++ b/packages/nuxt-cloudflare/tests/html-cache.test.ts
@@ -37,6 +37,18 @@ describe('html cache route rules', () => {
       '/sitemap.xml': { headers: { 'cache-control': 'public, max-age=60' } },
     })).toEqual([])
   })
+
+  it('allows an explicit private HTML cache policy', () => {
+    expect(findHtmlCacheRouteRuleViolations({
+      '/auth/**': {
+        cache: false,
+        headers: {
+          'cache-control': 'private, no-store',
+          'cloudflare-cdn-cache-control': 'no-store',
+        },
+      },
+    })).toEqual([])
+  })
 })
 
 describe('html response cache safety', () => {

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -43,15 +43,18 @@ describe('configureNitroCloudflare', () => {
     expect(nitro.cloudflare?.wrangler?.upload_source_maps).toBe(false)
   })
 
-  it('disables Workers Caching by default', () => {
+  it('enables version-isolated Workers Caching by default', () => {
     const nitro: NitroCloudflareShape = {}
 
     configureNitroCloudflare(nitro, {})
 
     expect(nitro.cloudflare?.wrangler?.cache).toEqual({
-      enabled: false,
+      enabled: true,
       cross_version_cache: false,
     })
+    expect(nitro.plugins).toEqual([
+      expect.stringMatching(/\/runtime\/server\/plugins\/workers-cache\.ts$/),
+    ])
   })
 
   it('enables Smart Placement by default', () => {
@@ -74,6 +77,19 @@ describe('configureNitroCloudflare', () => {
       cross_version_cache: false,
     })
   })
+
+  it('supports an explicit Workers Caching opt-out', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, {
+      workersCache: { _tag: 'disabled' },
+    })
+
+    expect(nitro.cloudflare?.wrangler?.cache).toEqual({
+      enabled: false,
+      cross_version_cache: false,
+    })
+  })
 })
 
 describe('setupCloudflareModule', () => {
@@ -82,7 +98,7 @@ describe('setupCloudflareModule', () => {
 
     setupCloudflareModule({ enabled: true }, nuxt)
 
-    expect(hooks).toEqual(['modules:done'])
+    expect(hooks).toEqual(['modules:done', 'nitro:config'])
   })
 
   it('registers the production Wrangler audit for builds', () => {
@@ -90,7 +106,7 @@ describe('setupCloudflareModule', () => {
 
     setupCloudflareModule({ enabled: true }, nuxt)
 
-    expect(hooks).toEqual(['modules:done', 'nitro:init'])
+    expect(hooks).toEqual(['modules:done', 'nitro:config', 'nitro:init'])
   })
 
   it('uses Nuxt server source maps as the upload policy', () => {

--- a/packages/nuxt-cloudflare/tests/nuxt.test.ts
+++ b/packages/nuxt-cloudflare/tests/nuxt.test.ts
@@ -24,12 +24,34 @@ describe('nuxt integration', () => {
     expect(nitro.cloudflare?.deployConfig).toBe(true)
     expect(nitro.cloudflare?.nodeCompat).toBe(true)
     expect(nitro.cloudflare?.wrangler).toMatchObject({
+      cache: { enabled: true, cross_version_cache: false },
       compatibility_flags: ['nodejs_compat'],
       secrets: { required: ['SESSION_PASSWORD'] },
       upload_source_maps: false,
       version_metadata: { binding: 'CF_VERSION_METADATA' },
     })
     expect(nitro.storage?.cache?.driver).toMatch(/\/src\/storage\.ts$/)
+    await nuxt.close()
+  })
+
+  it('blocks an HTML route rule that can populate Workers Cache', async () => {
+    const nuxt = await loadNuxt({
+      cwd: import.meta.dirname,
+      dev: true,
+      ready: false,
+      overrides: {
+        modules: [cloudflareModule],
+      },
+    })
+
+    await nuxt.ready()
+    await expect(nuxt.callHook('nitro:config', {
+      routeRules: {
+        '/docs/**': {
+          headers: { 'cloudflare-cdn-cache-control': 'public, max-age=3600' },
+        },
+      },
+    } as never)).rejects.toThrow('routeRules./docs/**.headers.cloudflare-cdn-cache-control')
     await nuxt.close()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,12 +209,18 @@ importers:
       consola:
         specifier: 'catalog:'
         version: 3.4.2
+      h3:
+        specifier: 'catalog:'
+        version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      nitropack:
+        specifier: 'catalog:'
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
       unstorage:
         specifier: 'catalog:'
-        version: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+        version: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -239,7 +245,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)
       nuxt:
         specifier: 'catalog:'
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -7285,7 +7291,7 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -7315,7 +7321,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
@@ -7467,7 +7473,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7553,7 +7559,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7639,7 +7645,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -10863,7 +10869,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -10958,7 +10964,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(ad8465325b42189410837bc3399b38ea)
       '@nuxt/schema': 4.5.2
@@ -11099,7 +11105,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(306b7872170b5fee229ee019d68f27d2)
       '@nuxt/schema': 4.5.2
@@ -11240,7 +11246,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(1ddd60ae9f6acff327e58c4f29acd342)
       '@nuxt/schema': 4.5.2
@@ -12604,7 +12610,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1):
+  unstorage@1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0


### PR DESCRIPTION
## Summary

- enable Workers Caching by default with per-version isolation
- default dynamic responses to private no-store unless explicitly cacheable
- force rendered HTML to private no-store
- reject HTML route rules using cache, ISR, SWR, or cache headers
- retain an explicit gateway opt-out

## Verification

- failing cache-default regression observed first
- 113 tests pass
- fixture production build and doctor pass
- local Wrangler response proves HTML no-store headers
- lint, typecheck, and package tarball pass