### PR TITLE
feat(nuxt-cloudflare)!: add cost controls and typed bindings

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -22,6 +22,7 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 - Final generated Wrangler config validated through Wrangler, then audited after production Nitro compiles
 - Production builds fail when server runtime config contains a value copied from a secret build environment variable. The error lists config paths only
 - Complete defaults and diagnostics applied to every named Wrangler environment
+- Exact Cloudflare binding and runtime types generated during `nuxt prepare`
 
 Persistent KV mounts are never wrapped. The expiry policy applies only to cache data.
 
@@ -175,14 +176,16 @@ D1 allows 100 bound parameters per statement, including each statement inside `d
 import type { CloudflareBindingSource } from '@harlan-zw/nuxt-cloudflare/bindings'
 import { createCloudflareBindings } from '@harlan-zw/nuxt-cloudflare/bindings'
 
-const cloudflare = createCloudflareBindings<Env>()
+const cloudflare = createCloudflareBindings()
 
 function requireDatabase(source?: CloudflareBindingSource) {
   return cloudflare.require('DB', source)
 }
 ```
 
-`Env` comes from `wrangler types`. The source may be an H3 event, Nitro task input, or task context. Eventless access uses Nitro's `globalThis.__env__` Cloudflare entry shim. An explicit environment always wins and never mixes with the global environment. Binding names are constrained to `keyof Env`. Missing required bindings throw.
+`nuxt prepare` runs Wrangler and writes exact, compatibility-aware types to `.nuxt/types/cloudflare-bindings.d.ts`. It merges root JSON, JSONC, or TOML bindings with `nitro.cloudflare.wrangler`. The declaration is available only to Nitro server code. Production builds compare it with the final generated Wrangler config and fail on drift. Set `bindingTypes: false` only when another tool owns the declaration.
+
+The source may be an H3 event, Nitro task input, or task context. Eventless access uses Nitro's `globalThis.__env__` Cloudflare entry shim. An explicit environment always wins and never mixes with the global environment. Binding names come from the generated `CloudflareBindings` interface. Missing required bindings throw. Pass a generic only to override generated types in a focused test.
 
 ### Scoped secrets file
 

--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -8,7 +8,7 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 
 - Cloudflare module preset, generated Wrangler config, and Node compatibility
 - Static assets remain asset first by default. Blanket `assets.run_worker_first: true` warns because valid authentication and transform use cases exist
-- Workers Logs sampled at 10%, traces at 1%, both overridable
+- Workers Logs sampled at 1%, traces at 1%, both overridable
 - Preview URLs disabled unless explicitly enabled
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
@@ -62,6 +62,23 @@ Cloudflare KV requires TTLs of at least 60 seconds. The cache wrapper raises sho
 Keep server runtime secret defaults empty. Nuxt reads matching `NUXT_*` values from Worker secret bindings at runtime. The production build guard rejects secret build environment values before Nitro can include them in the bundle. Nuxt Scripts proxy signing remains allowed because that module registers its security plugin during the build.
 
 Workers Caching is separate from Nitro's KV-backed cache. The module enables version-isolated caching by default. Rendered HTML always stays private. API and asset responses keep explicit cache policies. Set `workersCache: { _tag: 'disabled' }` to opt out. Choose cross-version caching only with an explicit purge path.
