### PR TITLE
feat(nuxt-dx): persist draggable overlay position

### DIFF
--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
+    "@vueuse/core": "catalog:",
     "citty": "catalog:",
     "consola": "catalog:",
     "oxc-parser": "catalog:",

--- a/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
+++ b/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
@@ -1,5 +1,7 @@
 import type { ComponentPublicInstance } from 'vue'
 import type { DiagnosticIssue } from '../report'
+import { useEventListener, useStorage } from '@vueuse/core'
+import { effectScope } from 'vue'
 import { defineNuxtPlugin, useRoute, useRuntimeConfig } from '#app'
 import { HYDRATION_SUMMARY_ERROR, parseComponentTrace, parseHydrationWarning } from '../hydration'
 import { formatDiagnosticReport, formatIssueLine, issueSignature, relativeSourcePath } from '../report'
@@ -14,6 +16,109 @@ interface DebugComponent extends ComponentPublicInstance {
 interface DxConfig {
   position: 'bottom-left' | 'bottom-right'
   sourceRoot: string
+}
+
+type OverlayEdge = 'top' | 'right' | 'bottom' | 'left'
+
+interface OverlayPosition {
+  _tag: OverlayEdge
+  offset: number
+}
+
+type DragState
+  = | { _tag: 'idle' }
+    | { _tag: 'pending', pointerId: number, startX: number, startY: number, offsetX: number, offsetY: number }
+    | { _tag: 'dragging', pointerId: number, offsetX: number, offsetY: number }
+
+interface Point {
+  x: number
+  y: number
+}
+
+interface Size {
+  width: number
+  height: number
+}
+
+const OVERLAY_MARGIN = 12
+const PANEL_GAP = 8
+const DRAG_THRESHOLD = 4
+const SNAP_THRESHOLD = 2
+const POSITION_STORAGE_KEY = 'nuxt-dx:overlay-position'
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum)
+}
+
+function snapOffset(value: number): number {
+  if (value < 5)
+    return 0
+  if (value > 95)
+    return 100
+  if (Math.abs(value - 50) < SNAP_THRESHOLD)
+    return 50
+  return value
+}
+
+function overlayPositionFromPoint(point: Point, viewport: Size): OverlayPosition {
+  const centerX = viewport.width / 2
+  const centerY = viewport.height / 2
+  const angle = Math.atan2(point.y - centerY, point.x - centerX)
+  const horizontalMargin = 70
+  const topLeft = Math.atan2(-centerY + horizontalMargin, -centerX)
+  const topRight = Math.atan2(-centerY + horizontalMargin, viewport.width - centerX)
+  const bottomLeft = Math.atan2(viewport.height - horizontalMargin - centerY, -centerX)
+  const bottomRight = Math.atan2(viewport.height - horizontalMargin - centerY, viewport.width - centerX)
+  const edge: OverlayEdge = angle >= topLeft && angle <= topRight
+    ? 'top'
+    : angle >= topRight && angle <= bottomRight
+      ? 'right'
+      : angle >= bottomRight && angle <= bottomLeft
+        ? 'bottom'
+        : 'left'
+  const axisValue = edge === 'top' || edge === 'bottom'
+    ? point.x / viewport.width
+    : point.y / viewport.height
+
+  return { _tag: edge, offset: snapOffset(clamp(axisValue * 100, 0, 100)) }
+}
+
+function defaultOverlayPosition(position: DxConfig['position']): OverlayPosition {
+  return { _tag: 'bottom', offset: position === 'bottom-left' ? 0 : 100 }
+}
+
+function parseOverlayPosition(raw: string): OverlayPosition {
+  const value: unknown = JSON.parse(raw)
+  if (
+    typeof value === 'object'
+    && value !== null
+    && '_tag' in value
+    && ['top', 'right', 'bottom', 'left'].includes(String(value._tag))
+    && 'offset' in value
+    && typeof value.offset === 'number'
+    && Number.isFinite(value.offset)
+  ) {
+    return { _tag: value._tag as OverlayEdge, offset: clamp(value.offset, 0, 100) }
+  }
+  throw new Error('Saved Nuxt DX overlay position is invalid.')
+}
+
+function overlayAnchor(position: OverlayPosition, viewport: Size, trigger: Size): Point {
+  const halfWidth = trigger.width / 2
+  const halfHeight = trigger.height / 2
+  const horizontal = clamp(position.offset / 100 * viewport.width, OVERLAY_MARGIN + halfWidth, viewport.width - OVERLAY_MARGIN - halfWidth)
+  const vertical = clamp(position.offset / 100 * viewport.height, OVERLAY_MARGIN + halfHeight, viewport.height - OVERLAY_MARGIN - halfHeight)
+
+  switch (position._tag) {
+    case 'top':
+      return { x: horizontal, y: OVERLAY_MARGIN + halfHeight }
+    case 'right':
+      return { x: viewport.width - OVERLAY_MARGIN - halfWidth, y: vertical }
+    case 'bottom':
+      return { x: horizontal, y: viewport.height - OVERLAY_MARGIN - halfHeight }
+    case 'left':
+      return { x: OVERLAY_MARGIN + halfWidth, y: vertical }
+  }
 }
 
 const OVERLAY_STYLES = `
@@ -35,23 +140,27 @@ const OVERLAY_STYLES = `
   --dx-success-border: rgb(52 211 153 / 52%);
   position: fixed;
   z-index: 2147483000;
