### PR TITLE
feat(nuxt-cloudflare): enforce platform deployment safeguards

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -7,19 +7,20 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 ## Defaults
 
 - Cloudflare module preset, generated Wrangler config, and Node compatibility
-- Static assets remain asset first by default. Blanket `assets.run_worker_first: true` fails the build and `doctor`; narrow route-pattern arrays remain available for intentional middleware and skew recovery
+- Static assets remain asset first by default. Blanket `assets.run_worker_first: true` warns because valid authentication and transform use cases exist
 - Workers Logs sampled at 10%, traces at 1%, both overridable
 - Preview URLs disabled unless explicitly enabled
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
-- Workers Caching enabled by default with per-version isolation
-- Dynamic responses default to `private, no-store`; rendered HTML is forcibly private and conflicting route rules are diagnosed
-- Smart Placement enabled by default; explicit region, host, or hostname placement is preserved
+- Smart Placement enabled unless the project chooses a placement
+- Workers Caching enabled with version isolation
+- Rendered HTML forced to `private, no-store`; explicit non-HTML cache policies remain intact
 - Source-map upload when the Nitro build emits maps; explicit `false` is preserved
 - Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
 - Version metadata is skipped when `CF_VERSION_METADATA` already names another binding
 - Raw `cloudflare-kv-binding` on Nitro's `cache` mount upgraded to a 30-day physical expiry
-- Final generated Wrangler config audited after production Nitro compiles
+- Final generated Wrangler config validated through Wrangler, then audited after production Nitro compiles
+- Production builds fail when server runtime config contains a value copied from a secret build environment variable. The error lists config paths only
 - Complete defaults and diagnostics applied to every named Wrangler environment
 
 Persistent KV mounts are never wrapped. The expiry policy applies only to cache data.
@@ -56,21 +57,11 @@ export default defineNuxtConfig({
 })
 ```
 
-Cloudflare KV requires TTLs of at least 60 seconds.
+Cloudflare KV requires TTLs of at least 60 seconds. The cache wrapper raises shorter positive TTLs to 60 seconds.
 
-Workers Caching is separate from Nitro's KV-backed cache. It is enabled by default with `cross_version_cache: false`, so each deployment starts with an isolated cache. Dynamic Nitro responses default to `Cache-Control: private, no-store` and `Cloudflare-CDN-Cache-Control: no-store` unless they declare an explicit cache policy. Rendered HTML always receives those private directives; this is required because Cloudflare otherwise heuristically caches a `200` response with no cache header for two hours.
+Keep server runtime secret defaults empty. Nuxt reads matching `NUXT_*` values from Worker secret bindings at runtime. The production build guard rejects secret build environment values before Nitro can include them in the bundle. Nuxt Scripts proxy signing remains allowed because that module registers its security plugin during the build.
 
-Potential HTML route rules warn when they use `cache`, `isr`, `swr`, or publicly cacheable `Cache-Control`, `CDN-Cache-Control`, and `Cloudflare-CDN-Cache-Control` headers. Rules proven to be HTML through prerendering, a `.html` path, or an explicit `text/html` content type fail the build. Explicit `private` and `no-store` policies are safe. API, Nuxt OG Image, and static asset routes remain available for explicit caching. Disable Workers Caching only for a gateway that must execute on every request:
-
-```ts
-export default defineNuxtConfig({
-  nuxtCloudflare: {
-    workersCache: { _tag: 'disabled' },
-  },
-})
-```
-
-Smart Placement moves fetch handlers only when Cloudflare measures a faster location near upstream services. Assets-first delivery remains close to the user. Queue handlers, RPC methods, and named entrypoints are unaffected. An authored region, host, or hostname placement overrides the smart default.
+Workers Caching is separate from Nitro's KV-backed cache. The module enables version-isolated caching by default. Rendered HTML always stays private. API and asset responses keep explicit cache policies. Set `workersCache: { _tag: 'disabled' }` to opt out. Choose cross-version caching only with an explicit purge path.
 
 ## Doctor
 
@@ -84,7 +75,7 @@ pnpm nuxt-cloudflare doctor --strict --allow-warning source-maps-disabled
 
 The CLI reads Wrangler config through Wrangler itself, so JSON, JSONC, TOML, environments, upward lookup, and Nitro generated-config redirects follow deployment semantics. It separately inspects root authoring format. Existing TOML remains supported and receives non-blocking guidance because Cloudflare recommends JSONC for new projects. Shadowed root configs warn because they can silently drift.
 
-Errors cover blanket Worker-first assets, malformed selective asset patterns, missing `nodejs_compat`, malformed compatibility dates, secret names duplicated across `vars` and `secrets.required`, queue platform-limit violations, and unflattened generated environments. Warnings cover secret-looking variable names, telemetry gaps, stale dates, implicit or cross-version Workers Caching, `keep_vars`, public endpoints, preview URLs, missing DLQs, and project policy. Secret values are never included.
+Errors cover malformed asset patterns, invalid Durable Object lifecycles, invalid Container storage, queue limits, unsafe example bindings, and unflattened generated environments. Warnings cover blanket Worker-first assets, missing environment bindings, unrestricted email, local service fidelity, deprecated fields, telemetry gaps, and public endpoints. Secret values are never included.
 
 Normal mode fails errors. `--strict` also fails warnings. Intentional exceptions remain visible and may be listed with `--allow-warning`. Module builds use the equivalent policy:
 
@@ -113,6 +104,14 @@ pnpm wrangler check startup --config .output/server/wrangler.json
 
 Pass the final generated config explicitly to `types` and `check startup`; Nitro's `.wrangler/deploy/config.json` redirect does not apply to those commands.
 
+### Product guidance
+
+- Named environments do not inherit bindings. The doctor reports each omitted root binding.
+- AI, Browser, Images, mTLS, Vectorize, and Flagship warn when local development omits `remote: true`.
+- Every Container must match a local SQLite Durable Object. Legacy `dev` and `standard` instance types warn.
+- Email bindings should restrict senders or destinations.
+- Legacy module bindings and the old Pipeline `pipeline` field warn with their current replacements.
+
 ## Runtime primitives
 
 ### D1 sessions and safe retries
@@ -128,7 +127,7 @@ await retryIdempotentD1Write({
 })
 ```
 
-One `first-primary` session is cached per request and binding. D1 already retries read-only queries. Write retries require an explicit safety tag. `lock-only` retries SQLite lock contention; `replay-safe` also permits classified transient network and reset failures.
+One `first-primary` session is cached per request and binding. D1 already retries read-only queries. Write retries require an explicit safety tag. `lock-only` retries SQLite lock contention; `replay-safe` also permits classified network and storage reset failures. Resource pressure, queue delay, CPU, and memory errors are never retried.
 
 ### D1 parameter plans
 
@@ -190,7 +189,7 @@ The writer uses exclusive creation and mode 0600. It removes partial files after
 
 ## Deliberate boundaries
 
-The module does not choose Worker names, routes, domains, resource IDs, CPU limits, queue jobs, R2 deletion policy, or deployment promotion. `@harlan-zw/nuxt-cf-jobs` continues to own queues, job durability, recovery, and outbox behavior.
+The module does not choose Worker names, routes, domains, resource IDs, placement, CPU limits, queue jobs, R2 deletion policy, or deployment promotion. `@harlan-zw/nuxt-cf-jobs` continues to own queues, job durability, recovery, and outbox behavior.
 
 Next high-value extractions from Nuxt SEO and gscdump:
 

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -63,7 +63,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.6',
+    version: '0.0.7',
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/d1.ts
+++ b/packages/nuxt-cloudflare/src/d1.ts
@@ -43,13 +43,10 @@ export type D1RetryErrorKind
 const REQUEST_D1_SESSIONS = Symbol.for('@harlan-zw/nuxt-cloudflare:d1-sessions')
 const TRANSIENT_D1_SIGNALS = [
   'Network connection lost',
-  'operation was aborted',
-  'overloaded',
-  'Requests queued for too long',
-  'exceeded its CPU time limit',
+  'D1 DB reset because its code was updated',
+  'Internal error while starting up D1 DB storage caused object to be reset',
+  'Internal error in D1 DB storage caused object to be reset',
   'storage caused object to be reset',
-  'reset because its code was updated',
-  'Internal error in D1',
   'cannot resolve d1 db due to transient issue on remote node',
 ] as const
 

