### PR TITLE
fix(nuxt-cloudflare): classify cache route diagnostics

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -13,7 +13,7 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
 - Workers Caching enabled by default with per-version isolation
-- Dynamic responses default to `private, no-store`; rendered HTML is forcibly private and conflicting page route rules fail the build
+- Dynamic responses default to `private, no-store`; rendered HTML is forcibly private and conflicting route rules are diagnosed
 - Smart Placement enabled by default; explicit region, host, or hostname placement is preserved
 - Source-map upload when the Nitro build emits maps; explicit `false` is preserved
 - Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
@@ -60,7 +60,7 @@ Cloudflare KV requires TTLs of at least 60 seconds.
 
 Workers Caching is separate from Nitro's KV-backed cache. It is enabled by default with `cross_version_cache: false`, so each deployment starts with an isolated cache. Dynamic Nitro responses default to `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store` unless they declare an explicit cache policy. Rendered HTML always receives those private directives; this is required because Cloudflare otherwise heuristically caches a `200` response with no cache header for two hours.
 
-HTML-capable route rules fail the build when they use `cache`, `isr`, `swr`, or publicly cacheable `Cache-Control`, `CDN-Cache-Control`, and `Cloudflare-CDN-Cache-Control` headers. Explicit `private` and `no-store` policies are safe. API and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
+Potential HTML route rules warn when they use `cache`, `isr`, `swr`, or publicly cacheable `Cache-Control`, `CDN-Cache-Control`, and `Cloudflare-CDN-Cache-Control` headers. Rules proven to be HTML through prerendering, a `.html` path, or an explicit `text/html` content type fail the build. Explicit `private` and `no-store` policies are safe. API, Nuxt OG Image, and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
 
 ```ts
 export default defineNuxtConfig({

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -63,7 +63,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.5',
+    version: '0.0.6',
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/html-cache.ts
+++ b/packages/nuxt-cloudflare/src/html-cache.ts
@@ -1,11 +1,12 @@
 export type HtmlCacheRouteRuleViolation
-  = | { _tag: 'html-cache-header', route: string, configPath: string }
-    | { _tag: 'html-cache-route-rule', route: string, configPath: string }
+  = | { _tag: 'html-cache-header', severity: 'error' | 'warning', route: string, configPath: string }
+    | { _tag: 'html-cache-route-rule', severity: 'error' | 'warning', route: string, configPath: string }
 
 const NON_HTML_ROUTE_PREFIXES = [
   '/api',
   '/_ipx',
   '/_nuxt',
+  '/_og',
   '/assets',
   '/fonts',
   '/images',
@@ -34,6 +35,21 @@ function isPrivateCachePolicy(value: unknown): boolean {
   return typeof value === 'string' && PRIVATE_CACHE_DIRECTIVE_RE.test(value)
 }
 
+function hasHtmlContentType(headers: Record<string, unknown> | undefined): boolean {
+  if (!headers)
+    return false
+  const contentType = Object.entries(headers)
+    .find(([name]) => name.toLowerCase() === 'content-type')?.[1]
+  return typeof contentType === 'string' && /^text\/html(?:;|$)/i.test(contentType)
+}
+
+function resolveViolationSeverity(route: string, value: Record<string, unknown>): 'error' | 'warning' {
+  const definitelyHtml = value.prerender === true
+    || /\.html(?:$|[?*])/i.test(route)
+    || hasHtmlContentType(isRecord(value.headers) ? value.headers : undefined)
+  return definitelyHtml ? 'error' : 'warning'
+}
+
 export function findHtmlCacheRouteRuleViolations(
   routeRules: Record<string, unknown> | undefined,
 ): HtmlCacheRouteRuleViolation[] {
@@ -44,11 +60,13 @@ export function findHtmlCacheRouteRuleViolations(
     if (!isHtmlCapableRoute(route) || !isRecord(value))
       return []
 
+    const severity = resolveViolationSeverity(route, value)
     const violations: HtmlCacheRouteRuleViolation[] = []
     for (const name of CACHE_ROUTE_RULE_NAMES) {
       if (value[name] !== undefined && value[name] !== false) {
         violations.push({
           _tag: 'html-cache-route-rule',
+          severity,
           route,
           configPath: `routeRules.${route}.${name}`,
         })
@@ -62,6 +80,7 @@ export function findHtmlCacheRouteRuleViolations(
       if (CACHE_HEADER_NAMES.has(name.toLowerCase()) && !isPrivateCachePolicy(value.headers[name])) {
         violations.push({
           _tag: 'html-cache-header',
+          severity,
           route,
           configPath: `routeRules.${route}.headers.${name}`,
         })
@@ -75,6 +94,9 @@ export function formatHtmlCacheRouteRuleViolations(
   violations: readonly HtmlCacheRouteRuleViolation[],
 ): string {
   return violations
-    .map(violation => `${violation.configPath}: Workers Caching requires HTML responses to remain private and no-store.`)
+    .map((violation) => {
+      const subject = violation.severity === 'error' ? 'HTML route' : 'Potential HTML route'
+      return `${violation.configPath}: ${subject} must remain private and no-store when Workers Cache is enabled.`
+    })
     .join('\n')
 }

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -153,9 +153,13 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
     if (resolveModuleWorkersCachePolicy(options)._tag === 'disabled')
       return
     const violations = findHtmlCacheRouteRuleViolations(nitroConfig.routeRules)
-    if (violations.length > 0) {
+    const warnings = violations.filter(violation => violation.severity === 'warning')
+    const errors = violations.filter(violation => violation.severity === 'error')
+    if (warnings.length > 0)
+      logger.warn(formatHtmlCacheRouteRuleViolations(warnings))
+    if (errors.length > 0) {
       throw new Error(
-        `[nuxt-cloudflare] HTML route rules conflict with Workers Caching:\n${formatHtmlCacheRouteRuleViolations(violations)}`,
+        `[nuxt-cloudflare] HTML route rules conflict with Workers Caching:\n${formatHtmlCacheRouteRuleViolations(errors)}`,
       )
     }
   })

--- a/packages/nuxt-cloudflare/tests/html-cache.test.ts
+++ b/packages/nuxt-cloudflare/tests/html-cache.test.ts
@@ -6,10 +6,10 @@ import {
 import { hasExplicitCachePolicy, withHtmlNoStoreHeaders } from '../src/runtime/server/utils/workers-cache'
 
 describe('html cache route rules', () => {
-  it('rejects every cache mechanism on HTML-capable routes', () => {
+  it('warns for ambiguous routes and rejects only explicit HTML routes', () => {
     const violations = findHtmlCacheRouteRuleViolations({
       '/': { swr: 60 },
-      '/blog/**': { isr: 300 },
+      '/blog/**': { isr: 300, prerender: true },
       '/docs/**': {
         headers: {
           'Cache-Control': 'no-cache',
@@ -20,11 +20,11 @@ describe('html cache route rules', () => {
     })
 
     expect(violations).toEqual([
-      { _tag: 'html-cache-route-rule', route: '/', configPath: 'routeRules./.swr' },
-      { _tag: 'html-cache-route-rule', route: '/blog/**', configPath: 'routeRules./blog/**.isr' },
-      { _tag: 'html-cache-header', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cache-Control' },
-      { _tag: 'html-cache-header', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control' },
-      { _tag: 'html-cache-route-rule', route: '/shop/**', configPath: 'routeRules./shop/**.cache' },
+      { _tag: 'html-cache-route-rule', severity: 'warning', route: '/', configPath: 'routeRules./.swr' },
+      { _tag: 'html-cache-route-rule', severity: 'error', route: '/blog/**', configPath: 'routeRules./blog/**.isr' },
+      { _tag: 'html-cache-header', severity: 'warning', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cache-Control' },
+      { _tag: 'html-cache-header', severity: 'warning', route: '/docs/**', configPath: 'routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control' },
+      { _tag: 'html-cache-route-rule', severity: 'warning', route: '/shop/**', configPath: 'routeRules./shop/**.cache' },
     ])
     expect(formatHtmlCacheRouteRuleViolations(violations)).toContain('routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control')
   })
@@ -32,6 +32,9 @@ describe('html cache route rules', () => {
   it('allows cache rules on API and static asset routes', () => {
     expect(findHtmlCacheRouteRuleViolations({
       '/api/**': { cache: { maxAge: 60 } },
+      '/_og/d/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/_og/r/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/_og/s/**': { headers: { 'cache-control': 'public, immutable' } },
       '/_nuxt/**': { headers: { 'cache-control': 'public, immutable' } },
       '/fonts/**': { headers: { 'cache-control': 'public, immutable' } },
       '/sitemap.xml': { headers: { 'cache-control': 'public, max-age=60' } },

--- a/packages/nuxt-cloudflare/tests/nuxt.test.ts
+++ b/packages/nuxt-cloudflare/tests/nuxt.test.ts
@@ -34,7 +34,7 @@ describe('nuxt integration', () => {
     await nuxt.close()
   })
 
-  it('blocks an HTML route rule that can populate Workers Cache', async () => {
+  it('warns for ambiguous cache rules and blocks prerendered HTML cache rules', async () => {
     const nuxt = await loadNuxt({
       cwd: import.meta.dirname,
       dev: true,
@@ -46,8 +46,18 @@ describe('nuxt integration', () => {
 
     await nuxt.ready()
     await expect(nuxt.callHook('nitro:config', {
+      virtual: {},
       routeRules: {
         '/docs/**': {
+          headers: { 'cloudflare-cdn-cache-control': 'public, max-age=3600' },
+        },
+      },
+    } as never)).resolves.toBeUndefined()
+    await expect(nuxt.callHook('nitro:config', {
+      virtual: {},
+      routeRules: {
+        '/docs/**': {
+          prerender: true,
           headers: { 'cloudflare-cdn-cache-control': 'public, max-age=3600' },
         },
       },


### PR DESCRIPTION
## Summary

- exempt Nuxt OG Image routes from HTML cache diagnostics
- warn for ambiguous extensionless routes
- block only prerendered, `.html`, or explicit `text/html` routes
- retain runtime no-store enforcement for rendered HTML

## Verification

- 114 tests pass
- lint passes
- Nuxt and TypeScript typechecks pass
- production fixture build and doctor pass
- package tarball includes runtime cache protection