### PR TITLE
refactor(ci): prefix the shared CI family with harlan-desktop

### DIFF
--- a/.github/actions/harlan-desktop-setup/action.yml
+++ b/.github/actions/harlan-desktop-setup/action.yml
@@ -1,6 +1,9 @@
-name: Setup pnpm workspace
+name: Harlan Desktop setup
 description: Install pnpm, Node, and the workspace, with the store cached and lifecycle scripts off.
 
+# NOT GENERAL PURPOSE. Harlan's own sites only; the pinned versions track what
+# those sites run and change without notice.
+#
 # The four steps below were copied into ten repositories, which is why the action
 # SHA, the Node version, and the install flags had drifted apart across 22, 24,
 # 24.x, lts/*, 24.11.0, and 24.18.0. Pin them once here instead.

--- a/.github/workflows/harlan-desktop-site-ci.yml
+++ b/.github/workflows/harlan-desktop-site-ci.yml
@@ -1,5 +1,10 @@
-name: Nuxt site CI
+name: Harlan Desktop site CI
 
+# NOT GENERAL PURPOSE. This is Harlan's own gate for Harlan's own sites, and its
+# default is to dispatch to ephemeral containers on Harlan's desktop. Nothing here
+# is supported for anyone else, which is why every name in this family carries the
+# `harlan-desktop-` prefix.
+#
 # The pull request gate shared by every Harlan site. A calling repository keeps a
 # ten line workflow and gets lint, typecheck, and test as three separate,
 # separately required checks.
@@ -11,7 +16,7 @@ name: Nuxt site CI
 #
 # Moving a site between GitHub-hosted and the workstation pool is one input:
 #
-#   runs-on: '["self-hosted", "linux", "x64", "harlans-desktop-ci"]'
+#   runs-on: '["self-hosted", "linux", "x64", "harlan-desktop-ci"]'
 #
 # WHY THE SETUP STEPS ARE INLINE
 #

--- a/infra/github-runner/Dockerfile
+++ b/infra/github-runner/Dockerfile
@@ -32,10 +32,10 @@ RUN curl --fail --location --show-error \
   && rm /tmp/actions-runner.tar.gz \
   && chown --recursive runner:runner /opt/actions-runner
 
-COPY --chown=root:root entrypoint.sh /usr/local/bin/harlans-desktop-runner-entrypoint
+COPY --chown=root:root entrypoint.sh /usr/local/bin/harlan-desktop-runner-entrypoint
 
-RUN chmod 0755 /usr/local/bin/harlans-desktop-runner-entrypoint
+RUN chmod 0755 /usr/local/bin/harlan-desktop-runner-entrypoint
 
 USER runner
 
-ENTRYPOINT ["/usr/local/bin/harlans-desktop-runner-entrypoint"]
+ENTRYPOINT ["/usr/local/bin/harlan-desktop-runner-entrypoint"]

--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -40,10 +40,10 @@ everywhere and a site moves between hosted and self-hosted by changing one input
 
 | Label | Use |
 | --- | --- |
-| `harlans-desktop-ci` | Lint, typecheck, test, build. No production secret. |
-| `harlans-desktop-deploy` | Production deploys. Larger container, one at a time. |
+| `harlan-desktop-ci` | Lint, typecheck, test, build. No production secret. |
+| `harlan-desktop-deploy` | Production deploys. Larger container, one at a time. |
 
-Write them as `runs-on: [self-hosted, linux, x64, harlans-desktop-ci]`. The runner adds
+Write them as `runs-on: [self-hosted, linux, x64, harlan-desktop-ci]`. The runner adds
 `self-hosted`, `linux`, and `x64` itself.
 
 ## Host setup