+
+## Cost controls
+
+Cloudflare pricing changes. Check the linked pricing pages before making a budget.
+
+- Workers Logs use a 1% routine sample. [Workers Logs pricing](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#pricing) currently includes 20 million monthly events on Workers Paid, then charges $0.60 per million events.
+- Invocation logs remain enabled for baseline visibility. A high-volume Worker with complete custom failure telemetry can set `observability.logs.invocation_logs: false`. This removes one event from each sampled invocation.
+- Traces use a separate 1% sample. Each span is a metered event. [Trace pricing](https://developers.cloudflare.com/workers/observability/traces/#limits--pricing) currently lists 10 million included monthly events and says the quota is shared with logs. This differs from the Workers Logs page. Budget against the lower quota until Cloudflare resolves the difference.
+- Workers Caching uses version isolation by default. [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/#workers) bills cache hits as Worker requests, including static assets and Worker-to-Worker requests. Disable it when measured CPU savings do not exceed the added request cost.
+- Static assets stay asset first. Their requests are free and unlimited. Blanket Worker-first routing makes them billable Worker requests, so the module warns about it.
+- Cloudflare's 30-second CPU limit remains unchanged. The doctor warns when `limits.cpu_ms` exceeds 30,000 because the higher ceiling increases runaway-cost exposure.
+- Queue retries add billed read operations. Messages incur one operation per 64 KB chunk for each write, read, and delete. Keep payloads small and retries deliberate.
+- The KV-backed Nitro cache expires entries after 30 days by default. This bounds stored cache data. It does not reduce billed reads or writes.
+
+[D1 pricing](https://developers.cloudflare.com/d1/platform/pricing/) charges for rows read, rows written, and stored data. Indexes reduce billed scans but add writes and storage. Read replicas have no extra replica charge. The module does not change D1 routing or session behavior.
+
+Doctor warnings surface log or trace sampling above 1%, Workers Caching with static assets, CPU limits above 30 seconds, and queue retries above three.
 
 ## Doctor
 

--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -172,15 +172,17 @@ D1 allows 100 bound parameters per statement, including each statement inside `d
 ### Bindings
 
 ```ts
-import type { CloudflareEventLike } from '@harlan-zw/nuxt-cloudflare/bindings'
-import { requireCloudflareBinding } from '@harlan-zw/nuxt-cloudflare/bindings'
+import type { CloudflareBindingSource } from '@harlan-zw/nuxt-cloudflare/bindings'
+import { createCloudflareBindings } from '@harlan-zw/nuxt-cloudflare/bindings'
 
-function requireDatabase(event: CloudflareEventLike<Env>) {
-  return requireCloudflareBinding(event, 'DB')
+const cloudflare = createCloudflareBindings<Env>()
+
+function requireDatabase(source?: CloudflareBindingSource) {
+  return cloudflare.require('DB', source)
 }
 ```
 
-`Env` comes from `wrangler types`. Binding access is request-bound and binding names are constrained to `keyof Env`. Missing required bindings throw; there is no global or empty-object fallback.
+`Env` comes from `wrangler types`. The source may be an H3 event, Nitro task input, or task context. Eventless access uses Nitro's `globalThis.__env__` Cloudflare entry shim. An explicit environment always wins and never mixes with the global environment. Binding names are constrained to `keyof Env`. Missing required bindings throw.
 
 ### Scoped secrets file
 

--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -67,16 +67,16 @@ Workers Caching is separate from Nitro's KV-backed cache. The module enables ver
 
 Cloudflare pricing changes. Check the linked pricing pages before making a budget.
 
-- Workers Logs use a 1% routine sample. [Workers Logs pricing](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#pricing) currently includes 20 million monthly events on Workers Paid, then charges $0.60 per million events.
-- Invocation logs remain enabled for baseline visibility. A high-volume Worker with complete custom failure telemetry can set `observability.logs.invocation_logs: false`. This removes one event from each sampled invocation.
-- Traces use a separate 1% sample. Each span is a metered event. [Trace pricing](https://developers.cloudflare.com/workers/observability/traces/#limits--pricing) currently lists 10 million included monthly events and says the quota is shared with logs. This differs from the Workers Logs page. Budget against the lower quota until Cloudflare resolves the difference.
-- Workers Caching uses version isolation by default. [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/#workers) bills cache hits as Worker requests, including static assets and Worker-to-Worker requests. Disable it when measured CPU savings do not exceed the added request cost.
-- Static assets stay asset first. Their requests are free and unlimited. Blanket Worker-first routing makes them billable Worker requests, so the module warns about it.
-- Cloudflare's 30-second CPU limit remains unchanged. The doctor warns when `limits.cpu_ms` exceeds 30,000 because the higher ceiling increases runaway-cost exposure.
-- Queue retries add billed read operations. Messages incur one operation per 64 KB chunk for each write, read, and delete. Keep payloads small and retries deliberate.
-- The KV-backed Nitro cache expires entries after 30 days by default. This bounds stored cache data. It does not reduce billed reads or writes.
+- Workers Logs use a 1% routine sample. Paid plans include 20 million monthly events. Extra events cost $0.60 per million. See [Workers Logs pricing](https://developers.cloudflare.com/workers/observability/logs/workers-logs/#pricing).
+- Invocation logs remain enabled. High-volume Workers with complete error telemetry can set `observability.logs.invocation_logs: false`. This removes one event per sampled invocation.
+- Traces use a separate 1% sample. Each span is metered. [Trace pricing](https://developers.cloudflare.com/workers/observability/traces/#limits--pricing) lists 10 million included monthly events. It also says the quota is shared with logs. The Workers Logs page lists 20 million. Budget against 10 million until the pages agree.
+- Workers Caching uses version isolation by default. [Workers pricing](https://developers.cloudflare.com/workers/platform/pricing/#workers) bills cache hits as Worker requests. This includes static assets and Worker-to-Worker requests. Disable caching when CPU savings do not exceed the added request cost.
+- Static assets stay asset first. Their requests are free and unlimited. The module warns when blanket Worker-first routing makes assets billable.
+- Cloudflare's 30-second CPU limit remains unchanged. The doctor warns when `limits.cpu_ms` exceeds 30,000. A higher ceiling increases runaway-cost exposure.
+- Queue retries add billed read operations. Each 64 KB message chunk incurs write, read, and delete operations. Keep payloads small and retries deliberate.
+- The KV-backed Nitro cache expires entries after 30 days. This bounds stored cache data. It does not reduce billed operations.
 
-[D1 pricing](https://developers.cloudflare.com/d1/platform/pricing/) charges for rows read, rows written, and stored data. Indexes reduce billed scans but add writes and storage. Read replicas have no extra replica charge. The module does not change D1 routing or session behavior.
+[D1 pricing](https://developers.cloudflare.com/d1/platform/pricing/) charges for rows read, rows written, and stored data. Indexes reduce billed scans but add writes and storage. Read replicas add no separate charge. The module preserves D1 routing and session behavior.
 
 Doctor warnings surface log or trace sampling above 1%, Workers Caching with static assets, CPU limits above 30 seconds, and queue retries above three.
 

--- a/packages/nuxt-cloudflare/nuxt.config.ts
+++ b/packages/nuxt-cloudflare/nuxt.config.ts
@@ -1,1 +1,11 @@
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  // @ts-expect-error Module Builder loads this config before it generates module option types.
+  nuxtCloudflare: {
+    bindingTypes: false,
+  },
+  typescript: {
+    tsConfig: {
+      exclude: ['../tests/fixtures'],
+    },
+  },
+})

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -86,7 +86,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "pnpm run build && vitest run && pnpm run test:fixture",
-    "test:fixture": "nuxt build tests/fixtures/basic && node dist/cli/index.mjs doctor --cwd tests/fixtures/basic",
+    "test:fixture": "nuxi prepare tests/fixtures/basic && tsc --noEmit -p tests/fixtures/basic/.nuxt/tsconfig.server.json && nuxt build tests/fixtures/basic && node dist/cli/index.mjs doctor --cwd tests/fixtures/basic",
     "typecheck": "nuxt typecheck && tsc --noEmit -p tsconfig.check.json",
     "test:attw": "attw --pack",
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
@@ -98,6 +98,7 @@
   "dependencies": {
     "@nuxt/kit": "catalog:",
     "citty": "catalog:",
+    "confbox": "catalog:",
     "consola": "catalog:",
     "h3": "catalog:",
     "nitropack": "catalog:",

--- a/packages/nuxt-cloudflare/src/binding-types.ts
+++ b/packages/nuxt-cloudflare/src/binding-types.ts
@@ -1,0 +1,129 @@
+import type { WranglerConfigInput } from './wrangler'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { parseJSON, parseJSONC, parseTOML } from 'confbox'
+import { extname, resolve } from 'pathe'
+import { experimental_generateTypes } from 'wrangler'
+import { discoverWranglerSourceConfigs } from './diagnostics'
+
+interface BindingTypeGenerationOptions {
+  buildDir: string
+  compatibilityDate?: string
+  config: WranglerConfigInput
+  nodeCompat: boolean
+}
+
+export interface CloudflareBindingTypeArtifact {
+  content: string
+  signature: string
+}
+
+interface PreparedBindingTypeGenerationOptions extends Omit<BindingTypeGenerationOptions, 'config'> {
+  rootDir: string
+  wrangler: WranglerConfigInput
+}
+
+const COMPUTED_WRANGLER_KEYS = new Set([
+  'configPath',
+  'definedEnvironments',
+  'targetEnvironment',
+  'topLevelName',
+  'userConfigPath',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function mergeDefaults(primary: unknown, fallback: unknown): unknown {
+  if (primary === undefined || primary === null)
+    return fallback
+  if (Array.isArray(primary) && Array.isArray(fallback))
+    return [...primary, ...fallback]
+  if (!isRecord(primary) || !isRecord(fallback))
+    return primary
+
+  const merged: Record<string, unknown> = { ...primary }
+  for (const [key, value] of Object.entries(fallback))
+    merged[key] = mergeDefaults(merged[key], value)
+  return merged
+}
+
+function normalizeConfig(config: WranglerConfigInput, options: BindingTypeGenerationOptions): WranglerConfigInput {
+  const normalized = Object.fromEntries(
+    Object.entries(config).filter(([key, value]) => !COMPUTED_WRANGLER_KEYS.has(key) && value !== undefined),
+  ) as WranglerConfigInput
+  delete normalized.main
+
+  normalized.assets = mergeDefaults({ binding: 'ASSETS', directory: '.' }, normalized.assets) as WranglerConfigInput['assets']
+  normalized.compatibility_date ??= options.compatibilityDate
+
+  if (options.nodeCompat) {
+    const flags = new Set(normalized.compatibility_flags ?? [])
+    if (flags.has('nodejs_compat_v2') && flags.has('no_nodejs_compat_v2'))
+      flags.delete('nodejs_compat_v2')
+    if (!flags.has('nodejs_compat_v2')) {
+      flags.add('nodejs_compat')
+      flags.add('no_nodejs_compat_v2')
+    }
+    normalized.compatibility_flags = [...flags]
+  }
+
+  return normalized
+}
+
+async function readAuthoredConfig(rootDir: string): Promise<WranglerConfigInput> {
+  const [path] = discoverWranglerSourceConfigs(rootDir)
+  if (!path)
+    return {}
+  const source = await readFile(path, 'utf8')
+  const extension = extname(path)
+  if (extension === '.toml')
+    return parseTOML(source) as WranglerConfigInput
+  if (extension === '.jsonc')
+    return parseJSONC(source) as WranglerConfigInput
+  return parseJSON(source) as WranglerConfigInput
+}
+
+async function generateCloudflareBindingTypes(
+  options: BindingTypeGenerationOptions,
+): Promise<CloudflareBindingTypeArtifact> {
+  const directory = resolve(options.buildDir, 'nuxt-cloudflare')
+  const configPath = resolve(directory, 'wrangler.json')
+  const typePath = resolve(options.buildDir, 'types/cloudflare-bindings.d.ts')
+  await mkdir(directory, { recursive: true })
+  await writeFile(configPath, `${JSON.stringify(normalizeConfig(options.config, options), null, 2)}\n`)
+
+  const generated = await experimental_generateTypes({
+    config: configPath,
+    envInterface: 'CloudflareBindings',
+    includeRuntime: true,
+    path: typePath,
+    strictVars: false,
+  })
+  if (!generated.env || !generated.runtime)
+    throw new Error('[nuxt-cloudflare] Wrangler did not generate Cloudflare binding and runtime types.')
+
+  return {
+    content: generated.content,
+    signature: `${generated.env}\0${generated.runtime}`,
+  }
+}
+
+export async function prepareCloudflareBindingTypes(
+  options: PreparedBindingTypeGenerationOptions,
+): Promise<CloudflareBindingTypeArtifact> {
+  const authored = await readAuthoredConfig(options.rootDir)
+  const config = mergeDefaults(options.wrangler, authored) as WranglerConfigInput
+  return generateCloudflareBindingTypes({ ...options, config })
+}
+
+export async function assertCloudflareBindingTypesCurrent(
+  options: BindingTypeGenerationOptions & { expectedSignature: string },
+): Promise<void> {
+  const generated = await generateCloudflareBindingTypes(options)
+  if (generated.signature !== options.expectedSignature) {
+    throw new Error(
+      '[nuxt-cloudflare] Generated binding types differ from the final Wrangler config. Run `nuxt prepare` and review binding configuration order.',
+    )
+  }
+}

--- a/packages/nuxt-cloudflare/src/bindings.ts
+++ b/packages/nuxt-cloudflare/src/bindings.ts
@@ -1,31 +1,70 @@
-export interface CloudflareEventLike<Environment extends object> {
-  context?: {
-    cloudflare?: {
-      env?: Environment
-    }
+type BindingName<Environment extends object> = Extract<keyof Environment, string>
+
+type CloudflareEntryHost = typeof globalThis & { __env__?: unknown }
+
+export interface CloudflareBindingSource {
+  cloudflare?: unknown
+  context?: unknown
+}
+
+export interface CloudflareBindings<Environment extends object> {
+  resolve: (source?: CloudflareBindingSource) => Environment | undefined
+  get: <Name extends BindingName<Environment>>(
+    name: Name,
+    source?: CloudflareBindingSource,
+  ) => Environment[Name] | undefined
+  require: <Name extends BindingName<Environment>>(
+    name: Name,
+    source?: CloudflareBindingSource,
+  ) => Exclude<Environment[Name], undefined>
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function envFromContext(value: unknown): Record<string, unknown> | undefined {
+  const cloudflare = asRecord(value)?.cloudflare
+  return asRecord(asRecord(cloudflare)?.env)
+}
+
+function resolveEnvironment<Environment extends object>(source?: CloudflareBindingSource): Environment | undefined {
+  const sourceRecord = asRecord(source)
+  const sourceEnv = envFromContext(sourceRecord?.context) ?? envFromContext(sourceRecord)
+  const globalEnv = asRecord((globalThis as CloudflareEntryHost).__env__)
+  return (sourceEnv ?? globalEnv) as Environment | undefined
+}
+
+/**
+ * Creates typed binding access for Wrangler's generated `Env` or `CloudflareEnv`.
+ *
+ * The source may be an H3 event, a Nitro task run input, or a Nitro task context.
+ * If the source has no environment, Nitro's Cloudflare entry shim is used.
+ */
+export function createCloudflareBindings<Environment extends object>(): CloudflareBindings<Environment> {
+  function get<Name extends BindingName<Environment>>(
+    name: Name,
+    source?: CloudflareBindingSource,
+  ): Environment[Name] | undefined {
+    const env = resolveEnvironment<Environment>(source)
+    return env && Object.hasOwn(env, name) ? env[name] : undefined
   }
-}
 
-export function getCloudflareBinding<
-  Environment extends object,
-  Name extends Extract<keyof Environment, string>,
->(
-  event: CloudflareEventLike<Environment>,
-  name: Name,
-): Environment[Name] | undefined {
-  const env = event.context?.cloudflare?.env
-  return env && Object.hasOwn(env, name) ? env[name] : undefined
-}
+  function requireBinding<Name extends BindingName<Environment>>(
+    name: Name,
+    source?: CloudflareBindingSource,
+  ): Exclude<Environment[Name], undefined> {
+    const binding = get(name, source)
+    if (binding === undefined)
+      throw new Error(`Cloudflare binding "${name}" is unavailable`)
+    return binding as Exclude<Environment[Name], undefined>
+  }
 
-export function requireCloudflareBinding<
-  Environment extends object,
-  Name extends Extract<keyof Environment, string>,
->(
-  event: CloudflareEventLike<Environment>,
-  name: Name,
-): Exclude<Environment[Name], undefined> {
-  const binding = getCloudflareBinding(event, name)
-  if (binding === undefined)
-    throw new Error(`Cloudflare binding "${name}" is unavailable`)
-  return binding as Exclude<Environment[Name], undefined>
+  return {
+    resolve: resolveEnvironment,
+    get,
+    require: requireBinding,
+  }
 }

--- a/packages/nuxt-cloudflare/src/bindings.ts
+++ b/packages/nuxt-cloudflare/src/bindings.ts
@@ -2,12 +2,16 @@ type BindingName<Environment extends object> = Extract<keyof Environment, string
 
 type CloudflareEntryHost = typeof globalThis & { __env__?: unknown }
 
+declare global {
+  interface CloudflareBindings {}
+}
+
 export interface CloudflareBindingSource {
   cloudflare?: unknown
   context?: unknown
 }
 
-export interface CloudflareBindings<Environment extends object> {
+export interface CloudflareBindingAccessor<Environment extends object> {
   resolve: (source?: CloudflareBindingSource) => Environment | undefined
   get: <Name extends BindingName<Environment>>(
     name: Name,
@@ -38,12 +42,12 @@ function resolveEnvironment<Environment extends object>(source?: CloudflareBindi
 }
 
 /**
- * Creates typed binding access for Wrangler's generated `Env` or `CloudflareEnv`.
+ * Creates typed binding access for the generated `CloudflareBindings` environment.
  *
  * The source may be an H3 event, a Nitro task run input, or a Nitro task context.
  * If the source has no environment, Nitro's Cloudflare entry shim is used.
  */
-export function createCloudflareBindings<Environment extends object>(): CloudflareBindings<Environment> {
+export function createCloudflareBindings<Environment extends object = CloudflareBindings>(): CloudflareBindingAccessor<Environment> {
   function get<Name extends BindingName<Environment>>(
     name: Name,
     source?: CloudflareBindingSource,

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -3,7 +3,7 @@ import type { Nitro } from 'nitropack/types'
 import type { WranglerDiagnosticPolicy } from './diagnostics'
 import type { WorkersCachePolicy } from './wrangler'
 import process from 'node:process'
-import { defineNuxtModule, useLogger } from '@nuxt/kit'
+import { addTypeTemplate, defineNuxtModule, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import {
   diagnoseWranglerSourceConfigs,
@@ -19,6 +19,7 @@ import {
 } from './wrangler'
 
 export interface ModuleOptions {
+  bindingTypes?: boolean
   enabled?: boolean
   compatibilityDate?: string
   compatibilityMaxAgeDays?: number
@@ -142,7 +143,13 @@ export function configureNitroCloudflare(
   }
 }
 
-async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions, rootDir: string): Promise<void> {
+async function auditGeneratedWranglerConfig(
+  nitro: Nitro,
+  options: ModuleOptions,
+  buildDir: string,
+  rootDir: string,
+  bindingTypeSignature?: string,
+): Promise<void> {
   const path = resolve(nitro.options.output.serverDir, 'wrangler.json')
   const result = await readWranglerJsonFile(path)
   if (result._tag === 'missing')
@@ -154,6 +161,17 @@ async function auditGeneratedWranglerConfig(nitro: Nitro, options: ModuleOptions
   const validated = readProjectWranglerConfig({ config: path, cwd: rootDir })
   if (validated._tag === 'invalid')
     throw new Error('[nuxt-cloudflare] Generated Wrangler config fails Wrangler schema validation. Run Wrangler locally for validation details.')
+
+  if (bindingTypeSignature) {
+    const { assertCloudflareBindingTypesCurrent } = await import('./binding-types')
+    await assertCloudflareBindingTypesCurrent({
+      buildDir,
+      compatibilityDate: result.config.compatibility_date,
+      config: result.config,
+      expectedSignature: bindingTypeSignature,
+      nodeCompat: Boolean(nitro.options.cloudflare?.nodeCompat),
+    })
+  }
 
   const diagnostics = [
     ...diagnoseWranglerConfig(result.config, {
@@ -186,6 +204,29 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
     Boolean(nuxt.options.sourcemap.server),
   )
 
+  let bindingTypeSignature: string | undefined
+
+  if (options.bindingTypes !== false) {
+    addTypeTemplate({
+      filename: 'types/cloudflare-bindings.d.ts',
+      getContents: async () => {
+        const { prepareCloudflareBindingTypes } = await import('./binding-types')
+        const compatibilityDate = nuxt.options.compatibilityDate
+        const artifact = await prepareCloudflareBindingTypes({
+          buildDir: nuxt.options.buildDir,
+          compatibilityDate: typeof compatibilityDate === 'string'
+            ? compatibilityDate || undefined
+            : compatibilityDate.cloudflare ?? compatibilityDate.default,
+          nodeCompat: Boolean((nuxt.options.nitro as NitroCloudflareShape).cloudflare?.nodeCompat),
+          rootDir: nuxt.options.rootDir,
+          wrangler: (nuxt.options.nitro as NitroCloudflareShape).cloudflare?.wrangler ?? {},
+        })
+        bindingTypeSignature = artifact.signature
+        return artifact.content
+      },
+    }, { nitro: true })
+  }
+
   configure()
   nuxt.hook('modules:done', () => {
     configure()
@@ -212,7 +253,13 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   })
   if (!nuxt.options.dev) {
     nuxt.hook('nitro:init', (nitro) => {
-      nitro.hooks.hook('compiled', () => auditGeneratedWranglerConfig(nitro, options, nuxt.options.rootDir))
+      nitro.hooks.hook('compiled', () => auditGeneratedWranglerConfig(
+        nitro,
+        options,
+        nuxt.options.buildDir,
+        nuxt.options.rootDir,
+        bindingTypeSignature,
+      ))
     })
   }
 }
@@ -224,6 +271,7 @@ export default defineNuxtModule<ModuleOptions>({
     compatibility: { nuxt: '>=4.5.0' },
   },
   defaults: {
+    bindingTypes: true,
     enabled: true,
     compatibilityMaxAgeDays: 90,
     doctor: { _tag: 'advisory' },

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -227,7 +227,7 @@ export default defineNuxtModule<ModuleOptions>({
     enabled: true,
     compatibilityMaxAgeDays: 90,
     doctor: { _tag: 'advisory' },
-    logsSampleRate: 0.1,
+    logsSampleRate: 0.01,
     tracesSampleRate: 0.01,
     versionMetadataBinding: 'CF_VERSION_METADATA',
     workersCache: { _tag: 'enabled', crossVersion: false },

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -57,6 +57,10 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   env?: Record<string, WranglerConfigInput>
   images?: WranglerRemoteBindingInput
   keep_vars?: boolean
+  limits?: {
+    cpu_ms?: number
+    subrequests?: number
+  }
   mtls_certificates?: WranglerRemoteBindingInput[]
   observability?: WranglerObservabilityInput
   placement?: WranglerPlacementInput
@@ -97,6 +101,7 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'container-durable-object-binding-missing',
   'container-durable-object-not-sqlite',
   'container-instance-type-deprecated',
+  'cpu-limit-raised',
   'durable-object-binding-inactive',
   'durable-object-lifecycle-mixed',
   'durable-object-lifecycle-unmanaged',
@@ -108,8 +113,10 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'missing-nodejs-compat',
   'nodejs-compat-version-implicit',
   'observability-disabled',
+  'observability-log-sampling-high',
   'observability-sampling-implicit',
   'observability-sampling-out-of-range',
+  'observability-trace-sampling-high',
   'plaintext-secret-var',
   'preview-urls-public',
   'pipeline-binding-deprecated',
@@ -127,6 +134,7 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'workers-dev-enabled',
   'workers-dev-implicit',
   'workers-cache-cross-version-enabled',
+  'workers-cache-assets-billable',
   'workers-cache-policy-implicit',
   'wrangler-config-shadowed',
   'wrangler-config-missing',
@@ -425,7 +433,7 @@ function applyEnvironmentDefaults(
         ...inheritedLogs,
         ...logs,
         enabled: logs?.enabled ?? inheritedLogs?.enabled ?? true,
-        head_sampling_rate: logs?.head_sampling_rate ?? inheritedLogs?.head_sampling_rate ?? options.logsSampleRate ?? 0.1,
+        head_sampling_rate: logs?.head_sampling_rate ?? inheritedLogs?.head_sampling_rate ?? options.logsSampleRate ?? 0.01,
         invocation_logs: logs?.invocation_logs ?? inheritedLogs?.invocation_logs ?? true,
       },
       traces: {
@@ -716,7 +724,7 @@ function diagnoseEnvironment(
       diagnostics.push({
         _tag: 'warning',
         code: 'queue-retries-above-policy',
-        message: `Queue consumer retries ${retries} times, above Cloudflare's default of 3. Verify the work is replay-safe.`,
+        message: `Queue consumer retries ${retries} times, above Cloudflare's default of 3. Each retry adds a billed read operation.`,
         configPath: `${prefix}queues.consumers.${index}.max_retries`,
       })
     }
@@ -841,6 +849,24 @@ function diagnosePolicy(
         configPath: `${prefix}observability`,
       })
     }