--- a/packages/nuxt-cloudflare/src/doctor.ts
+++ b/packages/nuxt-cloudflare/src/doctor.ts
@@ -42,7 +42,7 @@ export function diagnoseWranglerProject(options: DiagnoseWranglerProjectOptions)
   return {
     configPath: loaded.path,
     diagnostics: [
-      ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated }),
+      ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated, normalized: true }),
       ...diagnoseWranglerSourceConfigs(sourceConfigPaths),
     ],
     sourceConfigPaths,

--- a/packages/nuxt-cloudflare/src/html-cache.ts
+++ b/packages/nuxt-cloudflare/src/html-cache.ts
@@ -3,6 +3,7 @@ export type HtmlCacheRouteRuleViolation
     | { _tag: 'html-cache-route-rule', severity: 'error' | 'warning', route: string, configPath: string }
 
 const NON_HTML_ROUTE_PREFIXES = [
+  '/.well-known',
   '/api',
   '/_ipx',
   '/_nuxt',
@@ -10,9 +11,11 @@ const NON_HTML_ROUTE_PREFIXES = [
   '/assets',
   '/fonts',
   '/images',
+  '/mcp',
 ] as const
 
 const NON_HTML_EXTENSION_RE = /\.(?:avif|css|csv|gif|ico|jpe?g|js|json|map|md|mjs|pdf|png|svg|txt|webmanifest|webp|woff2?|xml)(?:$|[?*])/i
+const HTML_CONTENT_TYPE_RE = /^(?:application\/xhtml\+xml|text\/html)(?:\s*;|$)/i
 const CACHE_HEADER_NAMES = new Set([
   'cache-control',
   'cdn-cache-control',
@@ -25,22 +28,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function isHtmlCapableRoute(route: string): boolean {
-  if (NON_HTML_EXTENSION_RE.test(route))
+function findHeader(headers: Record<string, unknown>, name: string): unknown {
+  const entry = Object.entries(headers).find(([header]) => header.toLowerCase() === name)
+  return entry?.[1]
+}
+
+function hasExplicitNonHtmlContentType(value: Record<string, unknown>): boolean {
+  if (!isRecord(value.headers))
+    return false
+  const contentType = findHeader(value.headers, 'content-type')
+  return typeof contentType === 'string' && !HTML_CONTENT_TYPE_RE.test(contentType)
+}
+
+function hasHtmlContentType(headers: Record<string, unknown> | undefined): boolean {
+  if (!headers)
+    return false
+  const contentType = findHeader(headers, 'content-type')
+  return typeof contentType === 'string' && HTML_CONTENT_TYPE_RE.test(contentType)
+}
+
+function isHtmlCapableRoute(route: string, value: Record<string, unknown>): boolean {
+  if (NON_HTML_EXTENSION_RE.test(route) || hasExplicitNonHtmlContentType(value))
     return false
   return !NON_HTML_ROUTE_PREFIXES.some(prefix => route === prefix || route.startsWith(`${prefix}/`))
 }
 
 function isPrivateCachePolicy(value: unknown): boolean {
   return typeof value === 'string' && PRIVATE_CACHE_DIRECTIVE_RE.test(value)
-}
-
-function hasHtmlContentType(headers: Record<string, unknown> | undefined): boolean {
-  if (!headers)
-    return false
-  const contentType = Object.entries(headers)
-    .find(([name]) => name.toLowerCase() === 'content-type')?.[1]
-  return typeof contentType === 'string' && /^text\/html(?:;|$)/i.test(contentType)
 }
 
 function resolveViolationSeverity(route: string, value: Record<string, unknown>): 'error' | 'warning' {
@@ -57,7 +71,7 @@ export function findHtmlCacheRouteRuleViolations(
     return []
 
   return Object.entries(routeRules).flatMap(([route, value]) => {
-    if (!isHtmlCapableRoute(route) || !isRecord(value))
+    if (!isRecord(value) || !isHtmlCapableRoute(route, value))
       return []
 
     const severity = resolveViolationSeverity(route, value)

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -2,6 +2,7 @@ import type { Nuxt } from '@nuxt/schema'
 import type { Nitro } from 'nitropack/types'
 import type { WranglerDiagnosticPolicy } from './diagnostics'
 import type { WorkersCachePolicy } from './wrangler'
+import process from 'node:process'
 import { defineNuxtModule, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import {
@@ -59,9 +60,44 @@ const workersCachePluginPath = resolve(
     ? 'runtime/server/plugins/workers-cache.ts'
     : 'runtime/server/plugins/workers-cache.js',
 )
+const BUILD_SECRET_ENV_RE = /(?:^|_)(?:API_?KEY|AUTH_TOKEN|CLIENT_SECRET|CREDENTIALS?|ENCRYPTION_KEY|PASSWORD|PRIVATE_KEY|SECRET|SIGNING_KEY|TOKEN|SALT)(?:_|$)/i
+// Nuxt Scripts must resolve this value during setup to register its signed proxy plugin.
+const REQUIRED_BUILD_SECRET_NAMES = new Set(['NUXT_SCRIPTS_PROXY_SECRET'])
 
 function resolveModuleWorkersCachePolicy(options: ModuleOptions): WorkersCachePolicy {
   return options.workersCache ?? { _tag: 'enabled', crossVersion: false }
+}
+
+export function findPopulatedRuntimeSecretPaths(
+  config: unknown,
+  environment: Readonly<Record<string, string | undefined>>,
+): string[] {
+  const paths: string[] = []
+  const buildSecretValues = new Set(Object.entries(environment).flatMap(([name, value]) => {
+    return BUILD_SECRET_ENV_RE.test(name)
+      && !REQUIRED_BUILD_SECRET_NAMES.has(name)
+      && value
+      && value.length >= 8
+      ? [value]
+      : []
+  }))
+  const visit = (value: unknown, parents: string[]): void => {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      return
+    for (const [key, child] of Object.entries(value)) {
+      const path = [...parents, key]
+      if (path[0] === 'public')
+        continue
+      if (child && typeof child === 'object' && !Array.isArray(child)) {
+        visit(child, path)
+        continue
+      }
+      if (typeof child === 'string' && buildSecretValues.has(child))
+        paths.push(path.join('.'))
+    }
+  }
+  visit(config, [])
+  return paths
 }
 
 export function configureNitroCloudflare(
@@ -113,6 +149,11 @@ async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions
     throw new Error(`[nuxt-cloudflare] Generated Wrangler config is missing: ${path}`)
   if (result._tag === 'invalid')
     throw new Error(`[nuxt-cloudflare] Generated Wrangler config is invalid: ${result.reason}`)
+  // Keep Wrangler's CLI runtime out of Nuxt module evaluation and development startup.
+  const { readProjectWranglerConfig } = await import('./wrangler-reader')
+  const validated = readProjectWranglerConfig({ config: path, cwd: rootDir })
+  if (validated._tag === 'invalid')
+    throw new Error('[nuxt-cloudflare] Generated Wrangler config fails Wrangler schema validation. Run Wrangler locally for validation details.')
 
   const diagnostics = [
     ...diagnoseWranglerConfig(result.config, {
@@ -148,6 +189,12 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   configure()
   nuxt.hook('modules:done', () => {
     configure()
+    if (nuxt.options.dev)
+      return
+    const populatedRuntimeSecrets = findPopulatedRuntimeSecretPaths(nuxt.options.runtimeConfig, process.env)
+    if (populatedRuntimeSecrets.length > 0) {
+      throw new Error(`[nuxt-cloudflare] Runtime config contains secret build environment values: ${populatedRuntimeSecrets.join(', ')}. Keep defaults empty and use Worker secret bindings.`)
+    }
   })
   nuxt.hook('nitro:config', (nitroConfig) => {
     if (resolveModuleWorkersCachePolicy(options)._tag === 'disabled')

--- a/packages/nuxt-cloudflare/src/storage.ts
+++ b/packages/nuxt-cloudflare/src/storage.ts
@@ -30,7 +30,7 @@ export function withDefaultKvExpiration<Options, Instance>(
     setItem(key: string, value: string, transactionOptions: TransactionOptions = {}) {
       const requestedTtl = Number(transactionOptions.ttl)
       const ttl = Number.isFinite(requestedTtl) && requestedTtl > 0
-        ? requestedTtl
+        ? Math.max(requestedTtl, 60)
         : parsedDefaultTtl
       return setItem(key, value, { ...transactionOptions, ttl })
     },

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -17,6 +17,17 @@ export type WranglerPlacementInput
     | { hostname: string, host?: never, mode?: never, region?: never }
     | { region: string, host?: never, hostname?: never, mode?: never }
 
+export interface WranglerRemoteBindingInput extends Record<string, unknown> {
+  binding?: string
+  remote?: boolean
+}
+
+export interface WranglerContainerInput extends Record<string, unknown> {
+  class_name?: string
+  image?: string
+  instance_type?: string | Record<string, unknown>
+}
+
 export type WorkersCachePolicy
   = | { _tag: 'disabled' }
     | { _tag: 'enabled', crossVersion: boolean }
@@ -36,12 +47,17 @@ export interface WranglerObservabilityInput {
 }
 
 export interface WranglerConfigInput extends Record<string, unknown> {
+  ai?: WranglerRemoteBindingInput
   assets?: WranglerAssetsInput
+  browser?: WranglerRemoteBindingInput
   cache?: WranglerWorkersCacheInput
   compatibility_date?: string
   compatibility_flags?: string[]
+  containers?: WranglerContainerInput[]
   env?: Record<string, WranglerConfigInput>
+  images?: WranglerRemoteBindingInput
   keep_vars?: boolean
+  mtls_certificates?: WranglerRemoteBindingInput[]
   observability?: WranglerObservabilityInput
   placement?: WranglerPlacementInput
   preview_urls?: boolean
@@ -54,6 +70,7 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   secrets?: {
     required?: string[]
   }
+  vectorize?: WranglerRemoteBindingInput[]
   upload_source_maps?: boolean
   vars?: Record<string, unknown>
   version_metadata?: {
@@ -77,11 +94,17 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'assets-worker-first-pattern-invalid',
   'compatibility-date-missing',
   'compatibility-date-invalid',
+  'container-durable-object-binding-missing',
+  'container-durable-object-not-sqlite',
+  'container-instance-type-deprecated',
   'durable-object-binding-inactive',
   'durable-object-lifecycle-mixed',
   'durable-object-lifecycle-unmanaged',
+  'email-binding-unrestricted',
+  'environment-binding-missing',
   'generated-config-has-env',
   'keep-vars-enabled',
+  'legacy-module-binding',
   'missing-nodejs-compat',
   'nodejs-compat-version-implicit',
   'observability-disabled',
@@ -89,6 +112,7 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'observability-sampling-out-of-range',
   'plaintext-secret-var',
   'preview-urls-public',
+  'pipeline-binding-deprecated',
   'queue-dlq-missing',
   'queue-retries-above-policy',
   'queue-retries-out-of-range',
@@ -97,6 +121,8 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'source-maps-disabled',
   'stale-compatibility-date',
   'traces-disabled',
+  'remote-binding-not-enabled',
+  'unsafe-hello-world-binding',
   'version-metadata-missing',
   'workers-dev-enabled',
   'workers-dev-implicit',
@@ -122,6 +148,7 @@ export interface WranglerDiagnosticOptions {
   compatibilityMaxAgeDays?: number
   generated?: boolean
   now?: Date
+  normalized?: boolean
   publicVarNames?: readonly string[]
   requireNodeCompat?: boolean
 }
@@ -162,14 +189,6 @@ function resolveWorkersCachePolicy(policy: WorkersCachePolicy): WranglerWorkersC
   return { enabled: true, cross_version_cache: policy.crossVersion }
 }
 
-function resolveAuthoredWorkersCache(
-  cache: WranglerWorkersCacheInput | undefined,
-): WranglerWorkersCacheInput {
-  if (!cache)
-    return resolveWorkersCachePolicy({ _tag: 'disabled' })
-  return { ...cache, cross_version_cache: cache.cross_version_cache ?? false }
-}
-
 const WRANGLER_BINDING_CATEGORIES = [
   'data_blobs',
   'durable_objects',
@@ -203,41 +222,148 @@ const WRANGLER_BINDING_CATEGORIES = [
   'secrets_store_secrets',
   'artifacts',
   'ratelimits',
+  'worker_loaders',
+  'vpc_services',
+  'vpc_networks',
   'assets',
   'unsafe_hello_world',
   'flagship',
 ] as const
 
-function addBindingNames(names: Set<string>, value: unknown): void {
+const WRANGLER_RECORD_BINDING_CATEGORIES = new Set<string>([
+  'cloudchamber',
+  'data_blobs',
+  'define',
+  'text_blobs',
+  'vars',
+  'wasm_modules',
+])
+
+const WRANGLER_NON_INHERITED_BINDING_CATEGORIES = [
+  'agent_memory',
+  'ai',
+  'ai_search',
+  'ai_search_namespaces',
+  'analytics_engine_datasets',
+  'artifacts',
+  'browser',
+  'cloudchamber',
+  'containers',
+  'd1_databases',
+  'data_blobs',
+  'define',
+  'dispatch_namespaces',
+  'durable_objects',
+  'flagship',
+  'hyperdrive',
+  'images',
+  'kv_namespaces',
+  'logfwdr',
+  'media',
+  'mtls_certificates',
+  'pipelines',
+  'queues',
+  'r2_buckets',
+  'ratelimits',
+  'secrets',
+  'secrets_store_secrets',
+  'send_email',
+  'services',
+  'stream',
+  'streaming_tail_consumers',
+  'tail_consumers',
+  'text_blobs',
+  'unsafe',
+  'unsafe_hello_world',
+  'vars',
+  'vectorize',
+  'version_metadata',
+  'vpc_networks',
+  'vpc_services',
+  'wasm_modules',
+  'websearch',
+  'worker_loaders',
+  'workflows',
+] as const
+
+function addBindingNames(names: Set<string>, value: unknown, category?: string): void {
   if (Array.isArray(value)) {
     value.forEach((entry) => {
-      if (isRecord(entry) && typeof entry.binding === 'string')
+      if (!isRecord(entry))
+        return
+      if (typeof entry.binding === 'string')
         names.add(entry.binding)
+      else if (typeof entry.name === 'string')
+        names.add(entry.name)
+      else if (category === 'containers' && typeof entry.class_name === 'string')
+        names.add(entry.class_name)
+      else if ((category === 'tail_consumers' || category === 'streaming_tail_consumers') && typeof entry.service === 'string')
+        names.add(entry.service)
     })
     return
   }
   if (!isRecord(value))
     return
-  if (Array.isArray(value.bindings)
-    && value.bindings.every(binding => isRecord(binding) && typeof binding.name === 'string')) {
-    value.bindings.forEach(binding => names.add((binding as { name: string }).name))
+  if (Array.isArray(value.bindings)) {
+    value.bindings.forEach((binding) => {
+      if (isRecord(binding) && typeof binding.name === 'string')
+        names.add(binding.name)
+    })
     return
   }
   if (typeof value.binding === 'string') {
     names.add(value.binding)
     return
   }
-  Object.entries(value).forEach(([name, binding]) => {
-    if (binding !== undefined)
-      names.add(name)
-  })
+  if (category && WRANGLER_RECORD_BINDING_CATEGORIES.has(category)) {
+    Object.entries(value).forEach(([name, binding]) => {
+      if (binding !== undefined)
+        names.add(name)
+    })
+  }
 }
 
 function collectBindingNames(config: WranglerConfigInput): Set<string> {
   const names = new Set(config.secrets?.required ?? [])
-  WRANGLER_BINDING_CATEGORIES.forEach(category => addBindingNames(names, config[category]))
+  WRANGLER_BINDING_CATEGORIES.forEach(category => addBindingNames(names, config[category], category))
   addBindingNames(names, config.queues?.producers)
   return names
+}
+
+function collectCategoryBindingNames(config: WranglerConfigInput, category: string): Set<string> {
+  if (category === 'secrets')
+    return new Set(config.secrets?.required ?? [])
+  const names = new Set<string>()
+  if (category === 'queues') {
+    addBindingNames(names, config.queues?.producers)
+    config.queues?.consumers?.forEach((consumer) => {
+      if (typeof consumer.queue === 'string')
+        names.add(consumer.queue)
+    })
+  }
+  else {
+    addBindingNames(names, config[category], category)
+  }
+  return names
+}
+
+function configuredRemoteBindings(config: WranglerConfigInput): Array<{ path: string, value: Record<string, unknown> }> {
+  const bindings: Array<{ path: string, value: Record<string, unknown> }> = []
+  for (const category of ['ai', 'browser', 'images'] as const) {
+    const value = config[category]
+    if (isRecord(value) && typeof value.binding === 'string')
+      bindings.push({ path: category, value })
+  }
+  for (const category of ['flagship', 'mtls_certificates', 'vectorize'] as const) {
+    const value = config[category]
+    if (!Array.isArray(value))
+      continue
+    value.forEach((entry, index) => {
+      if (isRecord(entry) && typeof entry.binding === 'string')
+        bindings.push({ path: `${category}.${index}`, value: entry })
+    })
+  }
+  return bindings
 }
 
 export function applyCloudflareDefaults(
@@ -261,9 +387,12 @@ function applyEnvironmentDefaults(
 ): WranglerConfigInput {
   const compatibilityDate = config.compatibility_date ?? inherited.compatibility_date ?? options.compatibilityDate
   const compatibilityFlags = unique([...(config.compatibility_flags ?? inherited.compatibility_flags ?? []), 'nodejs_compat'])
+  const authoredCache = config.cache ?? inherited.cache
   const cache = options.workersCache
     ? resolveWorkersCachePolicy(options.workersCache)
-    : resolveAuthoredWorkersCache(config.cache ?? inherited.cache)
+    : authoredCache
+      ? { ...authoredCache, cross_version_cache: authoredCache.cross_version_cache ?? false }
+      : resolveWorkersCachePolicy({ _tag: 'disabled' })
   const requiredSecrets = unique([...(config.secrets?.required ?? []), ...(options.requiredSecrets ?? [])])
   const logs = config.observability?.logs
   const inheritedLogs = inherited.observability?.logs
@@ -319,14 +448,16 @@ function diagnoseEnvironment(
   config: WranglerConfigInput,
   prefix: string,
   diagnostics: WranglerDiagnostic[],
+  generated: boolean,
+  normalized: boolean,
   publicVarNames: ReadonlySet<string>,
 ): void {
   const workerFirst: unknown = config.assets?.run_worker_first
   if (workerFirst === true) {
     diagnostics.push({
-      _tag: 'error',
+      _tag: 'warning',
       code: 'assets-worker-first',
-      message: 'Replace blanket Worker-first routing with false or a narrow route-pattern array.',
+      message: 'Blanket Worker-first routing invokes the Worker for every asset. Use it only when authentication or response transforms require it.',
       configPath: `${prefix}assets.run_worker_first`,
     })
   }
@@ -356,7 +487,9 @@ function diagnoseEnvironment(
     ? Object.entries(config.exports).filter(([, value]) => isRecord(value) && value.type === 'durable-object')
     : []
   const migrations = Array.isArray(config.migrations) ? config.migrations : []
-  if (durableObjectExports.length > 0 && migrations.length > 0) {
+  const hasExports = normalized ? durableObjectExports.length > 0 : Object.hasOwn(config, 'exports')
+  const hasMigrations = normalized ? migrations.length > 0 : Object.hasOwn(config, 'migrations')
+  if (hasExports && hasMigrations) {
     diagnostics.push({
       _tag: 'error',
       code: 'durable-object-lifecycle-mixed',
@@ -372,7 +505,7 @@ function diagnoseEnvironment(
     return [binding.class_name]
   })
   const inactiveExportedClassNames = new Set(durableObjectExports.flatMap(([name, value]) => {
-    if (!isRecord(value) || value.state === undefined || value.state === 'created')
+    if (!isRecord(value) || value.state === undefined || value.state === 'created' || value.state === 'expecting-transfer')
       return []
     return [name]
   }))
@@ -380,12 +513,18 @@ function diagnoseEnvironment(
     diagnostics.push({
       _tag: 'error',
       code: 'durable-object-binding-inactive',
-      message: 'A Durable Object binding may target only an active declarative export with state created or omitted.',
+      message: 'A Durable Object binding may target only an active declarative export.',
       configPath: `${prefix}durable_objects.bindings`,
     })
   }
   const exportedClassNames = new Set(durableObjectExports.map(([name]) => name))
+  const exportedClassStorage = new Map(durableObjectExports.flatMap(([name, value]) => {
+    if (!isRecord(value) || (value.storage !== 'sqlite' && value.storage !== 'legacy-kv'))
+      return []
+    return [[name, value.storage] as const]
+  }))
   const migratedClassNames = new Set<string>()
+  const migratedClassStorage = new Map<string, 'legacy-kv' | 'sqlite'>()
   for (const migration of migrations) {
     if (!isRecord(migration))
       continue
@@ -394,6 +533,7 @@ function diagnoseEnvironment(
         for (const className of migration[key]) {
           if (typeof className === 'string') {
             migratedClassNames.add(className)
+            migratedClassStorage.set(className, key === 'new_sqlite_classes' ? 'sqlite' : 'legacy-kv')
           }
         }
       }
@@ -402,10 +542,16 @@ function diagnoseEnvironment(
       for (const rename of migration.renamed_classes) {
         if (!isRecord(rename))
           continue
-        if (typeof rename.from === 'string')
+        const storage = typeof rename.from === 'string' ? migratedClassStorage.get(rename.from) : undefined
+        if (typeof rename.from === 'string') {
           migratedClassNames.delete(rename.from)
-        if (typeof rename.to === 'string')
+          migratedClassStorage.delete(rename.from)
+        }
+        if (typeof rename.to === 'string') {
           migratedClassNames.add(rename.to)
+          if (storage)
+            migratedClassStorage.set(rename.to, storage)
+        }
       }
     }
     if (Array.isArray(migration.transferred_classes)) {
@@ -418,6 +564,7 @@ function diagnoseEnvironment(
       for (const className of migration.deleted_classes) {
         if (typeof className === 'string') {
           migratedClassNames.delete(className)
+          migratedClassStorage.delete(className)
         }
       }
     }
@@ -428,6 +575,101 @@ function diagnoseEnvironment(
       code: 'durable-object-lifecycle-unmanaged',
       message: 'Every locally defined Durable Object needs a declarative export or a legacy migration history.',
       configPath: `${prefix}durable_objects.bindings`,
+    })
+  }
+
+  for (const [index, container] of (config.containers ?? []).entries()) {
+    if (typeof container.class_name !== 'string')
+      continue
+    const configPath = `${prefix}containers.${index}.class_name`
+    if (!localClassNames.includes(container.class_name)) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'container-durable-object-binding-missing',
+        message: `Container class ${container.class_name} needs a matching local Durable Object binding.`,
+        configPath,
+      })
+    }
+    else if (exportedClassStorage.get(container.class_name) === 'legacy-kv'
+      || migratedClassStorage.get(container.class_name) === 'legacy-kv') {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'container-durable-object-not-sqlite',
+        message: `Container class ${container.class_name} needs SQLite Durable Object storage.`,
+        configPath,
+      })
+    }
+    if (container.instance_type === 'dev' || container.instance_type === 'standard') {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'container-instance-type-deprecated',
+        message: `Container instance type ${container.instance_type} is deprecated. Choose a current instance type.`,
+        configPath: `${prefix}containers.${index}.instance_type`,
+      })
+    }
+  }
+
+  if (!generated) {
+    for (const binding of configuredRemoteBindings(config)) {
+      if (binding.value.remote === true)
+        continue
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'remote-binding-not-enabled',
+        message: 'Set remote to true when local development needs the real Cloudflare service.',
+        configPath: `${prefix}${binding.path}.remote`,
+      })
+    }
+  }
+
+  if (Array.isArray(config.send_email)) {
+    config.send_email.forEach((binding, index) => {
+      if (!isRecord(binding))
+        return
+      const isRestricted = typeof binding.destination_address === 'string'
+        || (Array.isArray(binding.allowed_destination_addresses) && binding.allowed_destination_addresses.length > 0)
+        || (Array.isArray(binding.allowed_sender_addresses) && binding.allowed_sender_addresses.length > 0)
+      if (!isRestricted) {
+        diagnostics.push({
+          _tag: 'warning',
+          code: 'email-binding-unrestricted',
+          message: 'Restrict this email binding to approved senders or destinations.',
+          configPath: `${prefix}send_email.${index}`,
+        })
+      }
+    })
+  }
+
+  if (Array.isArray(config.pipelines)) {
+    config.pipelines.forEach((binding, index) => {
+      if (isRecord(binding) && typeof binding.pipeline === 'string') {
+        diagnostics.push({
+          _tag: 'warning',
+          code: 'pipeline-binding-deprecated',
+          message: 'Replace the deprecated pipeline field with stream.',
+          configPath: `${prefix}pipelines.${index}.pipeline`,
+        })
+      }
+    })
+  }
+
+  for (const category of ['data_blobs', 'text_blobs', 'wasm_modules'] as const) {
+    if (isRecord(config[category]) && Object.keys(config[category]).length > 0) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'legacy-module-binding',
+        message: `Replace legacy ${category} bindings with module rules and imports.`,
+        configPath: `${prefix}${category}`,
+      })
+    }
+  }
+
+  if (Array.isArray(config.unsafe_hello_world) && config.unsafe_hello_world.length > 0) {
+    diagnostics.push({
+      _tag: 'error',
+      code: 'unsafe-hello-world-binding',
+      message: 'Remove the explanatory unsafe_hello_world binding.',
+      configPath: `${prefix}unsafe_hello_world`,
     })
   }
 
@@ -454,6 +696,11 @@ function diagnoseEnvironment(
   }
 
   const consumers = config.queues?.consumers ?? []
+  const deadLetterQueues = new Set(consumers.flatMap((consumer) => {
+    return typeof consumer.dead_letter_queue === 'string' && consumer.dead_letter_queue.length > 0
+      ? [consumer.dead_letter_queue]
+      : []
+  }))
   consumers.forEach((consumer, index) => {
     const retries = consumer.max_retries
     const retryDelay = consumer.retry_delay
@@ -473,7 +720,9 @@ function diagnoseEnvironment(
         configPath: `${prefix}queues.consumers.${index}.max_retries`,
       })
     }
-    if (typeof consumer.dead_letter_queue !== 'string' || consumer.dead_letter_queue.length === 0) {
+    const drainsDeadLetterQueue = typeof consumer.queue === 'string' && deadLetterQueues.has(consumer.queue)
+    if (!drainsDeadLetterQueue
+      && (typeof consumer.dead_letter_queue !== 'string' || consumer.dead_letter_queue.length === 0)) {
       diagnostics.push({
         _tag: 'warning',
         code: 'queue-dlq-missing',
@@ -496,7 +745,7 @@ function diagnosePolicy(
   config: WranglerConfigInput,
   prefix: string,
   diagnostics: WranglerDiagnostic[],
-  options: Required<Pick<WranglerDiagnosticOptions, 'compatibilityMaxAgeDays' | 'now' | 'requireNodeCompat'>>,
+  options: Required<Pick<WranglerDiagnosticOptions, 'compatibilityMaxAgeDays' | 'generated' | 'normalized' | 'now' | 'requireNodeCompat'>>,
   publicVarNames: ReadonlySet<string>,
 ): void {
   const compatibilityDate = config.compatibility_date
@@ -658,7 +907,7 @@ function diagnosePolicy(
     })
   }
 
-  diagnoseEnvironment(config, prefix, diagnostics, publicVarNames)
+  diagnoseEnvironment(config, prefix, diagnostics, options.generated, options.normalized, publicVarNames)
 }
 
 function mergeObservability(
@@ -683,13 +932,15 @@ function resolveEnvironmentPolicy(
   root: WranglerConfigInput,
   environment: WranglerConfigInput,
 ): WranglerConfigInput {
+  const exports = environment.exports ?? root.exports
+  const migrations = environment.migrations ?? root.migrations
   return {
     ...environment,
     cache: environment.cache ?? root.cache,
     compatibility_date: environment.compatibility_date ?? root.compatibility_date,
     compatibility_flags: environment.compatibility_flags ?? root.compatibility_flags,
-    exports: environment.exports ?? root.exports,
-    migrations: environment.migrations ?? root.migrations,
+    ...(exports === undefined ? {} : { exports }),
+    ...(migrations === undefined ? {} : { migrations }),
     observability: mergeObservability(root.observability, environment.observability),
     placement: environment.placement ?? root.placement,
     preview_urls: environment.preview_urls ?? root.preview_urls,
@@ -705,6 +956,8 @@ export function diagnoseWranglerConfig(
   const diagnostics: WranglerDiagnostic[] = []
   const diagnosticOptions = {
     compatibilityMaxAgeDays: options.compatibilityMaxAgeDays ?? 90,
+    generated: options.generated ?? false,
+    normalized: options.normalized ?? false,
     now: options.now ?? new Date(),
     requireNodeCompat: options.requireNodeCompat ?? true,
   }
@@ -721,6 +974,19 @@ export function diagnoseWranglerConfig(
   const publicVarNames = new Set(options.publicVarNames ?? [])
   diagnosePolicy(config, '', diagnostics, diagnosticOptions, publicVarNames)
   for (const [name, environment] of Object.entries(config.env ?? {})) {
+    for (const category of WRANGLER_NON_INHERITED_BINDING_CATEGORIES) {
+      const rootNames = collectCategoryBindingNames(config, category)
+      const environmentNames = collectCategoryBindingNames(environment, category)
+      const missingNames = [...rootNames].filter(binding => !environmentNames.has(binding))
+      if (missingNames.length > 0) {
+        diagnostics.push({
+          _tag: 'warning',
+          code: 'environment-binding-missing',
+          message: `Named environments do not inherit ${category}. Add bindings for: ${missingNames.join(', ')}.`,
+          configPath: `env.${name}.${category}`,
+        })
+      }
+    }
     diagnosePolicy(
       resolveEnvironmentPolicy(config, environment),
       `env.${name}.`,

--- a/packages/nuxt-cloudflare/tests/d1.test.ts
+++ b/packages/nuxt-cloudflare/tests/d1.test.ts
@@ -109,6 +109,20 @@ describe('retryIdempotentD1Write', () => {
     expect(isTransientD1Error(error)).toBe(false)
   })
 
+  it.each([
+    'D1 DB is overloaded. Requests queued for too long.',
+    'D1 DB storage operation exceeded timeout which caused object to be reset.',
+    'D1 DB\'s isolate exceeded its memory limit and was reset.',
+    'D1 DB exceeded its CPU time limit and was reset.',
+  ])('does not amplify resource pressure by retrying: %s', async (message) => {
+    const error = new Error(`D1_ERROR: ${message}`)
+    const run = vi.fn().mockRejectedValue(error)
+
+    await expect(retryIdempotentD1Write({ safety: { _tag: 'replay-safe' }, run })).rejects.toBe(error)
+    expect(run).toHaveBeenCalledOnce()
+    expect(isTransientD1Error(error)).toBe(false)
+  })
+
   it('classifies mixed-case transient errors nested in a cause', () => {
     expect(isTransientD1Error(new Error('wrapper', {
       cause: new Error('D1_ERROR: NETWORK CONNECTION LOST'),

--- a/packages/nuxt-cloudflare/tests/html-cache.test.ts
+++ b/packages/nuxt-cloudflare/tests/html-cache.test.ts
@@ -29,15 +29,25 @@ describe('html cache route rules', () => {
     expect(formatHtmlCacheRouteRuleViolations(violations)).toContain('routeRules./docs/**.headers.Cloudflare-CDN-Cache-Control')
   })
 
-  it('allows cache rules on API and static asset routes', () => {
+  it('allows cache rules on API, generated image, and static asset routes', () => {
     expect(findHtmlCacheRouteRuleViolations({
       '/api/**': { cache: { maxAge: 60 } },
-      '/_og/d/**': { headers: { 'cache-control': 'public, immutable' } },
-      '/_og/r/**': { headers: { 'cache-control': 'public, immutable' } },
-      '/_og/s/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/mcp/server-card': { headers: { 'cache-control': 'public, max-age=3600' } },
       '/_nuxt/**': { headers: { 'cache-control': 'public, immutable' } },
+      '/_og/d/**': { headers: { 'cache-control': 'public, max-age=3600' } },
       '/fonts/**': { headers: { 'cache-control': 'public, immutable' } },
       '/sitemap.xml': { headers: { 'cache-control': 'public, max-age=60' } },
+    })).toEqual([])
+  })
+
+  it('allows a route with an explicit non-HTML content type', () => {
+    expect(findHtmlCacheRouteRuleViolations({
+      '/generated/**': {
+        headers: {
+          'cache-control': 'public, max-age=3600',
+          'content-type': 'image/png',
+        },
+      },
     })).toEqual([])
   })
 

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -1,17 +1,23 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { NitroCloudflareShape } from '../src/module'
-import { describe, expect, it } from 'vitest'
-import { configureNitroCloudflare, setupCloudflareModule } from '../src/module'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { configureNitroCloudflare, findPopulatedRuntimeSecretPaths, setupCloudflareModule } from '../src/module'
 
-function nuxtWithCapturedHooks(dev: boolean, serverSourceMaps = false): { hooks: string[], nuxt: Nuxt } {
+function nuxtWithCapturedHooks(dev: boolean, serverSourceMaps = false): {
+  callbacks: Record<string, () => unknown>
+  hooks: string[]
+  nuxt: Nuxt
+} {
+  const callbacks: Record<string, () => unknown> = {}
   const hooks: string[] = []
   const nuxt = {
-    hook(name: string) {
+    hook(name: string, callback: () => unknown) {
       hooks.push(name)
+      callbacks[name] = callback
     },
-    options: { dev, nitro: {}, sourcemap: { server: serverSourceMaps } },
+    options: { dev, nitro: {}, runtimeConfig: {}, sourcemap: { server: serverSourceMaps } },
   } as unknown as Nuxt
-  return { hooks, nuxt }
+  return { callbacks, hooks, nuxt }
 }
 
 describe('configureNitroCloudflare', () => {
@@ -89,10 +95,52 @@ describe('configureNitroCloudflare', () => {
       enabled: false,
       cross_version_cache: false,
     })
+    expect(nitro.plugins).toBeUndefined()
   })
 })
 
 describe('setupCloudflareModule', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('finds build environment secrets copied into runtime config without returning their values', () => {
+    const config = {
+      generated: { runtimeSyncSecret: 'generated-at-build' },
+      oauth: { clientSecret: 'oauth-sentinel' },
+      public: { apiKey: 'intentionally-public' },
+      resendApiKey: 'resend-sentinel',
+      session: { password: '' },
+    }
+
+    const paths = findPopulatedRuntimeSecretPaths(config, {
+      NUXT_OAUTH_CLIENT_SECRET: 'oauth-sentinel',
+      NUXT_RESEND_API_KEY: 'resend-sentinel',
+    })
+
+    expect(paths).toEqual(['oauth.clientSecret', 'resendApiKey'])
+    expect(JSON.stringify(paths)).not.toContain('sentinel')
+  })
+
+  it('permits Nuxt Scripts proxy signing required during module setup', () => {
+    expect(findPopulatedRuntimeSecretPaths({
+      'nuxt-scripts': { proxySecret: 'proxy-sentinel' },
+    }, {
+      NUXT_SCRIPTS_PROXY_SECRET: 'proxy-sentinel',
+    })).toEqual([])
+  })
+
+  it('blocks a production build with a populated runtime secret default', () => {
+    const { callbacks, nuxt } = nuxtWithCapturedHooks(false)
+    Object.assign(nuxt.options.runtimeConfig, { oauth: { clientSecret: 'oauth-sentinel' } })
+    vi.stubEnv('NUXT_OAUTH_CLIENT_SECRET', 'oauth-sentinel')
+
+    setupCloudflareModule({ enabled: true }, nuxt)
+
+    expect(callbacks['modules:done']).toThrow('oauth.clientSecret')
+    expect(callbacks['modules:done']).not.toThrow('oauth-sentinel')
+  })
+
   it('does not register the production Wrangler audit during development', () => {
     const { hooks, nuxt } = nuxtWithCapturedHooks(true)
 

--- a/packages/nuxt-cloudflare/tests/nuxt.test.ts
+++ b/packages/nuxt-cloudflare/tests/nuxt.test.ts
@@ -34,7 +34,7 @@ describe('nuxt integration', () => {
     await nuxt.close()
   })
 
-  it('warns for ambiguous cache rules and blocks prerendered HTML cache rules', async () => {
+  it('warns for ambiguous cache rules and blocks explicit HTML cache rules', async () => {
     const nuxt = await loadNuxt({
       cwd: import.meta.dirname,
       dev: true,

--- a/packages/nuxt-cloudflare/tests/storage.test.ts
+++ b/packages/nuxt-cloudflare/tests/storage.test.ts
@@ -27,4 +27,13 @@ describe('withDefaultKvExpiration', () => {
   it('rejects Cloudflare KV expiry below the platform minimum', () => {
     expect(() => withDefaultKvExpiration(driver(async () => {}), 59)).toThrow(/at least 60 seconds/)
   })
+
+  it('raises caller TTLs to the Cloudflare KV platform minimum', async () => {
+    const setItem = vi.fn(async () => {})
+    const wrapped = withDefaultKvExpiration(driver(setItem), 30 * 24 * 60 * 60)
+
+    await wrapped.setItem?.('short', 'value', { ttl: 1 })
+
+    expect(setItem).toHaveBeenCalledWith('short', 'value', { ttl: 60 })
+  })
 })

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -28,6 +28,48 @@ describe('applyCloudflareDefaults', () => {
     })
   })
 
+  it.each([
+    {
+      name: 'Nuxt SEO',
+      config: {
+        ai: { binding: 'AI' },
+        browser: { binding: 'BROWSER' },
+        cache: { enabled: false },
+        compatibility_date: '2026-08-11',
+        preview_urls: false,
+        send_email: [{ name: 'EMAIL', allowed_sender_addresses: ['noreply@notify.nuxtseo.com'] }],
+        vectorize: [{ binding: 'VECTORIZE', index_name: 'nuxtseo' }],
+        workers_dev: false,
+      },
+    },
+    {
+      name: 'gscdump',
+      config: {
+        cache: { enabled: true },
+        compatibility_date: '2026-08-11',
+        preview_urls: false,
+        send_email: [{ name: 'SEND_EMAIL', allowed_sender_addresses: ['health@notify.gscdump.com'] }],
+        workers_dev: false,
+      },
+    },
+  ])('normalizes the $name deployment baseline without product policy warnings', ({ config }) => {
+    const effective = applyCloudflareDefaults(config)
+    const diagnostics = diagnoseWranglerConfig(effective, {
+      generated: true,
+      now: new Date('2026-08-11T00:00:00Z'),
+    })
+
+    expect(effective.cache?.cross_version_cache).toBe(false)
+    expect(diagnostics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'email-binding-unrestricted' }),
+      expect.objectContaining({ code: 'preview-urls-public' }),
+      expect.objectContaining({ code: 'remote-binding-not-enabled' }),
+      expect.objectContaining({ code: 'workers-cache-policy-implicit' }),
+      expect.objectContaining({ code: 'workers-dev-enabled' }),
+      expect.objectContaining({ code: 'workers-dev-implicit' }),
+    ]))
+  })
+
   it('preserves an explicit source-map opt-out', () => {
     expect(applyCloudflareDefaults({ upload_source_maps: false })).toMatchObject({ upload_source_maps: false })
   })
@@ -43,7 +85,7 @@ describe('applyCloudflareDefaults', () => {
     }).cache).toEqual({ enabled: true, cross_version_cache: false })
   })
 
-  it('makes version isolation explicit for an enabled Workers Cache', () => {
+  it('makes an authored Workers Caching deployment scope explicit', () => {
     expect(applyCloudflareDefaults({
       cache: { enabled: true },
     }).cache).toEqual({ enabled: true, cross_version_cache: false })
@@ -94,6 +136,49 @@ describe('applyCloudflareDefaults', () => {
       .toBeUndefined()
     expect(applyCloudflareDefaults({ ai: { binding: 'CF_VERSION_METADATA' } }).version_metadata)
       .toBeUndefined()
+  })
+
+  it.each([
+    { send_email: [{ name: 'CF_VERSION_METADATA' }] },
+    { ratelimits: [{ name: 'CF_VERSION_METADATA' }] },
+    { worker_loaders: [{ binding: 'CF_VERSION_METADATA' }] },
+    { vpc_services: [{ binding: 'CF_VERSION_METADATA' }] },
+    { vpc_networks: [{ binding: 'CF_VERSION_METADATA' }] },
+  ])('does not collide with current Cloudflare product bindings: %j', (binding) => {
+    expect(applyCloudflareDefaults(binding).version_metadata).toBeUndefined()
+  })
+
+  it('warns when local development cannot faithfully simulate a binding', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      ai: { binding: 'AI' },
+      browser: { binding: 'BROWSER' },
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      images: { binding: 'IMAGES' },
+      mtls_certificates: [{ binding: 'MTLS', certificate_id: 'certificate' }],
+      observability: { enabled: true },
+      vectorize: [{ binding: 'VECTORIZE', index_name: 'index' }],
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics.filter(diagnostic => diagnostic.code === 'remote-binding-not-enabled'))
+      .toHaveLength(5)
+  })
+
+  it('does not apply local binding advice to a generated deployment config', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      ai: { binding: 'AI' },
+      browser: { binding: 'BROWSER' },
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      vectorize: [{ binding: 'VECTORIZE', index_name: 'index' }],
+      workers_dev: false,
+    }, { generated: true, now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
+      code: 'remote-binding-not-enabled',
+    }))
   })
 
   it.each(['wasm_modules', 'text_blobs', 'data_blobs'])(
@@ -149,7 +234,7 @@ describe('diagnoseWranglerConfig', () => {
       }))
   })
 
-  it('rejects blanket Worker-first asset routing', () => {
+  it('warns about blanket Worker-first asset routing', () => {
     const diagnostics = diagnoseWranglerConfig({
       compatibility_date: '2026-08-11',
       compatibility_flags: ['nodejs_compat'],
@@ -158,7 +243,7 @@ describe('diagnoseWranglerConfig', () => {
     }, { now: new Date('2026-08-11T00:00:00Z') })
 
     expect(diagnostics).toContainEqual(expect.objectContaining({
-      _tag: 'error',
+      _tag: 'warning',
       code: 'assets-worker-first',
     }))
   })
@@ -331,7 +416,7 @@ describe('diagnoseWranglerConfig', () => {
     expect(applyCloudflareDefaults({ preview_urls: true }).preview_urls).toBe(true)
   })
 
-  it('surfaces permanent deletion risk for a terminal DLQ consumer', () => {
+  it('does not require a second DLQ for a consumer draining a DLQ', () => {
     const diagnostics = diagnoseWranglerConfig({
       compatibility_date: '2026-08-11',
       compatibility_flags: ['nodejs_compat'],
@@ -345,7 +430,7 @@ describe('diagnoseWranglerConfig', () => {
       workers_dev: false,
     }, { now: new Date('2026-08-11T00:00:00Z') })
 
-    expect(diagnostics).toContainEqual(expect.objectContaining({
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({
       code: 'queue-dlq-missing',
       configPath: 'queues.consumers.1.dead_letter_queue',
     }))
@@ -358,6 +443,18 @@ describe('diagnoseWranglerConfig', () => {
       durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
       exports: { Room: { type: 'durable-object', storage: 'sqlite' } },
       migrations: [{ tag: 'v1', new_sqlite_classes: ['Room'] }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ _tag: 'error', code: 'durable-object-lifecycle-mixed' }))
+  })
+
+  it('rejects declarative Durable Object exports beside an empty legacy migration list', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      exports: { Room: { type: 'durable-object', storage: 'sqlite' } },
+      migrations: [],
       observability: { enabled: true },
       workers_dev: false,
     }, { now: new Date('2026-08-11T00:00:00Z') }))
@@ -377,7 +474,7 @@ describe('diagnoseWranglerConfig', () => {
     expect(diagnostics).not.toContainEqual(expect.objectContaining({ _tag: 'error' }))
   })
 
-  it.each(['deleted', 'renamed', 'transferred', 'expecting-transfer'])(
+  it.each(['deleted', 'renamed', 'transferred'])(
     'rejects a binding to an inactive declarative Durable Object state: %s',
     (state) => {
       expect(diagnoseWranglerConfig({
@@ -394,6 +491,100 @@ describe('diagnoseWranglerConfig', () => {
         }))
     },
   )
+
+  it('allows a binding to a live Durable Object expecting transfer', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      durable_objects: { bindings: [{ name: 'ROOM', class_name: 'Room' }] },
+      exports: {
+        Room: {
+          type: 'durable-object',
+          state: 'expecting-transfer',
+          storage: 'sqlite',
+          transfer_from: 'room-source',
+        },
+      },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .not
+      .toContainEqual(expect.objectContaining({ code: 'durable-object-binding-inactive' }))
+  })
+
+  it.each([
+    { category: 'containers', config: { containers: [{ class_name: 'SiteContainer', image: './Dockerfile' }] } },
+    { category: 'd1_databases', config: { d1_databases: [{ binding: 'DB', database_id: 'database' }] } },
+    { category: 'kv_namespaces', config: { kv_namespaces: [{ binding: 'CACHE', id: 'root-cache' }] } },
+    { category: 'queues', config: { queues: { consumers: [{ queue: 'JOBS' }] } } },
+    { category: 'tail_consumers', config: { tail_consumers: [{ service: 'tail-worker' }] } },
+  ])('warns when a named environment omits non-inherited $category config', ({ category, config }) => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      env: { production: {} },
+      ...config,
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'environment-binding-missing',
+        configPath: `env.production.${category}`,
+      }))
+  })
+
+  it('rejects a Container without its matching SQLite Durable Object', () => {
+    const base = {
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      containers: [{ class_name: 'SiteContainer', image: './Dockerfile' }],
+      observability: { enabled: true },
+      workers_dev: false,
+    }
+
+    expect(diagnoseWranglerConfig(base, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ code: 'container-durable-object-binding-missing' }))
+    expect(diagnoseWranglerConfig({
+      ...base,
+      durable_objects: { bindings: [{ name: 'CONTAINER', class_name: 'SiteContainer' }] },
+      migrations: [{ tag: 'v1', new_classes: ['SiteContainer'] }],
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ code: 'container-durable-object-not-sqlite' }))
+  })
+
+  it('warns when an email binding has no sender or destination restriction', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      send_email: [{ name: 'EMAIL' }],
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({ code: 'email-binding-unrestricted' }))
+  })
+
+  it('surfaces deprecated and unsafe product configuration', () => {
+    const diagnostics = diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      containers: [{ class_name: 'Container', image: './Dockerfile', instance_type: 'dev' }],
+      data_blobs: { DATA: './data.bin' },
+      durable_objects: { bindings: [{ name: 'CONTAINER', class_name: 'Container' }] },
+      exports: { Container: { type: 'durable-object', storage: 'sqlite' } },
+      observability: { enabled: true },
+      pipelines: [{ binding: 'PIPELINE', pipeline: 'legacy-name' }],
+      unsafe_hello_world: [{ binding: 'UNSAFE' }],
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') })
+
+    expect(diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'container-instance-type-deprecated' }),
+      expect.objectContaining({ code: 'legacy-module-binding' }),
+      expect.objectContaining({ code: 'pipeline-binding-deprecated' }),
+      expect.objectContaining({ _tag: 'error', code: 'unsafe-hello-world-binding' }),
+    ]))
+  })
 
   it('inherits root declarative Durable Object exports into named environments', () => {
     const diagnostics = diagnoseWranglerConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^0.18.5
       version: 0.18.5
     '@cloudflare/workers-types':
-      specifier: ^5.20260809.1
-      version: 5.20260809.1
+      specifier: ^5.20260811.1
+      version: 5.20260811.1
     '@nuxt/kit':
       specifier: ^4.5.2
       version: 4.5.2
@@ -106,8 +106,8 @@ catalogs:
       specifier: ^3.3.9
       version: 3.3.9
     wrangler:
-      specifier: ^4.120.0
-      version: 4.120.0
+      specifier: ^4.120.1
+      version: 4.120.1
     yaml:
       specifier: ^2.9.0
       version: 2.9.0
@@ -132,7 +132,7 @@ importers:
         version: 0.2.2
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)
+        version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)
       magicast:
         specifier: 'catalog:'
         version: 0.5.4
@@ -145,7 +145,7 @@ importers:
         version: 0.18.5
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260809.1
+        version: 5.20260811.1
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
@@ -175,10 +175,10 @@ importers:
         version: 20.11.2
       nitropack:
         specifier: 'catalog:'
-        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nuxt:
         specifier: 'catalog:'
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -196,7 +196,7 @@ importers:
         version: 3.3.9(typescript@5.9.3)
       wrangler:
         specifier: 'catalog:'
-        version: 4.120.0(@cloudflare/workers-types@5.20260809.1)
+        version: 4.120.1(@cloudflare/workers-types@5.20260811.1)
 
   packages/nuxt-cloudflare:
     dependencies:
@@ -214,13 +214,13 @@ importers:
         version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       nitropack:
         specifier: 'catalog:'
-        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
       unstorage:
         specifier: 'catalog:'
-        version: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+        version: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -230,7 +230,7 @@ importers:
         version: 0.18.5
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260809.1
+        version: 5.20260811.1
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
@@ -257,7 +257,7 @@ importers:
         version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       wrangler:
         specifier: 'catalog:'
-        version: 4.120.0(@cloudflare/workers-types@5.20260809.1)
+        version: 4.120.1(@cloudflare/workers-types@5.20260811.1)
 
   packages/nuxt-domain-events:
     dependencies:
@@ -367,7 +367,7 @@ importers:
         version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       nitropack:
         specifier: 'catalog:'
-        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -419,7 +419,7 @@ importers:
         version: 3.4.2
       nitropack:
         specifier: 'catalog:'
-        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       oxc-parser:
         specifier: 'catalog:'
         version: 0.140.0
@@ -749,38 +749,38 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260801.1':
-    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
+  '@cloudflare/workerd-darwin-64@1.20260804.1':
+    resolution: {integrity: sha512-191/PPEFicRK2wK69eXzSjnLgHL79k7zR2VUpyIr8rhFgGns1b5bTHgnBuUrgU2LPbEtwbE5eL2hJ0uhLAFEow==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
-    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==}
+  '@cloudflare/workerd-darwin-arm64@1.20260804.1':
+    resolution: {integrity: sha512-aI2cAFLsrNkSz3kLSQrgrO9ICTfY7jb2h0jgaWDE9mQLQQDfpXeYrKWt07tTgMmeNP79o9w3NZe3aqtt8mTGHQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260801.1':
-    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
+  '@cloudflare/workerd-linux-64@1.20260804.1':
+    resolution: {integrity: sha512-KBCjxBIlN2jucfQGaTK4EgmPsWzQgYR/zYhPfi3mkWwdoTyG1dgrt2aizKps/SYse85ci/SOxojKk0/K7vstPw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260801.1':
-    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260804.1':
+    resolution: {integrity: sha512-7lswfarBZ7xkHpTFrNb74ExwOltIalVaASc+GOYfCNtnwFxK/JZSVByfm/hnZEBtrHU7fMY2z7dYT64rwS0pHg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260801.1':
-    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
+  '@cloudflare/workerd-windows-64@1.20260804.1':
+    resolution: {integrity: sha512-GOgRWYtxISN5rAWfx3K7zubt3xEn0/ZPFrbcLL+GwT4ouCKyNoHqfT1cPNB6Nx7t8BHEjnuTG7gkHO4Wd5ORdg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260809.1':
-    resolution: {integrity: sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ==}
+  '@cloudflare/workers-types@5.20260811.1':
+    resolution: {integrity: sha512-jS3o9240P8t7Y/2lecXPC0rGdODZgHyFTWy9Asdm8htE2Uepx4PAvbcVo3EC0r8wZuv6rahDc1MMj+3nDZj/QA==}
 
   '@colordx/core@5.5.0':
     resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
@@ -4487,8 +4487,8 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  miniflare@5.20260801.1-alpha:
-    resolution: {integrity: sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==}
+  miniflare@5.20260804.0-alpha:
+    resolution: {integrity: sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
@@ -6183,17 +6183,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  workerd@1.20260801.1:
-    resolution: {integrity: sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==}
+  workerd@1.20260804.1:
+    resolution: {integrity: sha512-b0P38g5/ssemwWxd/mafNYggEZ0ere7PCiUH6RCHkgqjRhhXTP45nDiL2L3iIvi8uF2IjNrGpVgMXEunCaeY/w==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.120.0:
-    resolution: {integrity: sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==}
+  wrangler@4.120.1:
+    resolution: {integrity: sha512-rQJ38rY02XiVITbSBWHC7oap3M2evcXgsC4CdlIX4WQENUZMMnue9j2vXO4aIi39KR+jDH+UHK8JNqp1+UjkRQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260801.1
+      '@cloudflare/workers-types': ^5.20260804.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6600,28 +6600,28 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260804.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260801.1
+      workerd: 1.20260804.1
 
-  '@cloudflare/workerd-darwin-64@1.20260801.1':
+  '@cloudflare/workerd-darwin-64@1.20260804.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260804.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260801.1':
+  '@cloudflare/workerd-linux-64@1.20260804.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+  '@cloudflare/workerd-linux-arm64@1.20260804.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260801.1':
+  '@cloudflare/workerd-windows-64@1.20260804.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260809.1': {}
+  '@cloudflare/workers-types@5.20260811.1': {}
 
   '@colordx/core@5.5.0': {}
 
@@ -7291,7 +7291,7 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -7321,7 +7321,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
@@ -7463,7 +7463,7 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nostics: 1.2.0
       nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.9
@@ -7473,7 +7473,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7549,7 +7549,7 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nostics: 1.2.0
       nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.9
@@ -7559,7 +7559,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7618,7 +7618,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.2(ad8465325b42189410837bc3399b38ea)':
+  '@nuxt/nitro-server@4.5.2(86bebef3c2d367abe47f4b69f74979aa)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -7635,9 +7635,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -7645,7 +7645,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7832,7 +7832,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.5.2(14cf2ac12b556b28c8b27b4244a37682)':
+  '@nuxt/vite-builder@4.5.2(555c4df54b493c158fea29b99adca3d2)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
@@ -7850,7 +7850,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9228,9 +9228,9 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)):
+  db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)):
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)
 
   debug@4.4.3:
     dependencies:
@@ -9301,9 +9301,9 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260809.1
+      '@cloudflare/workers-types': 5.20260811.1
       zod: 4.4.3
 
   duplexer@0.1.2: {}
@@ -10720,12 +10720,12 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  miniflare@5.20260801.1-alpha:
+  miniflare@5.20260804.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
       undici: 7.29.0
-      workerd: 1.20260801.1
+      workerd: 1.20260804.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -10802,7 +10802,7 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
-  nitropack@2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
+  nitropack@2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -10823,7 +10823,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))
+      db0: 0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -10869,7 +10869,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -10960,16 +10960,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.2(ad8465325b42189410837bc3399b38ea)
+      '@nuxt/nitro-server': 4.5.2(86bebef3c2d367abe47f4b69f74979aa)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(14cf2ac12b556b28c8b27b4244a37682)
+      '@nuxt/vite-builder': 4.5.2(555c4df54b493c158fea29b99adca3d2)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -11105,7 +11105,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(306b7872170b5fee229ee019d68f27d2)
       '@nuxt/schema': 4.5.2
@@ -11246,7 +11246,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(1ddd60ae9f6acff327e58c4f29acd342)
       '@nuxt/schema': 4.5.2
@@ -12610,7 +12610,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3)))(ioredis@5.11.1):
+  unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -12621,7 +12621,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
-      db0: 0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260809.1)(zod@4.4.3))
+      db0: 0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3))
       ioredis: 5.11.1
 
   untun@0.2.2: {}
@@ -12918,26 +12918,26 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  workerd@1.20260801.1:
+  workerd@1.20260804.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260801.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260801.1
-      '@cloudflare/workerd-linux-64': 1.20260801.1
-      '@cloudflare/workerd-linux-arm64': 1.20260801.1
-      '@cloudflare/workerd-windows-64': 1.20260801.1
+      '@cloudflare/workerd-darwin-64': 1.20260804.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260804.1
+      '@cloudflare/workerd-linux-64': 1.20260804.1
+      '@cloudflare/workerd-linux-arm64': 1.20260804.1
+      '@cloudflare/workerd-windows-64': 1.20260804.1
 
-  wrangler@4.120.0(@cloudflare/workers-types@5.20260809.1):
+  wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260804.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260801.1-alpha
+      miniflare: 5.20260804.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260801.1
+      workerd: 1.20260804.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260809.1
+      '@cloudflare/workers-types': 5.20260811.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ trustPolicyIgnoreAfter: 262800
 catalog:
   '@antfu/eslint-config': ^9.3.0
   '@arethetypeswrong/cli': ^0.18.5
-  '@cloudflare/workers-types': ^5.20260809.1
+  '@cloudflare/workers-types': ^5.20260811.1
   '@nuxt/kit': ^4.5.2
   '@nuxt/module-builder': ^1.0.2
   '@nuxt/schema': ^4.5.2
@@ -39,7 +39,7 @@ catalog:
   vue: ^3.5.40
   vue-router: ^5.2.0
   vue-tsc: ^3.3.9
-  wrangler: ^4.120.0
+  wrangler: ^4.120.1
   yaml: ^2.9.0
   zod: ^4.4.3
 
@@ -56,3 +56,8 @@ allowBuilds:
 peerDependencyRules:
   allowedVersions:
     vue-sfc-transformer: '>=0.1.1 <0.3.0'
+
+minimumReleaseAgeExclude:
+  - '@cloudflare/workers-types@5.20260811.1'
+  - miniflare@5.20260804.0-alpha
+  - wrangler@4.120.1


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Generated configs only passed a hand-maintained subset of Wrangler checks. New binding categories and invalid product config could slip through. D1 retries also treated resource pressure as transient, and KV accepted TTL values Cloudflare rejects.

Version 0.0.7 validates emitted config with Wrangler and covers Durable Objects, D1, storage, queues, email, pipelines, environments, observability, and secrets. It keeps the 0.0.6 Workers Cache policy: ambiguous HTML routes warn, explicit HTML caching fails, and known non-HTML routes remain cacheable.

### 📝 Migration

If production runtime config captures a secret from the build environment, leave its default empty and use a Worker secret binding.