-  inset-block-end: 0.75rem;
+  inset: 0 auto auto 0;
+  inline-size: 0;
+  block-size: 0;
   color-scheme: dark;
   font-family: ui-monospace, "SFMono-Regular", "Cascadia Code", "Liberation Mono", monospace;
   font-size: 0.8125rem;
   line-height: 1.5;
 }
 
-:host([data-side="left"]) { inset-inline-start: 0.75rem; }
-:host([data-side="right"]) { inset-inline-end: 0.75rem; }
-
 *, *::before, *::after { box-sizing: border-box; }
 button { font: inherit; }
 
 .trigger {
+  position: absolute;
+  z-index: 1;
+  inset: 0 auto auto 0;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
+  min-inline-size: 2.5rem;
   min-block-size: 2.5rem;
   max-inline-size: calc(100vw - 1.5rem);
   padding: 0.5rem 0.75rem;
@@ -61,12 +170,16 @@ button { font: inherit; }
   color: var(--dx-text);
   box-shadow: 0 0.5rem 1.75rem rgb(0 0 0 / 28%);
   backdrop-filter: blur(0.75rem);
-  cursor: pointer;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  transform: translate(-50%, -50%);
   transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
 }
 
 .trigger:hover { background: var(--dx-surface-hover); }
-.trigger:active { transform: translateY(1px); }
+.trigger:active { transform: translate(-50%, -50%) scale(0.97); }
+:host([data-dragging]) .trigger { cursor: grabbing; transition: none; }
 .trigger[data-status="error"] { border-color: var(--dx-error-border); }
 .trigger[data-status="warning"] { border-color: var(--dx-warning-border); }
 .trigger[data-status="hydration"] { border-color: var(--dx-hydration-border); }