@@ -52,25 +52,25 @@ Needs Docker, GitHub CLI authenticated with repository administration access on
 every repository in `runners.conf`.
 
 ```bash
-docker build --tag harlans-desktop-github-runner:2.336.0 infra/github-runner
+docker build --tag harlan-desktop-github-runner:2.336.0 infra/github-runner
 
 install -Dm755 infra/github-runner/supervisor \
-  ~/.local/lib/harlans-desktop-github-runner/supervisor
+  ~/.local/lib/harlan-desktop-github-runner/supervisor
 install -Dm644 infra/github-runner/runners.conf \
-  ~/.config/harlans-desktop-github-runner/runners.conf
-install -Dm644 infra/github-runner/harlans-desktop-github-runner.service \
-  ~/.config/systemd/user/harlans-desktop-github-runner.service
+  ~/.config/harlan-desktop-github-runner/runners.conf
+install -Dm644 infra/github-runner/harlan-desktop-github-runner.service \
+  ~/.config/systemd/user/harlan-desktop-github-runner.service
 
 systemctl --user daemon-reload
-systemctl --user enable --now harlans-desktop-github-runner.service
+systemctl --user enable --now harlan-desktop-github-runner.service
 ```
 
 ## Status
 
 ```bash
-harlans-desktop-runner          # both sections
-harlans-desktop-runner pool     # the workstation only, no network calls
-harlans-desktop-runner sites    # open pull requests and their checks
+harlan-desktop-runner          # both sections
+harlan-desktop-runner pool     # the workstation only, no network calls
+harlan-desktop-runner sites    # open pull requests and their checks
 ```
 
 `pool` reads the supervisor's own reservation files under `XDG_RUNTIME_DIR`, the
@@ -93,13 +93,13 @@ docker ps --filter label=com.harlanzw.desktop-runner=true \
 gh api repos/harlan-zw/nuxtseo.com/actions/runners \
   --jq '.runners[] | [.name, .status, .busy] | @tsv'
 
-journalctl --user --unit harlans-desktop-github-runner.service --follow
+journalctl --user --unit harlan-desktop-github-runner.service --follow
 ```
 
 Stop local CI before shutting down or doing CPU-heavy local work:
 
 ```bash
-systemctl --user stop harlans-desktop-github-runner.service
+systemctl --user stop harlan-desktop-github-runner.service
 ```
 
 Queued jobs wait up to 24 hours for a matching online runner, so starting the
@@ -113,8 +113,8 @@ service drains the queue.
 | --- | --- | --- |
 | `HARLANS_DESKTOP_RUNNER_CPU_BUDGET` | `32` | Cores that in-flight jobs may hold at once, across all pools. |
 | `HARLANS_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
-| `HARLANS_DESKTOP_RUNNER_IMAGE` | `harlans-desktop-github-runner:2.336.0` | Image tag. |
-| `HARLANS_DESKTOP_RUNNER_CONFIG` | `/etc/harlans-desktop-github-runner/runners.conf` | Pool table. |
+| `HARLANS_DESKTOP_RUNNER_IMAGE` | `harlan-desktop-github-runner:2.336.0` | Image tag. |
+| `HARLANS_DESKTOP_RUNNER_CONFIG` | `/etc/harlan-desktop-github-runner/runners.conf` | Pool table. |
 
 Idle warm containers cost about 60 MB each and no CPU, so they do not spend the
 budget. Only a warm container holding a job, and a burst container from the

--- a/infra/github-runner/harlan-desktop-github-runner.service
+++ b/infra/github-runner/harlan-desktop-github-runner.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=HARLANS_DESKTOP_RUNNER_CONFIG=%h/.config/harlans-desktop-github-runner/runners.conf
-ExecStart=%h/.local/lib/harlans-desktop-github-runner/supervisor
+Environment=HARLANS_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner/runners.conf
+ExecStart=%h/.local/lib/harlan-desktop-github-runner/supervisor
 Restart=always
 RestartSec=10
 KillMode=mixed

--- a/infra/github-runner/harlan-desktop-runner
+++ b/infra/github-runner/harlan-desktop-runner
@@ -3,9 +3,9 @@
 # Status for Harlan's desktop GitHub runner, and for whatever is currently in
 # flight across the sites it serves.
 #
-#   harlans-desktop-runner            both sections
-#   harlans-desktop-runner pool       the workstation only, no network calls
-#   harlans-desktop-runner sites      open pull requests and their checks
+#   harlan-desktop-runner            both sections
+#   harlan-desktop-runner pool       the workstation only, no network calls
+#   harlan-desktop-runner sites      open pull requests and their checks
 #
 # Pool numbers come from the supervisor's own reservation files under
 # XDG_RUNTIME_DIR, which are the same files it sizes bursts from, so this reports
@@ -13,8 +13,8 @@
 
 set -uo pipefail
 
-readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlans-desktop-github-runner"
-readonly unit='harlans-desktop-github-runner.service'
+readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlan-desktop-github-runner"
+readonly unit='harlan-desktop-github-runner.service'
 readonly container_label='com.harlanzw.desktop-runner'
 
 # The site inventory, mirroring SITES.md. `path` is the main checkout, used to