+    const logsSampleRate = config.observability.logs?.head_sampling_rate
+    if (logsEnabled && logsSampleRate !== undefined && logsSampleRate > 0.01 && logsSampleRate <= 1) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'observability-log-sampling-high',
+        message: 'Log sampling exceeds the 1% routine budget and can create significant metered event volume.',
+        configPath: `${prefix}observability.logs.head_sampling_rate`,
+      })
+    }
+    const tracesSampleRate = config.observability.traces?.head_sampling_rate
+    if (tracesEnabled && tracesSampleRate !== undefined && tracesSampleRate > 0.01 && tracesSampleRate <= 1) {
+      diagnostics.push({
+        _tag: 'warning',
+        code: 'observability-trace-sampling-high',
+        message: 'Trace sampling exceeds the 1% routine budget; each captured span is a metered event.',
+        configPath: `${prefix}observability.traces.head_sampling_rate`,
+      })
+    }
   }
   if (config.upload_source_maps !== true) {
     diagnostics.push({
@@ -880,6 +906,22 @@ function diagnosePolicy(
       code: 'workers-cache-cross-version-enabled',
       message: 'Cross-version caching can serve responses from superseded deployments until expiry or purge.',
       configPath: `${prefix}cache.cross_version_cache`,
+    })
+  }
+  if (config.cache?.enabled && config.assets !== undefined) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'workers-cache-assets-billable',
+      message: 'Workers Caching makes cached static asset requests billable. Confirm CPU savings exceed request charges.',
+      configPath: `${prefix}cache.enabled`,
+    })
+  }
+  if (typeof config.limits?.cpu_ms === 'number' && config.limits.cpu_ms > 30_000) {
+    diagnostics.push({
+      _tag: 'warning',
+      code: 'cpu-limit-raised',
+      message: 'The CPU limit exceeds Cloudflare\'s 30-second default and increases runaway-cost exposure.',
+      configPath: `${prefix}limits.cpu_ms`,
     })
   }
   if (config.preview_urls === true) {

--- a/packages/nuxt-cloudflare/tests/bindings.test.ts
+++ b/packages/nuxt-cloudflare/tests/bindings.test.ts
@@ -1,32 +1,83 @@
-import type { CloudflareEventLike } from '../src/bindings'
-import { describe, expect, expectTypeOf, it } from 'vitest'
-import { getCloudflareBinding, requireCloudflareBinding } from '../src/bindings'
+import type { H3Event } from 'h3'
+import type { TaskContext, TaskEvent } from 'nitropack/types'
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest'
+import { createCloudflareBindings } from '../src/bindings'
 
 interface TestEnvironment {
   DB: { marker: 'db' }
   OPTIONAL_CACHE?: { marker: 'cache' }
 }
 
+const bindings = createCloudflareBindings<TestEnvironment>()
+const taskEnvHost = globalThis as typeof globalThis & { __env__?: unknown }
+
+afterEach(() => {
+  delete taskEnvHost.__env__
+})
+
 describe('cloudflare bindings', () => {
-  it('reads bindings only from the explicit request environment', () => {
-    const event: CloudflareEventLike<{ DB: { marker: string }, MISSING?: never }> = { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }
-    expect(getCloudflareBinding(event, 'DB')).toEqual({ marker: 'db' })
-    expect(getCloudflareBinding(event, 'MISSING')).toBeUndefined()
+  it('reads a binding from a request event', () => {
+    const event = { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }
+
+    expect(bindings.get('DB', event)).toEqual({ marker: 'db' })
   })
 
-  it('fails loudly for a required missing binding', () => {
-    const event: CloudflareEventLike<{ DB: unknown }> = { context: {} }
-    expect(() => requireCloudflareBinding(event, 'DB')).toThrow('Cloudflare binding "DB" is unavailable')
+  it.each([
+    ['task run input', { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }],
+    ['task context', { cloudflare: { env: { DB: { marker: 'db' } } } }],
+  ])('reads a binding from a Nitro %s', (_label, source) => {
+    expect(bindings.get('DB', source)).toEqual({ marker: 'db' })
+  })
+
+  it('falls back to the Cloudflare entry environment without an event', () => {
+    taskEnvHost.__env__ = { DB: { marker: 'db' } }
+
+    expect(bindings.get('DB')).toEqual({ marker: 'db' })
+  })
+
+  it('returns undefined for an unavailable optional binding', () => {
+    const event = { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }
+
+    expect(bindings.get('OPTIONAL_CACHE', event)).toBeUndefined()
+  })
+
+  it('fails loudly for an unavailable required binding', () => {
+    expect(() => bindings.require('DB', { context: {} })).toThrow('Cloudflare binding "DB" is unavailable')
+  })
+
+  it('prefers a task run input over its task context and the global fallback', () => {
+    taskEnvHost.__env__ = { DB: { marker: 'global' } }
+    const source = {
+      cloudflare: { env: { DB: { marker: 'context' } } },
+      context: { cloudflare: { env: { DB: { marker: 'input' } } } },
+    }
+
+    expect(bindings.get('DB', source)).toEqual({ marker: 'input' })
+  })
+
+  it('does not mix global bindings into an explicit environment', () => {
+    taskEnvHost.__env__ = { DB: { marker: 'global' } }
+
+    expect(bindings.get('DB', { context: { cloudflare: { env: {} } } })).toBeUndefined()
   })
 
   it('derives binding names and values from the generated environment type', () => {
-    const event: CloudflareEventLike<TestEnvironment> = { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }
-    expectTypeOf(requireCloudflareBinding(event, 'DB')).toEqualTypeOf<{ marker: 'db' }>()
-    expectTypeOf(getCloudflareBinding(event, 'OPTIONAL_CACHE')).toEqualTypeOf<{ marker: 'cache' } | undefined>()
+    const event = { context: { cloudflare: { env: { DB: { marker: 'db' } } } } }
+
+    expectTypeOf(bindings.require('DB', event)).toEqualTypeOf<{ marker: 'db' }>()
+    expectTypeOf(bindings.get('OPTIONAL_CACHE')).toEqualTypeOf<{ marker: 'cache' } | undefined>()
+    expectTypeOf(bindings.resolve(event)).toEqualTypeOf<TestEnvironment | undefined>()
 
     if (false) {
+      const requestEvent = {} as H3Event
+      const taskInput = {} as TaskEvent
+      const taskContext = {} as TaskContext
+      bindings.get('DB', requestEvent)
+      bindings.get('DB', taskInput)
+      bindings.get('DB', taskContext)
+
       // @ts-expect-error unknown binding names must be rejected by the generated environment type.
-      requireCloudflareBinding(event, 'TYPO')
+      bindings.require('TYPO')
     }
   })
 })

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/nuxt.config.ts
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/nuxt.config.ts
@@ -12,6 +12,8 @@ export default defineNuxtConfig({
       wrangler: {
         name: 'nuxt-cloudflare-fixture',
         assets: { run_worker_first: ['/pro/_nuxt/*'] },
+        d1_databases: [{ binding: 'DB', database_id: 'fixture-database' }],
+        queues: { producers: [{ binding: 'JOBS', queue: 'fixture-jobs' }] },
       },
     },
     storage: {

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/server/api/bindings.get.ts
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/server/api/bindings.get.ts
@@ -1,0 +1,13 @@
+import { createCloudflareBindings } from '@harlan-zw/nuxt-cloudflare/bindings'
+
+const bindings = createCloudflareBindings()
+
+export default defineEventHandler((event) => {
+  const statement = bindings.require('DB', event).prepare('SELECT 1')
+  return { statement: Boolean(statement) }
+})
+
+if (false) {
+  // @ts-expect-error Wrangler did not generate this binding.
+  bindings.require('UNKNOWN')
+}

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/server/tasks/bindings.ts
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/server/tasks/bindings.ts
@@ -1,0 +1,14 @@
+import { createCloudflareBindings } from '@harlan-zw/nuxt-cloudflare/bindings'
+
+const bindings = createCloudflareBindings()
+
+export default defineTask({
+  meta: {
+    name: 'bindings',
+    description: 'Checks generated Cloudflare binding types.',
+  },
+  async run(event) {
+    const response = await bindings.require('JOBS', event).send({ source: 'fixture' })
+    return { result: response }
+  },
+})

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/wrangler.jsonc
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/wrangler.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "kv_namespaces": [
+    { "binding": "CACHE", "id": "fixture-cache" }
+  ],
+  "r2_buckets": [
+    { "binding": "FILES", "bucket_name": "fixture-files" }
+  ]
+}

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -135,7 +135,7 @@ describe('setupCloudflareModule', () => {
     Object.assign(nuxt.options.runtimeConfig, { oauth: { clientSecret: 'oauth-sentinel' } })
     vi.stubEnv('NUXT_OAUTH_CLIENT_SECRET', 'oauth-sentinel')
 
-    setupCloudflareModule({ enabled: true }, nuxt)
+    setupCloudflareModule({ bindingTypes: false, enabled: true }, nuxt)
 
     expect(callbacks['modules:done']).toThrow('oauth.clientSecret')
     expect(callbacks['modules:done']).not.toThrow('oauth-sentinel')
@@ -144,7 +144,7 @@ describe('setupCloudflareModule', () => {
   it('does not register the production Wrangler audit during development', () => {
     const { hooks, nuxt } = nuxtWithCapturedHooks(true)
 
-    setupCloudflareModule({ enabled: true }, nuxt)
+    setupCloudflareModule({ bindingTypes: false, enabled: true }, nuxt)
 
     expect(hooks).toEqual(['modules:done', 'nitro:config'])
   })
@@ -152,7 +152,7 @@ describe('setupCloudflareModule', () => {
   it('registers the production Wrangler audit for builds', () => {
     const { hooks, nuxt } = nuxtWithCapturedHooks(false)
 
-    setupCloudflareModule({ enabled: true }, nuxt)
+    setupCloudflareModule({ bindingTypes: false, enabled: true }, nuxt)
 
     expect(hooks).toEqual(['modules:done', 'nitro:config', 'nitro:init'])
   })
@@ -161,8 +161,8 @@ describe('setupCloudflareModule', () => {
     const disabled = nuxtWithCapturedHooks(false, false)
     const enabled = nuxtWithCapturedHooks(false, true)
 
-    setupCloudflareModule({ enabled: true }, disabled.nuxt)
-    setupCloudflareModule({ enabled: true }, enabled.nuxt)
+    setupCloudflareModule({ bindingTypes: false, enabled: true }, disabled.nuxt)
+    setupCloudflareModule({ bindingTypes: false, enabled: true }, enabled.nuxt)
 
     expect(disabled.nuxt.options.nitro.cloudflare?.wrangler?.upload_source_maps).toBe(false)
     expect(enabled.nuxt.options.nitro.cloudflare?.wrangler?.upload_source_maps).toBe(true)

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { applyCloudflareDefaults, diagnoseWranglerConfig } from '../src/wrangler'
 
 describe('applyCloudflareDefaults', () => {
+  it('samples routine Workers Logs at one percent by default', () => {
+    expect(applyCloudflareDefaults({}).observability?.logs?.head_sampling_rate).toBe(0.01)
+  })
+
   it('adds the proven Nuxt SEO and gscdump baseline without replacing user sampling', () => {
     expect(applyCloudflareDefaults({
       compatibility_flags: ['global_fetch_strictly_public'],
@@ -207,6 +211,69 @@ describe('applyCloudflareDefaults', () => {
 })
 
 describe('diagnoseWranglerConfig', () => {
+  it('warns when log sampling exceeds the routine one-percent budget', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: {
+        enabled: true,
+        logs: { enabled: true, head_sampling_rate: 0.1 },
+        traces: { enabled: true, head_sampling_rate: 0.01 },
+      },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'observability-log-sampling-high',
+      }))
+  })
+
+  it('warns when trace sampling exceeds the routine one-percent budget', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: {
+        enabled: true,
+        logs: { enabled: true, head_sampling_rate: 0.01 },
+        traces: { enabled: true, head_sampling_rate: 0.1 },
+      },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'observability-trace-sampling-high',
+      }))
+  })
+
+  it('warns when Workers Caching makes static asset requests billable', () => {
+    expect(diagnoseWranglerConfig({
+      assets: { directory: '.output/public' },
+      cache: { enabled: true, cross_version_cache: false },
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'workers-cache-assets-billable',
+      }))
+  })
+
+  it('warns when a raised CPU limit increases runaway-cost exposure', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      limits: { cpu_ms: 60_000 },
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .toContainEqual(expect.objectContaining({
+        _tag: 'warning',
+        code: 'cpu-limit-raised',
+      }))
+  })
+
   it('warns when Workers Caching policy is implicit', () => {
     expect(diagnoseWranglerConfig({
       compatibility_date: '2026-08-11',

--- a/packages/nuxt-cloudflare/tsconfig.check.json
+++ b/packages/nuxt-cloudflare/tsconfig.check.json
@@ -9,6 +9,7 @@
   ],
   "exclude": [
     "dist",
-    "node_modules"
+    "node_modules",
+    "tests/fixtures"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     citty:
       specifier: ^0.2.2
       version: 0.2.2
+    confbox:
+      specifier: ^0.2.4
+      version: 0.2.4
     consola:
       specifier: ^3.4.2
       version: 3.4.2
@@ -206,6 +209,9 @@ importers:
       citty:
         specifier: 'catalog:'
         version: 0.2.2
+      confbox:
+        specifier: 'catalog:'
+        version: 0.2.4
       consola:
         specifier: 'catalog:'
         version: 3.4.2
@@ -220,7 +226,7 @@ importers:
         version: 2.0.3
       unstorage:
         specifier: 'catalog:'
-        version: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+        version: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -7291,7 +7297,7 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
+  '@nuxt/devtools@3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -7321,7 +7327,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.4.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
@@ -7473,7 +7479,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7559,7 +7565,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -7645,7 +7651,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
       vue: 3.5.41(typescript@5.9.3)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -10869,7 +10875,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      unstorage: 1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -10964,7 +10970,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(86bebef3c2d367abe47f4b69f74979aa)
       '@nuxt/schema': 4.5.2
@@ -11105,7 +11111,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(306b7872170b5fee229ee019d68f27d2)
       '@nuxt/schema': 4.5.2
@@ -11246,7 +11252,7 @@ snapshots:
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
-      '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/devtools': 3.4.1(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/nitro-server': 4.5.2(1ddd60ae9f6acff327e58c4f29acd342)
       '@nuxt/schema': 4.5.2
@@ -12610,7 +12616,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1):
+  unstorage@1.17.5(db0@0.3.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(zod@4.4.3)))(ioredis@5.11.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   '@vue/test-utils': ^2.4.11
   '@vueuse/core': ^14.4.0
   citty: ^0.2.2
+  confbox: ^0.2.4
   consola: ^3.4.2
   drizzle-orm: 1.0.0-rc.4
   eslint: ^10.8.1


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

Workers Logs defaulted to 10%, while cache hits, raised CPU ceilings, and queue retries had no cost diagnostics. Routine logs now default to 1%, and Doctor flags those billable choices.

H3 handlers and Nitro tasks also required separate binding casts. One accessor now reads both event shapes.

`nuxt prepare` runs Wrangler against root JSON, JSONC, or TOML plus `nitro.cloudflare.wrangler`. Server code gets the actual binding and runtime types, and production builds reject drift from the final config.

### ⚠️ Breaking Changes

`getCloudflareBinding`, `requireCloudflareBinding`, and `CloudflareEventLike` are removed.

### 📝 Migration

Create one accessor and pass an H3 event, Nitro `TaskEvent`, or `TaskContext`:

```ts
const bindings = createCloudflareBindings()
const db = bindings.require('DB', event)
```