### PR TITLE
fix(nuxt-cloudflare): expose bindings to Nuxt typecheck

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -183,7 +183,7 @@ function requireDatabase(source?: CloudflareBindingSource) {
 }
 ```
 
-`nuxt prepare` runs Wrangler and writes exact, compatibility-aware types to `.nuxt/types/cloudflare-bindings.d.ts`. It merges root JSON, JSONC, or TOML bindings with `nitro.cloudflare.wrangler`. The declaration is available only to Nitro server code. Production builds compare it with the final generated Wrangler config and fail on drift. Set `bindingTypes: false` only when another tool owns the declaration.
+`nuxt prepare` runs Wrangler and writes exact, compatibility-aware types to `.nuxt/types/cloudflare-bindings.d.ts`. It merges root JSON, JSONC, or TOML bindings with `nitro.cloudflare.wrangler`. Nuxt and Nitro typechecks both reference the declaration, while bindings remain server runtime values. Production builds compare it with the final generated Wrangler config and fail on drift. Set `bindingTypes: false` only when another tool owns the declaration.
 
 The source may be an H3 event, Nitro task input, or task context. Eventless access uses Nitro's `globalThis.__env__` Cloudflare entry shim. An explicit environment always wins and never mixes with the global environment. Binding names come from the generated `CloudflareBindings` interface. Missing required bindings throw. Pass a generic only to override generated types in a focused test.
 

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -86,7 +86,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "pnpm run build && vitest run && pnpm run test:fixture",
-    "test:fixture": "nuxi prepare tests/fixtures/basic && tsc --noEmit -p tests/fixtures/basic/.nuxt/tsconfig.server.json && nuxt build tests/fixtures/basic && node dist/cli/index.mjs doctor --cwd tests/fixtures/basic",
+    "test:fixture": "nuxi prepare tests/fixtures/basic && nuxt typecheck tests/fixtures/basic && nuxt build tests/fixtures/basic && node dist/cli/index.mjs doctor --cwd tests/fixtures/basic",
     "typecheck": "nuxt typecheck && tsc --noEmit -p tsconfig.check.json",
     "test:attw": "attw --pack",
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -224,7 +224,7 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
         bindingTypeSignature = artifact.signature
         return artifact.content
       },
-    }, { nitro: true })
+    }, { nitro: true, nuxt: true })
   }
 
   configure()

--- a/packages/nuxt-cloudflare/tests/fixtures/basic/tsconfig.json
+++ b/packages/nuxt-cloudflare/tests/fixtures/basic/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
## Summary

Register generated Cloudflare binding declarations with both Nuxt and Nitro type contexts.

Add a fixture that runs the same combined `nuxt typecheck` used by consumers.

## Verification

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`