### PR TITLE
fix(ci): call the CPU budget what it is, a burst threshold

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -81,7 +81,7 @@ state in `/tmp`: `PrivateTmp` would hide it from this command.
 `sites` lists every open pull request across the inventory with its check state,
 then up to three recent local branches per repository that have commits and no
 pull request. That last part is capped on purpose, since nuxtseo.com alone keeps
-over a hundred branches. Raise `HARLANS_DESKTOP_RUNNER_BRANCH_LIMIT` for the long
+over a hundred branches. Raise `HARLAN_DESKTOP_RUNNER_BRANCH_LIMIT` for the long
 tail.
 
 Check capacity and logs:
@@ -111,17 +111,28 @@ service drains the queue.
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `HARLANS_DESKTOP_RUNNER_CPU_BUDGET` | `32` | Cores that in-flight jobs may hold at once, across all pools. |
-| `HARLANS_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
-| `HARLANS_DESKTOP_RUNNER_IMAGE` | `harlan-desktop-github-runner:2.336.0` | Image tag. |
-| `HARLANS_DESKTOP_RUNNER_CONFIG` | `/etc/harlan-desktop-github-runner/runners.conf` | Pool table. |
+| `HARLAN_DESKTOP_RUNNER_CPU_BUDGET` | `32` | Threshold above which bursts are held. Not a cap; see below. |
+| `HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
+| `HARLAN_DESKTOP_RUNNER_IMAGE` | `harlan-desktop-github-runner:2.336.0` | Image tag. |
+| `HARLAN_DESKTOP_RUNNER_CONFIG` | `/etc/harlan-desktop-github-runner/runners.conf` | Pool table. |
 
-Idle warm containers cost about 60 MB each and no CPU, so they do not spend the
-budget. Only a warm container holding a job, and a burst container from the
-moment it launches, do.
+Idle warm containers cost about 60 MB each and no CPU, so they do not spend
+against the threshold. Only a warm container holding a job, and a burst container
+from the moment it launches, do.
+
+`CPU_BUDGET` holds back **bursts**; it cannot cap total load. A warm container
+claims its job straight from GitHub and the supervisor has no say in it, so the
+real floor is `sum(warm * cpus)` across every pool, and in-flight CPU exceeds the
+threshold whenever enough warm runners are busy at once. That is intended: under
+a wide multi-repository push, warm capacity absorbs the work and the rest queues
+for a few seconds rather than piling burst containers onto a 24 core box.
+
+The catch is that when the warm floor is at or above the threshold, bursting is
+effectively off. The supervisor warns at startup when that is true, since the
+symptom otherwise is every wide matrix serialising for no visible reason.
 
 ## Updating the runner
 
 Update `RUNNER_VERSION` and `RUNNER_SHA256` in the Dockerfile, update the tag in
-`HARLANS_DESKTOP_RUNNER_IMAGE` or the supervisor default, rebuild, then restart the
+`HARLAN_DESKTOP_RUNNER_IMAGE` or the supervisor default, rebuild, then restart the
 service. GitHub requires a runner update within 30 days of a release.

--- a/infra/github-runner/harlan-desktop-github-runner.service
+++ b/infra/github-runner/harlan-desktop-github-runner.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=HARLANS_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner/runners.conf
+Environment=HARLAN_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner/runners.conf
 ExecStart=%h/.local/lib/harlan-desktop-github-runner/supervisor
 Restart=always
 RestartSec=10