@@ -70,7 +70,7 @@ pool_section() {
   unit_state="$(systemctl --user is-active "$unit" 2>/dev/null)"
 
   if [[ "$unit_state" != active ]]; then
-    printf '%sharlans-desktop-github-runner%s  %s%s%s\n' \
+    printf '%sharlan-desktop-github-runner%s  %s%s%s\n' \
       "$bold" "$reset" "$red" "${unit_state:-not installed}" "$reset"
     printf '  %sstart it with: systemctl --user start %s%s\n' "$dim" "$unit" "$reset"
     return
@@ -91,7 +91,7 @@ pool_section() {
     fi
   fi
 
-  printf '%sharlans-desktop-github-runner%s  %s%s%s\n\n' \
+  printf '%sharlan-desktop-github-runner%s  %s%s%s\n\n' \
     "$bold" "$reset" "$green" "${uptime:-active}" "$reset"
 
   if [[ ! -d "$state_root/burst" ]]; then
@@ -108,11 +108,11 @@ pool_section() {
 
     local slug burst busy
     slug="$(printf '%s-%s' "${repository##*/}" "${labels%%,*}" \
-      | sed 's/^\(.*\)-harlans-desktop-/\1-/' \
+      | sed 's/^\(.*\)-harlan-desktop-/\1-/' \
       | tr -cs '[:alnum:]-' '-' | tr '[:upper:]' '[:lower:]')"
     burst="$(count_files "$state_root/burst/$slug")"
     # Every reservation whose container belongs to this pool is a job in flight.
-    busy="$(find "$state_root/spend" -maxdepth 1 -type f -name "harlans-desktop-$slug-*" 2>/dev/null | grep --count '' || true)"
+    busy="$(find "$state_root/spend" -maxdepth 1 -type f -name "harlan-desktop-$slug-*" 2>/dev/null | grep --count '' || true)"
 
     local marker="$dim"
     (( busy > 0 )) && marker="$green"
@@ -205,7 +205,7 @@ main() {
     sites) sites_section ;;
     all)   pool_section; printf '\n'; sites_section ;;
     *)
-      printf 'usage: harlans-desktop-runner [pool|sites]\n' >&2
+      printf 'usage: harlan-desktop-runner [pool|sites]\n' >&2
       return 2
       ;;
   esac

--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -15,10 +15,10 @@
 # unhead.unjs.io, request-indexing, harlanzw.com, and unlighthouse.dev stay on
 # GitHub-hosted runners.
 
-harlan-zw/nuxtseo.com|harlans-desktop-ci,nuxtseo-ci|2|5|6|12g|14g
-harlan-zw/nuxtseo.com|harlans-desktop-deploy,nuxtseo-deploy|1|1|16|32g|40g
-harlan-zw/gscdump.com|harlans-desktop-ci|1|5|6|12g|14g
-harlan-zw/mdream.dev|harlans-desktop-ci|1|3|6|12g|14g
-harlan-zw/zhead.dev|harlans-desktop-ci|1|3|6|12g|14g
-harlan-zw/scripts.nuxt.com|harlans-desktop-ci|1|2|6|12g|14g
-skilld-dev/skilld.dev|harlans-desktop-ci|1|3|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|5|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|32g|40g
+harlan-zw/gscdump.com|harlan-desktop-ci|1|5|6|12g|14g
+harlan-zw/mdream.dev|harlan-desktop-ci|1|3|6|12g|14g
+harlan-zw/zhead.dev|harlan-desktop-ci|1|3|6|12g|14g
+harlan-zw/scripts.nuxt.com|harlan-desktop-ci|1|2|6|12g|14g
+skilld-dev/skilld.dev|harlan-desktop-ci|1|3|6|12g|14g

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -39,8 +39,8 @@
 
 set -euo pipefail
 
-readonly runner_image="${HARLANS_DESKTOP_RUNNER_IMAGE:-harlans-desktop-github-runner:2.336.0}"
-readonly config_file="${HARLANS_DESKTOP_RUNNER_CONFIG:-/etc/harlans-desktop-github-runner/runners.conf}"
+readonly runner_image="${HARLANS_DESKTOP_RUNNER_IMAGE:-harlan-desktop-github-runner:2.336.0}"
+readonly config_file="${HARLANS_DESKTOP_RUNNER_CONFIG:-/etc/harlan-desktop-github-runner/runners.conf}"
 # 24 physical cores. Runner work is IO-heavy and rarely saturates its quota, so a
 # modest oversubscription keeps a wide matrix moving without starving
 # interactive work on the workstation.
@@ -50,7 +50,7 @@ readonly cpu_budget="${HARLANS_DESKTOP_RUNNER_CPU_BUDGET:-32}"
 readonly burst_idle_seconds="${HARLANS_DESKTOP_RUNNER_BURST_IDLE_SECONDS:-300}"
 readonly container_label='com.harlanzw.desktop-runner'
 # Readable by the status command, unlike /tmp under this unit's PrivateTmp.
-readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlans-desktop-github-runner"
+readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlan-desktop-github-runner"
 # Copied here at startup so the status command can size pools without reading a
 # config path it would otherwise have to guess.
 readonly published_config="$state_root/runners.conf"
@@ -82,7 +82,7 @@ require_command() {
   fi
 }
 
-# `harlan-zw/nuxtseo.com` + `harlans-desktop-ci` -> `nuxtseo-com-ci`. Used for container
+# `harlan-zw/nuxtseo.com` + `harlan-desktop-ci` -> `nuxtseo-com-ci`. Used for container
 # names and the Docker pool label, both of which reject `/` and `.`.
 #
 # A pool may carry several labels, so that a repository can answer to both its
@@ -92,7 +92,7 @@ pool_slug_for() {
   local repository="$1"
   local label="${2%%,*}"
 
-  printf '%s-%s' "${repository##*/}" "${label#harlans-desktop-}" \
+  printf '%s-%s' "${repository##*/}" "${label#harlan-desktop-}" \
     | tr --complement --squeeze-repeats '[:alnum:]-' '-' \
     | tr '[:upper:]' '[:lower:]'
 }
@@ -212,7 +212,7 @@ run_container() {
   # This string is what a job's log prints as `Runner name:`, and it is the only
   # place a reader sees whose machine ran their code. Lead with the machine, not
   # the pool.
-  runner_name="harlans-desktop-${pool_slug[$pool_index]}-$$-${RANDOM}"
+  runner_name="harlan-desktop-${pool_slug[$pool_index]}-$$-${RANDOM}"
 
   # The token enters on stdin, so it never lands on disk and never lands in an
   # env var that `docker inspect` would echo back.
@@ -269,7 +269,7 @@ run_container() {
 run_warm_slot() {
   local pool_index="$1"
   local slot_number="$2"
-  local container_name="harlans-desktop-${pool_slug[$pool_index]}-$slot_number"
+  local container_name="harlan-desktop-${pool_slug[$pool_index]}-$slot_number"
 
   while true; do
     if ! run_container "$pool_index" warm "$container_name"; then
@@ -320,7 +320,7 @@ run_scaler() {
       fi
 
       burst_counter=$(( burst_counter + 1 ))
-      container_name="harlans-desktop-$slug-burst-$burst_counter"
+      container_name="harlan-desktop-$slug-burst-$burst_counter"
       # Both reservations are written before the fork, so the next request in
       # this loop already sees this container.
       printf '%s\n' "${pool_cpus[$pool_index]}" >"$state_dir/burst/$slug/$container_name"
@@ -386,7 +386,7 @@ main() {
   read_config
 
   # A fixed path under the runtime directory, not mktemp under /tmp. The unit sets
-  # PrivateTmp, so anything in /tmp is invisible to `harlans-desktop-runner status`
+  # PrivateTmp, so anything in /tmp is invisible to `harlan-desktop-runner status`
   # and the counts it reports would have to be guessed from `docker ps` instead of
   # read from the real reservations.
   state_dir="$state_root"


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

`nuxt-site-ci.yml` and `actions/setup` read like general purpose tooling. They aren't. The workflow's whole point is dispatching to ephemeral containers on one desktop, and the action pins whatever versions my sites happen to run and will change without warning. Someone browsing this repo should be able to tell that before wiring it up, not after.

One prefix across the family, including the runner's own `harlans-` normalised to `harlan-` so there's a single spelling:

```
.github/workflows/harlan-desktop-site-ci.yml
.github/actions/harlan-desktop-setup
infra/github-runner/harlan-desktop-github-runner.service
infra/github-runner/harlan-desktop-runner
labels: harlan-desktop-ci, harlan-desktop-deploy
```

Both files now open with a NOT GENERAL PURPOSE note. The calling job key in each site becomes `harlan-desktop`, so a PR's checks read `harlan-desktop / lint` rather than `checks / lint`, which is also the name a branch rule ends up requiring.

`nuxt-dx-budget` deliberately keeps its plain name. It needs no self-hosted runner and is genuinely reusable by anyone.