@@ -105,15 +218,15 @@ button { font: inherit; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.summary[hidden] { display: none; }
 .summary-compact { display: none; }
 
 .panel {
   position: absolute;
-  inset-block-end: calc(100% + 0.5rem);
   display: flex;
   flex-direction: column;
-  inline-size: min(30rem, calc(100vw - 1.5rem));
-  max-block-size: min(34rem, calc(100vh - 5rem));
+  inline-size: min(30rem, calc(100dvw - 1.5rem));
+  max-block-size: min(34rem, calc(100dvh - 5rem));
   overflow: hidden;
   border: 1px solid var(--dx-border-strong);
   border-radius: 1rem;
@@ -121,15 +234,9 @@ button { font: inherit; }
   color: var(--dx-text);
   box-shadow: 0 1.25rem 3.75rem rgb(0 0 0 / 42%);
   backdrop-filter: blur(1rem);
-  transform-origin: bottom right;
   animation: dx-enter 140ms ease-out;
 }
 
-:host([data-side="left"]) .panel {
-  inset-inline-start: 0;
-  transform-origin: bottom left;
-}
-:host([data-side="right"]) .panel { inset-inline-end: 0; }
 .panel[hidden] { display: none; }
 
 .panel-header {
@@ -253,14 +360,15 @@ button { font: inherit; }
 .action[data-result="error"] { border-color: var(--dx-error-border); color: var(--dx-error); }
 
 @keyframes dx-enter {
-  from { opacity: 0; transform: translateY(0.25rem) scale(0.985); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  from { opacity: 0; transform: scale(0.985); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 @media (max-width: 40rem) {
+  .trigger { min-inline-size: 2.75rem; }
   .trigger, .action, .close { min-block-size: 2.75rem; }
   .summary-full { display: none; }
-  .summary-compact { display: inline; }
+  .summary-compact:not([hidden]) { display: inline; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -292,10 +400,29 @@ export default defineNuxtPlugin({
     const config = (runtimeConfig.public as Record<string, unknown>).nuxtDx as DxConfig
     const issues: DiagnosticIssue[] = []
     const seen = new Set<string>()
+    const runtimeScope = effectScope()
+    const persistedPosition = runtimeScope.run(() => useStorage<OverlayPosition>(
+      POSITION_STORAGE_KEY,
+      defaultOverlayPosition(config.position),
+      undefined,
+      {
+        deep: false,
+        flush: 'sync',
+        listenToStorageChanges: false,
+        shallow: true,
+        writeDefaults: false,
+        serializer: {
+          read: parseOverlayPosition,
+          write: value => JSON.stringify(value),
+        },
+        onError: error => console.warn('[nuxt-dx] Ignored the saved overlay position.', error),
+      },
+    ))!
+    let position = persistedPosition.value
 
     const host = document.createElement('div')
     host.dataset.nuxtDxOverlay = ''
-    host.dataset.side = config.position === 'bottom-left' ? 'left' : 'right'
+    host.dataset.edge = position._tag
     const root = host.attachShadow({ mode: 'open' })
 
     const style = document.createElement('style')
@@ -308,8 +435,10 @@ export default defineNuxtPlugin({
     badge.setAttribute('aria-expanded', 'false')
     const statusDot = element('span', 'status-dot')
     statusDot.setAttribute('aria-hidden', 'true')
-    const summary = element('span', 'summary summary-full', 'No issues')
-    const compactSummary = element('span', 'summary summary-compact', 'No issues')
+    const summary = element('span', 'summary summary-full')
+    const compactSummary = element('span', 'summary summary-compact')
+    summary.hidden = true
+    compactSummary.hidden = true
     badge.append(statusDot, summary, compactSummary)
 
     const panel = element('section', 'panel')
@@ -351,6 +480,48 @@ export default defineNuxtPlugin({
     document.body.append(host)
 
     let copyResetTimer: ReturnType<typeof setTimeout> | undefined
+    let dragState: DragState = { _tag: 'idle' }
+    let suppressClickUntil = 0
+
+    const viewportSize = (): Size => ({ width: window.innerWidth, height: window.innerHeight })
+    const alignPanel = (anchor: Point, trigger: Size) => {
+      if (panel.hidden)
+        return
+
+      const viewport = viewportSize()
+      const availableWidth = position._tag === 'top' || position._tag === 'bottom'
+        ? viewport.width - OVERLAY_MARGIN * 2
+        : viewport.width - OVERLAY_MARGIN * 2 - trigger.width - PANEL_GAP
+      panel.style.inlineSize = `${Math.min(480, availableWidth)}px`
+      const panelSize = { width: panel.offsetWidth, height: panel.offsetHeight }
+      const naturalLeft = position._tag === 'left'
+        ? anchor.x + trigger.width / 2 + PANEL_GAP
+        : position._tag === 'right'
+          ? anchor.x - trigger.width / 2 - PANEL_GAP - panelSize.width
+          : anchor.x - panelSize.width / 2
+      const naturalTop = position._tag === 'top'
+        ? anchor.y + trigger.height / 2 + PANEL_GAP
+        : position._tag === 'bottom'
+          ? anchor.y - trigger.height / 2 - PANEL_GAP - panelSize.height
+          : anchor.y - panelSize.height / 2
+      const left = clamp(naturalLeft, OVERLAY_MARGIN, viewport.width - OVERLAY_MARGIN - panelSize.width)
+      const top = clamp(naturalTop, OVERLAY_MARGIN, viewport.height - OVERLAY_MARGIN - panelSize.height)
+      const originX = position._tag === 'left' ? 0 : position._tag === 'right' ? panelSize.width : clamp(anchor.x - left, 0, panelSize.width)
+      const originY = position._tag === 'top' ? 0 : position._tag === 'bottom' ? panelSize.height : clamp(anchor.y - top, 0, panelSize.height)
+
+      panel.style.left = `${left - anchor.x}px`
+      panel.style.top = `${top - anchor.y}px`
+      panel.style.transformOrigin = `${originX}px ${originY}px`
+    }
+
+    const applyPosition = () => {
+      const trigger = { width: badge.offsetWidth, height: badge.offsetHeight }
+      const anchor = overlayAnchor(position, viewportSize(), trigger)
+      host.dataset.edge = position._tag
+      host.style.left = `${anchor.x}px`
+      host.style.top = `${anchor.y}px`
+      alignPanel(anchor, trigger)
+    }
 
     const render = () => {
       const count = (kind: DiagnosticIssue['kind']) => issues.filter(issue => issue.kind === kind).length
@@ -363,8 +534,10 @@ export default defineNuxtPlugin({
         hydration ? `${hydration} hydration` : '',
       ].filter(Boolean)
 
-      summary.textContent = counts.join(' · ') || 'No issues'
-      compactSummary.textContent = issues.length ? issueCountLabel(issues.length) : 'No issues'
+      summary.textContent = counts.join(' · ')
+      compactSummary.textContent = issues.length ? issueCountLabel(issues.length) : ''
+      summary.hidden = issues.length === 0
+      compactSummary.hidden = issues.length === 0
       panelCount.textContent = issues.length ? issueCountLabel(issues.length) : 'No issues detected'
       badge.dataset.status = errors ? 'error' : hydration ? 'hydration' : warnings ? 'warning' : 'ok'
       badge.setAttribute('aria-label', `Nuxt DX: ${counts.join(', ') || 'no issues'}`)
@@ -378,6 +551,7 @@ export default defineNuxtPlugin({
       }))
       issueList.hidden = issues.length === 0
       empty.hidden = issues.length > 0
+      applyPosition()
     }
 
     const addIssue = (issue: DiagnosticIssue) => {
@@ -394,6 +568,7 @@ export default defineNuxtPlugin({
     const setPanelOpen = (open: boolean, restoreFocus = false) => {
       panel.hidden = !open
       badge.setAttribute('aria-expanded', String(open))
+      applyPosition()
       if (!open && restoreFocus)
         badge.focus()
     }
@@ -448,51 +623,102 @@ export default defineNuxtPlugin({
       if (event.key === 'Escape' && !panel.hidden)
         setPanelOpen(false, true)
     }
-    window.addEventListener('error', onWindowError)
-    window.addEventListener('unhandledrejection', onUnhandledRejection)
-    window.addEventListener('keydown', onKeyDown)
+    const onPointerDown = (event: PointerEvent) => {
+      if (!event.isPrimary || event.button !== 0)
+        return
+      const rect = badge.getBoundingClientRect()
+      dragState = {
+        _tag: 'pending',
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        offsetX: event.clientX - rect.left - rect.width / 2,
+        offsetY: event.clientY - rect.top - rect.height / 2,
+      }
+      badge.setPointerCapture(event.pointerId)
+    }
+    const onPointerMove = (event: PointerEvent) => {
+      if (dragState._tag === 'idle' || event.pointerId !== dragState.pointerId)
+        return
+      if (dragState._tag === 'pending') {
+        if (Math.hypot(event.clientX - dragState.startX, event.clientY - dragState.startY) < DRAG_THRESHOLD)
+          return
+        dragState = { _tag: 'dragging', pointerId: dragState.pointerId, offsetX: dragState.offsetX, offsetY: dragState.offsetY }
+        host.dataset.dragging = ''
+        setPanelOpen(false)
+      }
+      event.preventDefault()
+      position = overlayPositionFromPoint({ x: event.clientX - dragState.offsetX, y: event.clientY - dragState.offsetY }, viewportSize())
+      applyPosition()
+    }
+    const finishDrag = (event: PointerEvent) => {
+      if (dragState._tag === 'idle' || event.pointerId !== dragState.pointerId)
+        return
+      const wasDragging = dragState._tag === 'dragging'
+      dragState = { _tag: 'idle' }
+      if (badge.hasPointerCapture(event.pointerId))
+        badge.releasePointerCapture(event.pointerId)
+      if (!wasDragging)
+        return
+      delete host.dataset.dragging
+      suppressClickUntil = Date.now() + 400
+      persistedPosition.value = position
+      applyPosition()
+    }
 
-    badge.addEventListener('click', () => setPanelOpen(panel.hidden))
-    closeButton.addEventListener('click', () => setPanelOpen(false, true))
-    clearButton.addEventListener('click', () => {
-      issues.length = 0
-      seen.clear()
-      render()
-    })
-    copyButton.addEventListener('click', () => {
-      const pageFile = (route.matched.at(-1)?.components?.default as { __file?: string } | undefined)?.__file
-      const report = formatDiagnosticReport({
-        url: `${window.location.origin}${route.fullPath}`,
-        routeName: String(route.name),
-        pageComponent: pageFile ? relativeSourcePath(pageFile, config.sourceRoot) : undefined,
-        issues,
+    runtimeScope.run(() => {
+      useEventListener(window, 'error', onWindowError)
+      useEventListener(window, 'unhandledrejection', onUnhandledRejection)
+      useEventListener(window, 'keydown', onKeyDown)
+      useEventListener(window, 'resize', applyPosition)
+      useEventListener(window, 'pointermove', onPointerMove, { passive: false })
+      useEventListener(window, 'pointerup', finishDrag)
+      useEventListener(window, 'pointercancel', finishDrag)
+      useEventListener(badge, 'pointerdown', onPointerDown)
+      useEventListener(badge, 'click', () => {
+        if (Date.now() < suppressClickUntil)
+          return
+        setPanelOpen(panel.hidden)
       })
-      navigator.clipboard.writeText(report).then(() => {
-        copyButton.textContent = 'Copied'
-        delete copyButton.dataset.result
-        if (copyResetTimer)
-          clearTimeout(copyResetTimer)
-        copyResetTimer = setTimeout(() => {
-          copyButton.textContent = 'Copy report'
+      useEventListener(closeButton, 'click', () => setPanelOpen(false, true))
+      useEventListener(clearButton, 'click', () => {
+        issues.length = 0
+        seen.clear()
+        render()
+      })
+      useEventListener(copyButton, 'click', () => {
+        const pageFile = (route.matched.at(-1)?.components?.default as { __file?: string } | undefined)?.__file
+        const report = formatDiagnosticReport({
+          url: `${window.location.origin}${route.fullPath}`,
+          routeName: String(route.name),
+          pageComponent: pageFile ? relativeSourcePath(pageFile, config.sourceRoot) : undefined,
+          issues,
+        })
+        navigator.clipboard.writeText(report).then(() => {
+          copyButton.textContent = 'Copied'
           delete copyButton.dataset.result
-        }, 1_500)
-      }).catch((error) => {
-        copyButton.textContent = 'Copy failed'
-        copyButton.dataset.result = 'error'
-        if (copyResetTimer)
-          clearTimeout(copyResetTimer)
-        copyResetTimer = setTimeout(() => {
-          copyButton.textContent = 'Copy report'
-          delete copyButton.dataset.result
-        }, 1_500)
-        originalConsoleError('[nuxt-dx] clipboard failed', error)
+          if (copyResetTimer)
+            clearTimeout(copyResetTimer)
+          copyResetTimer = setTimeout(() => {
+            copyButton.textContent = 'Copy report'
+            delete copyButton.dataset.result
+          }, 1_500)
+        }).catch((error) => {
+          copyButton.textContent = 'Copy failed'
+          copyButton.dataset.result = 'error'
+          if (copyResetTimer)
+            clearTimeout(copyResetTimer)
+          copyResetTimer = setTimeout(() => {
+            copyButton.textContent = 'Copy report'
+            delete copyButton.dataset.result
+          }, 1_500)
+          originalConsoleError('[nuxt-dx] clipboard failed', error)
+        })
       })
     })
 
     const cleanup = () => {
-      window.removeEventListener('error', onWindowError)
-      window.removeEventListener('unhandledrejection', onUnhandledRejection)
-      window.removeEventListener('keydown', onKeyDown)
+      runtimeScope.stop()
       removeIssueHook()
       if (copyResetTimer)
         clearTimeout(copyResetTimer)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.4.0(vue@3.5.41(typescript@5.9.3))
       citty:
         specifier: 'catalog:'
         version: 0.2.2


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

An empty Nuxt DX overlay no longer needs a “No issues” label. The trigger stays as a green dot until an issue arrives, and can be dragged around the viewport edge with its position restored after reload.