### PR TITLE
fix(nuxt-cloudflare): stabilize generated binding types

### DIFF
--- a/packages/nuxt-cloudflare/src/binding-types.ts
+++ b/packages/nuxt-cloudflare/src/binding-types.ts
@@ -71,6 +71,35 @@ function normalizeConfig(config: WranglerConfigInput, options: BindingTypeGenera
   return normalized
 }
 
+function compareText(left: string, right: string): number {
+  if (left < right)
+    return -1
+  if (left > right)
+    return 1
+  return 0
+}
+
+function canonicalizeBindingEnvironment(environment: string): string {
+  return environment
+    .replaceAll('\r\n', '\n')
+    .replace(
+      /(interface __BaseEnv_CloudflareBindings \{\n)([\s\S]*?)(\n\})/,
+      (_, opening: string, members: string, closing: string) => [
+        opening,
+        members.split('\n').sort((left, right) => compareText(left.trim(), right.trim())).join('\n'),
+        closing,
+      ].join(''),
+    )
+    .replace(
+      /Pick<Cloudflare\.Env,([^>]+)>/g,
+      (_, members: string) => `Pick<Cloudflare.Env, ${members.split('|').map(member => member.trim()).sort(compareText).join(' | ')}>`,
+    )
+}
+
+function createBindingTypeSignature(environment: string, runtime: string): string {
+  return `${canonicalizeBindingEnvironment(environment)}\0${runtime.replaceAll('\r\n', '\n')}`
+}
+
 async function readAuthoredConfig(rootDir: string): Promise<WranglerConfigInput> {
   const [path] = discoverWranglerSourceConfigs(rootDir)
   if (!path)
@@ -105,7 +134,7 @@ async function generateCloudflareBindingTypes(
 
   return {
     content: generated.content,
-    signature: `${generated.env}\0${generated.runtime}`,
+    signature: createBindingTypeSignature(generated.env, generated.runtime),
   }
 }
 

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -207,7 +207,7 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   let bindingTypeSignature: string | undefined
 
   if (options.bindingTypes !== false) {
-    addTypeTemplate({
+    const bindingTypesTemplate = addTypeTemplate({
       filename: 'types/cloudflare-bindings.d.ts',
       getContents: async () => {
         const { prepareCloudflareBindingTypes } = await import('./binding-types')
@@ -224,7 +224,10 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
         bindingTypeSignature = artifact.signature
         return artifact.content
       },
-    }, { nitro: true, nuxt: true })
+    }, { nitro: true })
+    nuxt.hook('prepare:types', ({ references }) => {
+      references.push({ path: bindingTypesTemplate.dst })
+    })
   }
 
   configure()

--- a/packages/nuxt-cloudflare/tests/binding-types.test.ts
+++ b/packages/nuxt-cloudflare/tests/binding-types.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { prepareCloudflareBindingTypes } from '../src/binding-types'
+
+describe('prepareCloudflareBindingTypes', () => {
+  it('gives reordered Wrangler vars and ProcessEnv keys the same signature', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-binding-types-'))
+    const common = {
+      compatibilityDate: '2026-08-11',
+      nodeCompat: true,
+      rootDir: root,
+    }
+
+    try {
+      const prepared = await prepareCloudflareBindingTypes({
+        ...common,
+        buildDir: join(root, 'prepared'),
+        wrangler: {
+          vars: {
+            NUXT_PUBLIC_BASE_URL: 'https://gscdump.com',
+            BING_INDEXING_PREVIEW_ALLOWLIST: '',
+            ICEBERG_R2_S3_ENDPOINT: 'https://example.r2.cloudflarestorage.com',
+            OVERLAY_CATALOG_ENABLED: 'true',
+          },
+        },
+      })
+      const final = await prepareCloudflareBindingTypes({
+        ...common,
+        buildDir: join(root, 'final'),
+        wrangler: {
+          vars: {
+            ICEBERG_R2_S3_ENDPOINT: 'https://example.r2.cloudflarestorage.com',
+            OVERLAY_CATALOG_ENABLED: 'true',
+            NUXT_PUBLIC_BASE_URL: 'https://gscdump.com',
+            BING_INDEXING_PREVIEW_ALLOWLIST: '',
+          },
+        },
+      })
+
+      expect(prepared.signature).toBe(final.signature)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/packages/nuxt-cloudflare/tests/nuxt.test.ts
+++ b/packages/nuxt-cloudflare/tests/nuxt.test.ts
@@ -1,9 +1,42 @@
 import type { NitroCloudflareShape } from '../src/module'
-import { loadNuxt } from '@nuxt/kit'
+import { loadNuxt, writeTypes } from '@nuxt/kit'
 import { describe, expect, it } from 'vitest'
 import cloudflareModule from '../src/module'
 
 describe('nuxt integration', () => {
+  it('keeps binding runtime types out of Vue global type files', async () => {
+    const nuxt = await loadNuxt({
+      cwd: import.meta.dirname,
+      dev: true,
+      ready: false,
+      overrides: {
+        modules: [cloudflareModule],
+      },
+    })
+
+    try {
+      await nuxt.ready()
+      const bindingTypePath = (path: string | undefined) => path?.endsWith('/types/cloudflare-bindings.d.ts')
+      const globalTypeFiles = nuxt.options.vite.vue?.script?.globalTypeFiles ?? []
+      const nuxtTypeReferences: string[] = []
+      nuxt.hook('prepare:types', ({ references }) => {
+        nuxtTypeReferences.push(...references.flatMap(reference => 'path' in reference ? reference.path : []))
+      })
+
+      expect(globalTypeFiles.some(bindingTypePath)).toBe(false)
+
+      await writeTypes(nuxt)
+      expect(nuxtTypeReferences.some(bindingTypePath)).toBe(true)
+
+      const nitroTypeReferences: Array<{ path?: string }> = []
+      await nuxt.callHook('nitro:prepare:types', { references: nitroTypeReferences } as never)
+      expect(nitroTypeReferences.some(reference => bindingTypePath(reference.path))).toBe(true)
+    }
+    finally {
+      await nuxt.close()
+    }
+  })
+
   it('applies defaults after every module and upgrades the existing cache mount', async () => {
     const nuxt = await loadNuxt({
       cwd: import.meta.dirname,


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

GSCdump exposed two 0.0.9 regressions. Reordered Wrangler vars failed the final drift audit, while Workers runtime declarations entered Vue's global SFC types and broke Nuxt UI prop resolution.

Canonicalize only the comparison signature. Keep generated types in Nuxt and Nitro references without registering them through Vue `globalTypeFiles`.