--- a/infra/github-runner/harlan-desktop-runner
+++ b/infra/github-runner/harlan-desktop-runner
@@ -122,9 +122,12 @@ pool_section() {
 
   local spent budget
   spent="$(sum_files "$state_root/spend")"
-  budget="${HARLANS_DESKTOP_RUNNER_CPU_BUDGET:-32}"
-  printf '\nCPU budget  %s of %s' "$spent" "$budget"
-  (( spent >= budget )) && printf '  %sfull, bursts are being held%s' "$yellow" "$reset"
+  budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
+  # Deliberately not "budget". This number can and does exceed the threshold: the
+  # threshold only holds back bursts, and a warm container's job arrives straight
+  # from GitHub with no say from the supervisor.
+  printf '\nCPU in flight  %s, burst threshold %s' "$spent" "$budget"
+  (( spent >= budget )) && printf '  %sbursts held%s' "$yellow" "$reset"
   printf '\n'
 
   local containers
@@ -136,7 +139,7 @@ pool_section() {
 # no pull request yet, which is the state most likely to be forgotten.
 sites_section() {
   # Most recently committed branches only. Raise it when you want the long tail.
-  local local_branch_limit="${HARLANS_DESKTOP_RUNNER_BRANCH_LIMIT:-3}"
+  local local_branch_limit="${HARLAN_DESKTOP_RUNNER_BRANCH_LIMIT:-3}"
 
   printf '%sSITES%s\n' "$bold" "$reset"
 

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -39,15 +39,15 @@
 
 set -euo pipefail
 
-readonly runner_image="${HARLANS_DESKTOP_RUNNER_IMAGE:-harlan-desktop-github-runner:2.336.0}"
-readonly config_file="${HARLANS_DESKTOP_RUNNER_CONFIG:-/etc/harlan-desktop-github-runner/runners.conf}"
+readonly runner_image="${HARLAN_DESKTOP_RUNNER_IMAGE:-harlan-desktop-github-runner:2.336.0}"
+readonly config_file="${HARLAN_DESKTOP_RUNNER_CONFIG:-/etc/harlan-desktop-github-runner/runners.conf}"
 # 24 physical cores. Runner work is IO-heavy and rarely saturates its quota, so a
 # modest oversubscription keeps a wide matrix moving without starving
 # interactive work on the workstation.
-readonly cpu_budget="${HARLANS_DESKTOP_RUNNER_CPU_BUDGET:-32}"
+readonly cpu_budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
 # A burst container that has claimed nothing by now is surplus. Stopping it
 # returns the pool to `warm` after a quiet spell.
-readonly burst_idle_seconds="${HARLANS_DESKTOP_RUNNER_BURST_IDLE_SECONDS:-300}"
+readonly burst_idle_seconds="${HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS:-300}"
 readonly container_label='com.harlanzw.desktop-runner'
 # Readable by the status command, unlike /tmp under this unit's PrivateTmp.
 readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlan-desktop-github-runner"
@@ -315,7 +315,7 @@ run_scaler() {
 
       spent="$(sum_markers "$state_dir/spend")"
       if (( spent + pool_cpus[pool_index] > cpu_budget )); then
-        log "CPU budget spent ($spent of $cpu_budget); holding $slug at $live"
+        log "CPU in flight $spent, burst threshold $cpu_budget; holding $slug at $live"
         continue
       fi
 
@@ -412,6 +412,16 @@ main() {
       prune_offline_runners "${pool_repository[$pool_index]}"
     fi
   done
+
+  # Sizing mistakes here are silent otherwise: the pool simply stops bursting and
+  # every wide matrix serialises behind its warm slots for no visible reason.
+  local warm_floor=0
+  for pool_index in "${!pool_repository[@]}"; do
+    warm_floor=$(( warm_floor + pool_warm[pool_index] * pool_cpus[pool_index] ))
+  done
+  if (( warm_floor >= cpu_budget )); then
+    log "Warm floor is $warm_floor CPU against a burst threshold of $cpu_budget, so bursting is off whenever most pools are busy. Lower warm, or raise HARLAN_DESKTOP_RUNNER_CPU_BUDGET."
+  fi
 
   run_scaler &
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Pushing the whole nine repo rollout through the pool printed `CPU budget 48 of 32`, over its own stated cap, which reads as a broken counter.

It isn't broken. The threshold only holds back **bursts**, and it can't do more than that: a warm container claims its job straight from GitHub and this process never gets a vote. The real floor is `sum(warm * cpus)`, currently 58 across the pools, so in-flight CPU exceeds 32 as soon as enough warm runners are busy.

The mechanism is fine, the label was wrong. Status now reads `CPU in flight 48, burst threshold 32`.

The consequence seemed worth surfacing rather than leaving to be rediscovered: with a warm floor above the threshold, bursting is effectively off whenever most pools are busy, and the only symptom is wide matrices serialising for no visible reason. The supervisor warns at startup when that's true.

Also finishes the #38 rename. That sed only matched lowercase `harlans-desktop`, so the environment variables were still `HARLANS_DESKTOP_*` while every other name had moved.

Open question: 58 of warm floor against 24 physical cores is itself aggressive, and I haven't retuned it. Lowering `cpus` per container from 6 to 4 would bring the floor to 40 and let bursting actually fire, at the cost of slower single jobs. Worth measuring once a few real matrices have run through.