### PR TITLE
feat(nuxt-wide-events): add migration parity and reduce overhead

### DIFF
--- a/packages/nuxt-wide-events/README.md
+++ b/packages/nuxt-wide-events/README.md
@@ -68,7 +68,7 @@ This constraint keeps the Field boundary visible to reviewers and coding agents.
 
 ## Production Output
 
-Production performs no stack formatting, deep redaction, regular expression matching, or pretty printing.
+Default production performs no stack formatting, deep redaction, regular expression matching, or pretty printing.
 
 ```json
 { "timestamp": "2026-08-13T04:12:00.000Z", "level": "info", "service": "shop", "method": "GET", "path": "/api/cart", "status": 200, "durationMs": 1.4, "requestId": "req_123", "cart.itemCount": 2, "user.id": "user_123" }
@@ -77,6 +77,60 @@ Production performs no stack formatting, deep redaction, regular expression matc
 Production errors include status only. All error strings remain absent because they can contain unapproved data.
 
 Development records include error messages and stacks. Development uses object output for easier inspection.
+
+## Background Operations
+
+`createWideEvent` is available in server code for Queue Jobs, scheduled work, and other background operations.
+
+```ts
+export default defineTask({
+  run() {
+    const wideEvent = createWideEvent({ 'job.id': 'job_123' })
+    wideEvent.setLevel('info')
+    return wideEvent.emit()
+  },
+})
+```
+
+The Nuxt auto-import selects JSON output in production and object output in development. It uses the configured `service` and `console` options.
+
+Use `@harlan-zw/nuxt-wide-events/standalone` when Nuxt auto-imports are unavailable. This package export always uses production JSON output without module configuration.
+
+Set `request: false` to disable request collection. Field enforcement and `createWideEvent` remain available.
+
+## Migrate from evlog
+
+Map `env.service` to `service`. Keep `exclude` and `sampling` unchanged. Do not copy `console: false`: evlog applies it to browser output, while this option controls server output.
+
+For requests, replace `log.set({ section: { value } })` with an approved flat Field:
+
+```ts
+addWideEventFields(event, { 'section.value': value })
+```
+
+For background operations, replace `createLogger(fields)` with `createWideEvent(fields)`. Replace each `.set(fields)` call with `addWideEventFields(wideEvent, fields)`. Keep `.setLevel()` and `.emit()`.
+
+Set `request: false` for background-only sites. Convert spreads, computed keys, arrays, and nested objects into configured primitive Fields. Keep browser logging and custom error transports in the application.
+
+## Production Filtering
+
+The configuration shape matches evlog for direct migration:
+
+```ts
+export default defineNuxtConfig({
+  wideEvents: {
+    exclude: ['/api/_nuxt_icon/**', '/api/_content/**'],
+    sampling: {
+      rates: { info: 10, warn: 50, debug: 0 },
+      keep: [{ duration: 1000 }, { status: 400 }],
+    },
+  },
+})
+```
+
+Rates are percentages. Keep conditions use `>=` and OR logic. Request Wide Events use `info` and `error` rates. Standalone Wide Events also use `debug` and `warn` rates.
+
+The module compiles route patterns during the build. Default production uses a separate plugin without filtering code.
 
 ## Drain Records
 
@@ -97,8 +151,11 @@ Set `drain: true` to enable this hook. Set `console: false` when the hook owns o
 | Option | Default | Purpose |
 | --- | --- | --- |
 | `enabled` | `true` | Register request collection and output. |
+| `request` | `true` | Collect one Wide Event for each request. |
 | `fields` | `[]` | Allow application Fields. |
 | `service` | none | Add a service name. |
+| `exclude` | `[]` | Exclude routes that match a glob pattern. |
+| `sampling` | none | Set rates and keep conditions for production. |
 | `console` | `true` | Write records to stdout. |
 | `drain` | `false` | Call the `wide-events:emit` hook. |
 
@@ -124,9 +181,9 @@ The Cloudflare fixture builds with the Workers preset, passes a Wrangler deploy 
 
 ## Scope
 
-The first version supports Nuxt server requests, flat primitive Fields, stdout, and a Nitro hook.
+The first version supports Nuxt server requests, flat primitive Fields, route exclusion, sampling, stdout, and a Nitro hook.
 
-It excludes browser logging, transports, sampling, route matching, audit logs, and error presentation.
+It excludes browser logging, transports, audit logs, and production error presentation.
 
 ## License
 

--- a/packages/nuxt-wide-events/bench/PROFILE.md
+++ b/packages/nuxt-wide-events/bench/PROFILE.md
@@ -30,3 +30,13 @@ npx 0x --tree-debug --output-dir .profiles/raw bench/profile.mjs raw 3000000
 ```
 
 Treat wall time as a local diagnostic. Use the Vitest benchmark and Nitro HTTP matrix for repeated comparisons.
+
+## Field ownership optimization
+
+A paired profile serialized three million fresh 20 Field records with fixed clocks. The optimized build reduced wall time from 6.12 to 2.60 seconds and maximum RSS from 69.3 to 66.1 MB.
+
+Package self samples fell from 1,600 to 440. Garbage collection samples fell from 166 to 51. The build now transfers validated inline Field literals into the Wide Event. Public runtime calls still copy their input.
+
+```sh
+npx 0x --tree-debug --output-dir .profiles/wide-fixed bench/profile.mjs wide-fixed 3000000
+```

--- a/packages/nuxt-wide-events/bench/RESULTS.md
+++ b/packages/nuxt-wide-events/bench/RESULTS.md
@@ -31,3 +31,17 @@ This case includes `crypto.randomUUID`, two `performance.now` calls, and ISO tim
 | evlog 2.26.0, redaction disabled | 653,709 | baseline |
 | pino 10.3.1, in-memory destination | 611,344 | 0.94x |
 | raw object plus JSON.stringify | 857,969 | 1.31x |
+
+## Optimization against origin/main
+
+This paired harness creates fresh Field objects for every operation. It compares the merged baseline with the optimized generated runtime.
+
+| Scenario | Baseline CPU | Optimized CPU | Change | Baseline allocation | Optimized allocation | Change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 5 Fields | 410 ns | 404 ns | -1.6% | 752 B | 696 B | -7.4% |
+| 20 Fields | 1.95 µs | 0.864 µs | -55.7% | 4,345 B | 1,137 B | -73.8% |
+| 2 Field layers | 614 ns | 618 ns | +0.7% | 1,161 B | 1,104 B | -4.8% |
+| Runtime clocks and request ID | 1.19 µs | 1.13 µs | -5.7% | 1,830 B | 1,776 B | -3.0% |
+| Error lifecycle | 513 ns | 433 ns | -15.6% | 752 B | 696 B | -7.5% |
+
+The 5 Field and layered CPU changes are within measurement noise. Build-validated inline Field literals use an ownership path. Public runtime calls remain nonmutating.

--- a/packages/nuxt-wide-events/bench/ci/perf.mjs
+++ b/packages/nuxt-wide-events/bench/ci/perf.mjs
@@ -1,3 +1,4 @@
+import { deepStrictEqual, ok } from 'node:assert/strict'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import v8 from 'node:v8'
@@ -20,33 +21,53 @@ const STARTED_AT = 10
 const ENDED_AT = 12.5
 const TIMESTAMP = '2026-08-13T00:00:00.000Z'
 const ALLOCATION_BATCH_SIZE = 20_000
-const fiveFields = {
-  userId: 'usr_abc123',
-  action: 'checkout',
-  cartItemCount: 3,
-  region: 'au-southeast-2',
-  sessionId: 'sess_xyz789',
-}
-const twentyFields = {
-  ...fiveFields,
-  cartTotal: 9999,
-  currency: 'AUD',
-  accountPlan: 'pro',
-  accountAgeDays: 365,
-  featureCheckoutV2: true,
-  paymentMethod: 'card',
-  paymentAttempt: 1,
-  inventoryReserved: true,
-  shippingCountry: 'AU',
-  shippingPostcode: '3000',
-  couponCode: null,
-  retryCount: 0,
-  queueDepth: 12,
-  responseCached: false,
-  experimentVariant: 'control',
-}
 const error = new Error('CI fixture error')
 let sink
+
+function createFiveFields() {
+  return {
+    action: 'checkout',
+    cartItemCount: 3,
+    region: 'au-southeast-2',
+    sessionId: 'sess_xyz789',
+    userId: 'usr_abc123',
+  }
+}
+
+function createTwentyFields() {
+  return {
+    accountAgeDays: 365,
+    accountPlan: 'pro',
+    action: 'checkout',
+    cartItemCount: 3,
+    cartTotal: 9999,
+    couponCode: null,
+    currency: 'AUD',
+    experimentVariant: 'control',
+    featureCheckoutV2: true,
+    inventoryReserved: true,
+    paymentAttempt: 1,
+    paymentMethod: 'card',
+    queueDepth: 12,
+    region: 'au-southeast-2',
+    responseCached: false,
+    retryCount: 0,
+    sessionId: 'sess_xyz789',
+    shippingCountry: 'AU',
+    shippingPostcode: '3000',
+    userId: 'usr_abc123',
+  }
+}
+
+function createLaterFields() {
+  return {
+    cacheHit: true,
+    queueDepth: 12,
+    retryCount: 0,
+    shippingCountry: 'AU',
+    tenantId: 'tenant_abc123',
+  }
+}
 
 function forceGarbageCollection() {
   globalThis.gc()
@@ -140,10 +161,10 @@ function measureAllocation(baseOperation, pullRequestOperation) {
 }
 
 function createScenarios(runtime) {
-  function fixedEvent(fields, hasError = false) {
+  function fixedEvent(createFields, hasError = false) {
     const event = { context: {}, method: 'POST' }
     runtime.startWideEvent(event, REQUEST_ID, STARTED_AT)
-    runtime.addWideEventFields(event, fields)
+    runtime.addWideEventFields(event, createFields(), true)
     if (hasError)
       runtime.captureWideEventError(event, error)
     return JSON.stringify(runtime.emitWideEvent(
@@ -159,15 +180,24 @@ function createScenarios(runtime) {
   function runtimeEvent() {
     const event = { context: {}, method: 'POST' }
     runtime.startWideEvent(event)
-    runtime.addWideEventFields(event, fiveFields)
+    runtime.addWideEventFields(event, createFiveFields(), true)
     return JSON.stringify(runtime.emitWideEvent(event, 200, 'ci', '/api/checkout'))
   }
 
+  function layeredEvent() {
+    const event = { context: {}, method: 'POST' }
+    runtime.startWideEvent(event, REQUEST_ID, STARTED_AT)
+    runtime.addWideEventFields(event, createFiveFields(), true)
+    runtime.addWideEventFields(event, createLaterFields(), true)
+    return JSON.stringify(runtime.emitWideEvent(event, 200, 'ci', '/api/checkout', ENDED_AT, TIMESTAMP))
+  }
+
   return [
-    { id: 'five', name: 'Five Fields serialized', operation: () => fixedEvent(fiveFields), cpuBatchSize: 1_500_000 },
-    { id: 'twenty', name: 'Twenty Fields serialized', operation: () => fixedEvent(twentyFields), cpuBatchSize: 250_000 },
+    { id: 'five', name: 'Five Fields serialized', operation: () => fixedEvent(createFiveFields), cpuBatchSize: 1_500_000 },
+    { id: 'twenty', name: 'Twenty Fields serialized', operation: () => fixedEvent(createTwentyFields), cpuBatchSize: 250_000 },
+    { id: 'layered', name: 'Two Field layers serialized', operation: layeredEvent, cpuBatchSize: 700_000 },
     { id: 'runtime', name: 'Runtime clocks and request ID', operation: runtimeEvent, cpuBatchSize: 600_000 },
-    { id: 'error', name: 'Error lifecycle', operation: () => fixedEvent(fiveFields, true), cpuBatchSize: 1_200_000 },
+    { id: 'error', name: 'Error lifecycle', operation: () => fixedEvent(createFiveFields, true), cpuBatchSize: 1_200_000 },
   ]
 }
 
@@ -182,6 +212,10 @@ async function main() {
   ])
   const baseScenarios = baseRuntime ? createScenarios(baseRuntime) : undefined
   const pullRequestScenarios = createScenarios(pullRequestRuntime)
+  if (baseScenarios) {
+    for (const [index, scenario] of pullRequestScenarios.entries())
+      deepStrictEqual(normalizedOutput(scenario, scenario.operation()), normalizedOutput(scenario, baseScenarios[index].operation()))
+  }
   const allocationOnly = process.argv.includes('--alloc-only')
   const baseBenches = []
   const pullRequestBenches = []
@@ -207,6 +241,16 @@ async function main() {
     base: baseBenches.length ? { benches: baseBenches } : null,
     pullRequest: { benches: pullRequestBenches },
   })}\n`)
+}
+
+function normalizedOutput(scenario, output) {
+  const record = JSON.parse(output)
+  if (scenario.id !== 'runtime')
+    return record
+  ok(typeof record.durationMs === 'number')
+  ok(typeof record.requestId === 'string')
+  ok(typeof record.timestamp === 'string')
+  return { ...record, durationMs: '<duration>', requestId: '<requestId>', timestamp: '<timestamp>' }
 }
 
 main().catch((error) => {

--- a/packages/nuxt-wide-events/bench/production-policy.bench.ts
+++ b/packages/nuxt-wide-events/bench/production-policy.bench.ts
@@ -1,0 +1,40 @@
+import type { WideEventRecord } from '../src/runtime/server/index'
+import { afterAll, bench, describe } from 'vitest'
+import { shouldEmitWideEvent } from '../src/runtime/server/production-policy'
+
+const exclude = /^(?:\/api\/_nuxt_icon\/.*|\/api\/_content\/.*|\/api\/_mdc\/.*)$/
+const sampling = { duration: 1000, info: 10, status: 400 }
+const request: WideEventRecord = {
+  durationMs: 10,
+  level: 'info',
+  method: 'GET',
+  path: '/api/checkout',
+  requestId: 'req_1',
+  status: 200,
+  timestamp: '2026-08-13T00:00:00.000Z',
+}
+const error = { ...request, level: 'error' as const, status: 404 }
+let sink: boolean
+
+afterAll(() => {
+  if (sink === undefined)
+    throw new Error('The benchmark sink was not written.')
+})
+
+describe('production request policy', () => {
+  bench('default', () => {
+    sink = true
+  })
+
+  bench('mdream policy, sampled request', () => {
+    sink = !exclude.test(request.path!)
+      && !exclude.test(request.path!)
+      && shouldEmitWideEvent(request, sampling)
+  })
+
+  bench('mdream policy, status kept', () => {
+    sink = !exclude.test(error.path!)
+      && !exclude.test(error.path!)
+      && shouldEmitWideEvent(error, sampling)
+  })
+})

--- a/packages/nuxt-wide-events/bench/profile.mjs
+++ b/packages/nuxt-wide-events/bench/profile.mjs
@@ -15,6 +15,51 @@ const fields = {
 }
 let sink
 
+function createFiveFields() {
+  return {
+    action: 'checkout',
+    cartItemCount: 3,
+    region: 'au-southeast-2',
+    sessionId: 'sess_xyz789',
+    userId: 'usr_abc123',
+  }
+}
+
+function createTwentyFields() {
+  return {
+    accountAgeDays: 365,
+    accountPlan: 'pro',
+    action: 'checkout',
+    cartItemCount: 3,
+    cartTotal: 9999,
+    couponCode: null,
+    currency: 'AUD',
+    experimentVariant: 'control',
+    featureCheckoutV2: true,
+    inventoryReserved: true,
+    paymentAttempt: 1,
+    paymentMethod: 'card',
+    queueDepth: 12,
+    region: 'au-southeast-2',
+    responseCached: false,
+    retryCount: 0,
+    sessionId: 'sess_xyz789',
+    shippingCountry: 'AU',
+    shippingPostcode: '3000',
+    userId: 'usr_abc123',
+  }
+}
+
+function createLaterFields() {
+  return {
+    cacheHit: true,
+    queueDepth: 12,
+    retryCount: 0,
+    shippingCountry: 'AU',
+    tenantId: 'tenant_abc123',
+  }
+}
+
 initLogger({
   env: { environment: 'production', service: 'profile' },
   pretty: false,
@@ -27,8 +72,35 @@ for (let iteration = 0; iteration < iterations; iteration++) {
   if (scenario === 'wide') {
     const event = { context: {}, method: 'POST' }
     startWideEvent(event)
-    addWideEventFields(event, fields)
+    addWideEventFields(event, createFiveFields(), true)
     sink = JSON.stringify(emitWideEvent(event, 200, 'profile', '/api/checkout'))
+  }
+  else if (scenario === 'wide-fixed') {
+    const event = { context: {}, method: 'POST' }
+    startWideEvent(event, 'req_profile_abc123', 10)
+    addWideEventFields(event, createTwentyFields(), true)
+    sink = JSON.stringify(emitWideEvent(
+      event,
+      200,
+      'profile',
+      '/api/checkout',
+      12.5,
+      '2026-08-13T00:00:00.000Z',
+    ))
+  }
+  else if (scenario === 'wide-layered') {
+    const event = { context: {}, method: 'POST' }
+    startWideEvent(event, 'req_profile_abc123', 10)
+    addWideEventFields(event, createFiveFields(), true)
+    addWideEventFields(event, createLaterFields(), true)
+    sink = JSON.stringify(emitWideEvent(
+      event,
+      200,
+      'profile',
+      '/api/checkout',
+      12.5,
+      '2026-08-13T00:00:00.000Z',
+    ))
   }
   else if (scenario === 'evlog') {
     const log = createLogger({

--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/runtime/server/index.d.ts",
       "import": "./dist/runtime/server/index.js"
     },
+    "./standalone": {
+      "types": "./dist/runtime/server/standalone.d.ts",
+      "import": "./dist/runtime/server/standalone.js"
+    },
     "./build": {
       "types": "./dist/build/index.d.mts",
       "import": "./dist/build/index.mjs"
@@ -42,6 +46,7 @@
   "typesVersions": {
     "*": {
       "server": ["dist/runtime/server/index.d.ts"],
+      "standalone": ["dist/runtime/server/standalone.d.ts"],
       "build": ["dist/build/index.d.mts"]
     }
   },

--- a/packages/nuxt-wide-events/src/build/runtime-config.ts
+++ b/packages/nuxt-wide-events/src/build/runtime-config.ts
@@ -1,0 +1,89 @@
+import type {
+  ModuleOptions,
+  WideEventSamplingRates,
+  WideEventsRuntimeConfig,
+  WideEventsRuntimeSampling,
+  WideEventTailSamplingCondition,
+} from '../types'
+
+type RuntimeOptions = Pick<ModuleOptions, 'console' | 'drain' | 'exclude' | 'sampling' | 'service'>
+
+export function resolveWideEventsRuntimeConfig(options: RuntimeOptions): WideEventsRuntimeConfig {
+  const exclude = compileRoutePatterns(options.exclude)
+  const sampling = resolveSampling(options.sampling?.rates, options.sampling?.keep)
+  return {
+    console: options.console ?? true,
+    drain: options.drain ?? false,
+    ...(options.service === undefined ? {} : { service: options.service }),
+    ...(exclude === undefined ? {} : { exclude }),
+    ...(sampling === undefined ? {} : { sampling }),
+  }
+}
+
+export function serializeWideEventsRuntimeConfig(config: WideEventsRuntimeConfig): string {
+  const { exclude, ...serializable } = config
+  if (exclude === undefined)
+    return `export default ${JSON.stringify(serializable)}\n`
+  const properties = JSON.stringify(serializable).slice(1, -1)
+  return `export default {${properties},"exclude":new RegExp(${JSON.stringify(exclude.source)})}\n`
+}
+
+function compileRoutePatterns(patterns: string[] | undefined): RegExp | undefined {
+  if (!patterns?.length)
+    return undefined
+  return new RegExp(`^(?:${patterns.map(globSource).join('|')})$`)
+}
+
+function globSource(pattern: string): string {
+  return pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replaceAll('**', '\0')
+    .replaceAll('*', '[^/]*')
+    .replaceAll('\0', '.*')
+    .replaceAll('?', '[^/]')
+}
+
+function resolveSampling(
+  rates: WideEventSamplingRates | undefined,
+  keep: WideEventTailSamplingCondition[] | undefined,
+): WideEventsRuntimeSampling | undefined {
+  for (const [level, rate] of Object.entries(rates ?? {}))
+    parseRate(level, rate)
+  for (const [index, condition] of (keep ?? []).entries()) {
+    if (condition.duration !== undefined && (!Number.isFinite(condition.duration) || condition.duration < 0))
+      throw new TypeError(`wideEvents.sampling.keep[${index}].duration must be a finite nonnegative number.`)
+    if (condition.status !== undefined && (!Number.isInteger(condition.status) || condition.status < 0))
+      throw new TypeError(`wideEvents.sampling.keep[${index}].status must be a nonnegative integer.`)
+  }
+
+  const duration = minimum(keep?.map(condition => condition.duration))
+  const status = minimum(keep?.map(condition => condition.status))
+  const info = rates?.info
+  const error = rates?.error
+  const debug = rates?.debug
+  const warn = rates?.warn
+  if (duration === undefined && status === undefined && info === undefined && error === undefined && debug === undefined && warn === undefined)
+    return undefined
+  return {
+    ...(debug === undefined ? {} : { debug }),
+    ...(duration === undefined ? {} : { duration }),
+    ...(error === undefined ? {} : { error }),
+    ...(info === undefined ? {} : { info }),
+    ...(status === undefined ? {} : { status }),
+    ...(warn === undefined ? {} : { warn }),
+  }
+}
+
+function parseRate(level: string, rate: number): void {
+  if (!Number.isFinite(rate) || rate < 0 || rate > 100)
+    throw new TypeError(`wideEvents.sampling.rates.${level} must be a finite number from 0 to 100.`)
+}
+
+function minimum(values: (number | undefined)[] | undefined): number | undefined {
+  let result: number | undefined
+  for (const value of values ?? []) {
+    if (value !== undefined && (result === undefined || value < result))
+      result = value
+  }
+  return result
+}

--- a/packages/nuxt-wide-events/src/build/source-scan.ts
+++ b/packages/nuxt-wide-events/src/build/source-scan.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import { normalize, relative } from 'pathe'
-import { formatWideEventSourceIssues, validateWideEventSource } from './source-validation'
+import { formatWideEventSourceIssues, transformWideEventSource } from './source-validation'
 
 const SOURCE_PATTERN = /\.[cm]?[jt]sx?$/i
 
@@ -17,10 +17,10 @@ export function createWideEventValidationPlugin(
         return null
 
       const displayFile = normalize(relative(rootDir, file))
-      const result = validateWideEventSource(source, displayFile, fields)
+      const result = transformWideEventSource(source, displayFile, fields)
       if (result._tag === 'Err')
         throw new Error(`[nuxt-wide-events]\n${formatWideEventSourceIssues(result.issues)}`)
-      return null
+      return result.source === source ? null : { code: result.source, map: null }
     },
   }
 }

--- a/packages/nuxt-wide-events/src/build/source-validation.ts
+++ b/packages/nuxt-wide-events/src/build/source-validation.ts
@@ -1,13 +1,21 @@
 import { parseSync } from 'vite'
 
-const API_NAME = 'addWideEventFields'
+const ADD_FIELDS_API_NAME = 'addWideEventFields'
+const CREATE_API_NAME = 'createWideEvent'
 const PACKAGE_SERVER_EXPORT = '@harlan-zw/nuxt-wide-events/server'
+const PACKAGE_STANDALONE_EXPORT = '@harlan-zw/nuxt-wide-events/standalone'
 const NUXT_SERVER_IMPORTS = new Set(['#imports', '#server-imports'])
 
 interface AstNode {
+  end?: number
   type: string
   start?: number
   [key: string]: any
+}
+
+interface SourceInsertion {
+  offset: number
+  text: string
 }
 
 interface SourceIssueBase {
@@ -19,6 +27,8 @@ export type WideEventSourceIssue
   = | SourceIssueBase & { _tag: 'ComputedField' }
     | SourceIssueBase & { _tag: 'DuplicateField', field: string }
     | SourceIssueBase & { _tag: 'DynamicFields' }
+    | SourceIssueBase & { _tag: 'InvalidApiReference' }
+    | SourceIssueBase & { _tag: 'NonDataField' }
     | SourceIssueBase & { _tag: 'ParseFailure', message: string }
     | SourceIssueBase & { _tag: 'SpreadFields' }
     | SourceIssueBase & { _tag: 'UnknownField', field: string }
@@ -27,13 +37,47 @@ export type ValidateWideEventSourceResult
   = | { _tag: 'Ok' }
     | { _tag: 'Err', issues: WideEventSourceIssue[] }
 
+export type TransformWideEventSourceResult
+  = | { _tag: 'Ok', source: string }
+    | { _tag: 'Err', issues: WideEventSourceIssue[] }
+
 export function validateWideEventSource(
   source: string,
   file: string,
   allowedFields: ReadonlySet<string>,
 ): ValidateWideEventSourceResult {
-  if (!source.includes(API_NAME))
-    return { _tag: 'Ok' }
+  const analysis = analyzeWideEventSource(source, file, allowedFields)
+  return analysis.issues.length > 0 ? { _tag: 'Err', issues: analysis.issues } : { _tag: 'Ok' }
+}
+
+export function transformWideEventSource(
+  source: string,
+  file: string,
+  allowedFields: ReadonlySet<string>,
+): TransformWideEventSourceResult {
+  const analysis = analyzeWideEventSource(source, file, allowedFields)
+  if (analysis.issues.length > 0)
+    return { _tag: 'Err', issues: analysis.issues }
+  let output = source
+  for (const insertion of analysis.ownedCallEnds.sort((a, b) => b.offset - a.offset))
+    output = `${output.slice(0, insertion.offset)}${insertion.text}${output.slice(insertion.offset)}`
+  return { _tag: 'Ok', source: output }
+}
+
+function analyzeWideEventSource(
+  source: string,
+  file: string,
+  allowedFields: ReadonlySet<string>,
+): { issues: WideEventSourceIssue[], ownedCallEnds: SourceInsertion[] } {
+  if (
+    !source.includes(ADD_FIELDS_API_NAME)
+    && !source.includes(CREATE_API_NAME)
+    && !source.includes(PACKAGE_SERVER_EXPORT)
+    && !source.includes(PACKAGE_STANDALONE_EXPORT)
+    && ![...NUXT_SERVER_IMPORTS].some(importSource => source.includes(importSource))
+  ) {
+    return { issues: [], ownedCallEnds: [] }
+  }
 
   const parsed = parseSync(file, source, {
     lang: languageFor(file),
@@ -41,22 +85,23 @@ export function validateWideEventSource(
   })
   if (parsed.errors.length > 0) {
     return {
-      _tag: 'Err',
       issues: parsed.errors.map(error => ({
         _tag: 'ParseFailure',
         file,
         line: 1,
         message: error.message,
       })),
+      ownedCallEnds: [],
     }
   }
 
   const issues: WideEventSourceIssue[] = []
+  const ownedCallEnds: SourceInsertion[] = []
   const rootScope = createScope(undefined)
   collectStatementBindings(parsed.program.body ?? [], rootScope)
-  visitNode(parsed.program, rootScope, source, file, allowedFields, issues)
+  visitNode(parsed.program, rootScope, source, file, allowedFields, issues, ownedCallEnds)
 
-  return issues.length > 0 ? { _tag: 'Err', issues } : { _tag: 'Ok' }
+  return { issues, ownedCallEnds }
 }
 
 export function formatWideEventSourceIssues(issues: readonly WideEventSourceIssue[]): string {
@@ -66,6 +111,10 @@ export function formatWideEventSourceIssues(issues: readonly WideEventSourceIssu
       return `${location} Field "${issue.field}" is not configured in wideEvents.fields.`
     if (issue._tag === 'DynamicFields')
       return `${location} addWideEventFields() requires an object literal.`
+    if (issue._tag === 'InvalidApiReference')
+      return `${location} Wide Event APIs must be called directly.`
+    if (issue._tag === 'NonDataField')
+      return `${location} Wide Event Fields must use data properties.`
     if (issue._tag === 'SpreadFields')
       return `${location} Wide Event fields cannot use object spreads.`
     if (issue._tag === 'ComputedField')
@@ -76,7 +125,8 @@ export function formatWideEventSourceIssues(issues: readonly WideEventSourceIssu
   }).join('\n')
 }
 
-type Binding = 'Api' | 'Local'
+type ApiBinding = 'AddFieldsApi' | 'CreateApi'
+type Binding = ApiBinding | 'Local' | 'NuxtNamespace' | 'ServerNamespace' | 'StandaloneNamespace'
 
 interface Scope {
   bindings: Map<string, Binding>
@@ -110,14 +160,51 @@ function collectStatementBindings(statements: readonly AstNode[], scope: Scope):
 
 function collectImportBindings(node: AstNode, scope: Scope): void {
   const source = node.source?.value
-  const serverImport = source === PACKAGE_SERVER_EXPORT || NUXT_SERVER_IMPORTS.has(source)
+  const namespaceBinding = source === PACKAGE_SERVER_EXPORT
+    ? 'ServerNamespace'
+    : source === PACKAGE_STANDALONE_EXPORT
+      ? 'StandaloneNamespace'
+      : NUXT_SERVER_IMPORTS.has(source)
+        ? 'NuxtNamespace'
+        : undefined
   for (const specifier of node.specifiers ?? []) {
     const local = specifier.local?.name
     if (!local)
       continue
+    if (node.importKind === 'type' || specifier.importKind === 'type') {
+      bindName(local, 'Local', scope)
+      continue
+    }
+    if (specifier.type === 'ImportNamespaceSpecifier') {
+      bindName(local, namespaceBinding ?? 'Local', scope)
+      continue
+    }
     const imported = propertyName(specifier.imported)
-    bindName(local, serverImport && imported === API_NAME ? 'Api' : 'Local', scope)
+    bindName(local, importedApiBinding(source, imported) ?? 'Local', scope)
   }
+}
+
+function importedApiBinding(source: unknown, imported: unknown): ApiBinding | undefined {
+  if (source === PACKAGE_STANDALONE_EXPORT)
+    return imported === CREATE_API_NAME ? 'CreateApi' : undefined
+  if (source === PACKAGE_SERVER_EXPORT)
+    return imported === ADD_FIELDS_API_NAME ? 'AddFieldsApi' : undefined
+  if (typeof source === 'string' && NUXT_SERVER_IMPORTS.has(source)) {
+    const binding = apiBinding(imported)
+    return isApiBinding(binding) ? binding : undefined
+  }
+}
+
+function isProtectedPackage(source: unknown): boolean {
+  return source === PACKAGE_SERVER_EXPORT || source === PACKAGE_STANDALONE_EXPORT
+}
+
+function isValueExport(node: AstNode): boolean {
+  if (node.exportKind === 'type')
+    return false
+  if (node.type === 'ExportNamedDeclaration' && node.specifiers?.length > 0)
+    return node.specifiers.some((specifier: AstNode) => specifier.exportKind !== 'type')
+  return true
 }
 
 function collectPatternBindings(node: AstNode | undefined, scope: Scope): void {
@@ -167,44 +254,199 @@ function visitNode(
   file: string,
   allowedFields: ReadonlySet<string>,
   issues: WideEventSourceIssue[],
+  ownedCallEnds: SourceInsertion[],
 ): void {
   if (!node)
     return
 
+  if (node.type === 'ImportDeclaration')
+    return
+  if (node.type === 'ExportAllDeclaration' || node.type === 'ExportNamedDeclaration') {
+    if (isProtectedPackage(node.source?.value) && isValueExport(node)) {
+      issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+      return
+    }
+    visitNode(node.declaration, scope, source, file, allowedFields, issues, ownedCallEnds)
+    for (const specifier of node.specifiers ?? []) {
+      if (specifier.exportKind !== 'type')
+        visitNode(specifier.local, scope, source, file, allowedFields, issues, ownedCallEnds)
+    }
+    return
+  }
+  if (node.type === 'ImportExpression') {
+    if (isProtectedPackage(node.source?.value)) {
+      issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+      return
+    }
+  }
   if (node.type === 'Program') {
-    visitChildren(node.body, scope, source, file, allowedFields, issues)
+    visitChildren(node.body, scope, source, file, allowedFields, issues, ownedCallEnds)
     return
   }
   if (node.type === 'BlockStatement') {
     const blockScope = createScope(scope)
     collectStatementBindings(node.body ?? [], blockScope)
-    visitChildren(node.body, blockScope, source, file, allowedFields, issues)
+    visitChildren(node.body, blockScope, source, file, allowedFields, issues, ownedCallEnds)
     return
   }
   if (isFunction(node)) {
     const functionScope = createScope(scope)
     bindName(node.id?.name, 'Local', functionScope)
-    for (const parameter of node.params ?? [])
+    for (const parameter of node.params ?? []) {
       collectPatternBindings(parameter, functionScope)
-    visitNode(node.body, functionScope, source, file, allowedFields, issues)
+    }
+    for (const parameter of node.params ?? [])
+      visitPatternExpressions(parameter, functionScope, source, file, allowedFields, issues, ownedCallEnds)
+    visitNode(node.body, functionScope, source, file, allowedFields, issues, ownedCallEnds)
     return
   }
   if (node.type === 'CatchClause') {
     const catchScope = createScope(scope)
     collectPatternBindings(node.param, catchScope)
-    visitNode(node.body, catchScope, source, file, allowedFields, issues)
+    visitNode(node.body, catchScope, source, file, allowedFields, issues, ownedCallEnds)
     return
   }
+  if (node.type === 'Identifier') {
+    const binding = resolveApiBinding(node.name, scope)
+    if (isApiBinding(binding) || isNamespaceBinding(binding))
+      issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+    return
+  }
+  if (node.type === 'MemberExpression' || node.type === 'OptionalMemberExpression') {
+    visitMemberExpression(node, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type === 'Property') {
+    if (node.computed)
+      visitNode(node.key, scope, source, file, allowedFields, issues, ownedCallEnds)
+    visitNode(node.value, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type === 'VariableDeclarator') {
+    visitPatternExpressions(node.id, scope, source, file, allowedFields, issues, ownedCallEnds)
+    visitNode(node.init, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (isTypeScriptExpression(node)) {
+    visitNode(node.expression, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type.startsWith('TS'))
+    return
   if (node.type === 'CallExpression') {
     const callee = unwrap(node.callee)
-    if (callee?.type === 'Identifier' && isApiBinding(callee.name, scope))
-      validateFieldsArgument(node.arguments?.[1], source, file, allowedFields, issues)
+    if (callee?.type === 'Identifier' && callee.name === 'require' && isProtectedPackage(node.arguments?.[0]?.value)) {
+      issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+      return
+    }
+    if (callee?.type === 'Identifier') {
+      const binding = resolveApiBinding(callee.name, scope)
+      if (binding === 'AddFieldsApi') {
+        validateFieldsArgument(node.arguments?.[1], source, file, allowedFields, issues)
+        markCompilerOwnedCall(node, source, file, issues, ownedCallEnds)
+        visitChildren(node.arguments, scope, source, file, allowedFields, issues, ownedCallEnds)
+        return
+      }
+      else if (binding === 'CreateApi' && node.arguments?.length > 0) {
+        validateFieldsArgument(node.arguments[0], source, file, allowedFields, issues)
+        visitChildren(node.arguments, scope, source, file, allowedFields, issues, ownedCallEnds)
+        return
+      }
+      else if (binding === 'CreateApi') {
+        return
+      }
+    }
   }
 
   for (const [key, value] of Object.entries(node)) {
     if (key === 'type' || key === 'start' || key === 'end')
       continue
-    visitUnknown(value, scope, source, file, allowedFields, issues)
+    visitUnknown(value, scope, source, file, allowedFields, issues, ownedCallEnds)
+  }
+}
+
+function markCompilerOwnedCall(
+  node: AstNode,
+  source: string,
+  file: string,
+  issues: WideEventSourceIssue[],
+  insertions: SourceInsertion[],
+): void {
+  const arguments_ = node.arguments ?? []
+  if (arguments_.length === 3 && arguments_[2]?.type === 'Literal' && arguments_[2].value === true)
+    return
+  if (arguments_.length !== 2) {
+    issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+    return
+  }
+  const fieldsEnd = arguments_[1]?.end
+  if (typeof fieldsEnd !== 'number')
+    return
+  insertions.push({ offset: fieldsEnd, text: ', true' })
+}
+
+function visitMemberExpression(
+  node: AstNode,
+  scope: Scope,
+  source: string,
+  file: string,
+  allowedFields: ReadonlySet<string>,
+  issues: WideEventSourceIssue[],
+  ownedCallEnds: SourceInsertion[],
+): void {
+  const object = unwrap(node.object)
+  if (object?.type === 'Identifier') {
+    const binding = resolveBinding(scope, object.name)
+    if (isNamespaceBinding(binding)) {
+      const property = node.computed ? undefined : propertyName(node.property)
+      if (node.computed || namespaceExposesApi(binding, property))
+        issues.push({ _tag: 'InvalidApiReference', file, line: lineAt(source, node.start) })
+      if (node.computed)
+        visitNode(node.property, scope, source, file, allowedFields, issues, ownedCallEnds)
+      return
+    }
+  }
+  visitNode(node.object, scope, source, file, allowedFields, issues, ownedCallEnds)
+  if (node.computed)
+    visitNode(node.property, scope, source, file, allowedFields, issues, ownedCallEnds)
+}
+
+function visitPatternExpressions(
+  input: AstNode | undefined,
+  scope: Scope,
+  source: string,
+  file: string,
+  allowedFields: ReadonlySet<string>,
+  issues: WideEventSourceIssue[],
+  ownedCallEnds: SourceInsertion[],
+): void {
+  const node = unwrap(input)
+  if (!node || node.type === 'Identifier')
+    return
+  if (node.type === 'AssignmentPattern') {
+    visitPatternExpressions(node.left, scope, source, file, allowedFields, issues, ownedCallEnds)
+    visitNode(node.right, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type === 'RestElement') {
+    visitPatternExpressions(node.argument, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type === 'ArrayPattern') {
+    for (const element of node.elements ?? [])
+      visitPatternExpressions(element, scope, source, file, allowedFields, issues, ownedCallEnds)
+    return
+  }
+  if (node.type === 'ObjectPattern') {
+    for (const property of node.properties ?? []) {
+      if (property.type === 'RestElement') {
+        visitPatternExpressions(property.argument, scope, source, file, allowedFields, issues, ownedCallEnds)
+        continue
+      }
+      if (property.computed)
+        visitNode(property.key, scope, source, file, allowedFields, issues, ownedCallEnds)
+      visitPatternExpressions(property.value, scope, source, file, allowedFields, issues, ownedCallEnds)
+    }
   }
 }
 
@@ -215,9 +457,10 @@ function visitChildren(
   file: string,
   allowedFields: ReadonlySet<string>,
   issues: WideEventSourceIssue[],
+  ownedCallEnds: SourceInsertion[],
 ): void {
   for (const node of nodes ?? [])
-    visitNode(node, scope, source, file, allowedFields, issues)
+    visitNode(node, scope, source, file, allowedFields, issues, ownedCallEnds)
 }
 
 function visitUnknown(
@@ -227,21 +470,54 @@ function visitUnknown(
   file: string,
   allowedFields: ReadonlySet<string>,
   issues: WideEventSourceIssue[],
+  ownedCallEnds: SourceInsertion[],
 ): void {
   if (Array.isArray(value)) {
     for (const item of value)
-      visitUnknown(item, scope, source, file, allowedFields, issues)
+      visitUnknown(item, scope, source, file, allowedFields, issues, ownedCallEnds)
     return
   }
   if (value && typeof value === 'object' && 'type' in value)
-    visitNode(value as AstNode, scope, source, file, allowedFields, issues)
+    visitNode(value as AstNode, scope, source, file, allowedFields, issues, ownedCallEnds)
 }
 
-function isApiBinding(name: unknown, scope: Scope): boolean {
+function resolveApiBinding(name: unknown, scope: Scope): Binding | undefined {
   if (typeof name !== 'string')
-    return false
+    return undefined
   const binding = resolveBinding(scope, name)
-  return binding === 'Api' || (binding === undefined && name === API_NAME)
+  if (binding)
+    return binding
+  return apiBinding(name)
+}
+
+function apiBinding(name: unknown): Binding | undefined {
+  if (name === ADD_FIELDS_API_NAME)
+    return 'AddFieldsApi'
+  if (name === CREATE_API_NAME)
+    return 'CreateApi'
+  return undefined
+}
+
+function isApiBinding(binding: Binding | undefined): binding is ApiBinding {
+  return binding === 'AddFieldsApi' || binding === 'CreateApi'
+}
+
+function isNamespaceBinding(binding: Binding | undefined): binding is 'NuxtNamespace' | 'ServerNamespace' | 'StandaloneNamespace' {
+  return binding === 'NuxtNamespace' || binding === 'ServerNamespace' || binding === 'StandaloneNamespace'
+}
+
+function namespaceExposesApi(binding: Binding, property: string | undefined): boolean {
+  if (property === CREATE_API_NAME)
+    return isNamespaceBinding(binding)
+  return property === ADD_FIELDS_API_NAME && binding !== 'StandaloneNamespace'
+}
+
+function isTypeScriptExpression(node: AstNode): boolean {
+  return node.type === 'TSAsExpression'
+    || node.type === 'TSInstantiationExpression'
+    || node.type === 'TSNonNullExpression'
+    || node.type === 'TSSatisfiesExpression'
+    || node.type === 'TSTypeAssertion'
 }
 
 function isFunction(node: AstNode): boolean {
@@ -273,6 +549,10 @@ function validateFieldsArgument(
     }
     if (property?.type !== 'Property' || property.computed === true) {
       issues.push({ _tag: 'ComputedField', file, line })
+      continue
+    }
+    if (property.kind !== 'init' || property.method === true) {
+      issues.push({ _tag: 'NonDataField', file, line })
       continue
     }
     const field = propertyName(property.key)

--- a/packages/nuxt-wide-events/src/module.ts
+++ b/packages/nuxt-wide-events/src/module.ts
@@ -1,6 +1,7 @@
-import type { ModuleOptions, WideEventsRuntimeConfig } from './types'
+import type { ModuleOptions } from './types'
 import { addServerImports, addServerPlugin, addTemplate, addTypeTemplate, createResolver, defineNuxtModule } from '@nuxt/kit'
 import { formatWideEventFieldIssues, resolveWideEventFields } from './build/fields'
+import { resolveWideEventsRuntimeConfig, serializeWideEventsRuntimeConfig } from './build/runtime-config'
 import { createWideEventValidationPlugin } from './build/source-scan'
 
 export type { ModuleOptions } from './types'
@@ -22,6 +23,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     enabled: true,
+    request: true,
     fields: [],
     console: true,
     drain: false,
@@ -36,15 +38,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     const fields = new Set(resolvedFields.fields)
     const resolver = createResolver(import.meta.url)
-    const runtimeConfig: WideEventsRuntimeConfig = {
-      console: options.console ?? true,
-      drain: options.drain ?? false,
-      ...(options.service === undefined ? {} : { service: options.service }),
-    }
+    const runtimeConfig = resolveWideEventsRuntimeConfig(options)
     const configTemplate = addTemplate({
       filename: 'wide-events/config.mjs',
       write: true,
-      getContents: () => `export default ${JSON.stringify(runtimeConfig)}\n`,
+      getContents: () => serializeWideEventsRuntimeConfig(runtimeConfig),
     })
     nuxt.options.alias['#wide-events/config'] = configTemplate.dst
     const nitro = ((nuxt.options as unknown as { nitro?: NitroConfigLike }).nitro ??= {})
@@ -54,12 +52,22 @@ export default defineNuxtModule<ModuleOptions>({
     nitro.rollupConfig.plugins ||= []
     nitro.rollupConfig.plugins.push(createWideEventValidationPlugin(nuxt.options.rootDir, fields))
 
-    addServerPlugin(resolver.resolve(nuxt.options.dev
-      ? './runtime/server/development-plugin'
-      : './runtime/server/production-plugin'))
+    if (options.request ?? true) {
+      addServerPlugin(resolver.resolve(nuxt.options.dev
+        ? './runtime/server/development-plugin'
+        : runtimeConfig.exclude || runtimeConfig.sampling
+          ? './runtime/server/production-policy-plugin'
+          : './runtime/server/production-plugin'))
+    }
     addServerImports({
       name: 'addWideEventFields',
       from: resolver.resolve('./runtime/server/index'),
+    })
+    addServerImports({
+      name: 'createWideEvent',
+      from: resolver.resolve(nuxt.options.dev
+        ? './runtime/server/standalone-development'
+        : './runtime/server/standalone-production'),
     })
     addWideEventTypes(resolvedFields.fields)
   },

--- a/packages/nuxt-wide-events/src/runtime/server/config.d.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/config.d.ts
@@ -2,6 +2,15 @@ declare module '#wide-events/config' {
   const config: {
     console: boolean
     drain: boolean
+    exclude?: RegExp
+    sampling?: {
+      debug?: number
+      duration?: number
+      error?: number
+      info?: number
+      status?: number
+      warn?: number
+    }
     service?: string
   }
   export default config

--- a/packages/nuxt-wide-events/src/runtime/server/development-plugin.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development-plugin.ts
@@ -14,21 +14,28 @@ interface ServerEvent extends WideEventLike {
   response?: { status?: number }
 }
 
+interface RequestEvent extends WideEventLike {
+  path: string
+}
+
 interface ServerResponse {
   status?: number
   statusCode?: number
 }
 
 const ERROR_KEY = Symbol('developmentError')
+const EXCLUDED_KEY = Symbol('excluded')
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('request', (event) => {
-    const request = event as unknown as WideEventLike
+    const request = event as unknown as RequestEvent
+    if (isExcluded(request))
+      return
     startWideEvent(request)
   })
 
   nitroApp.hooks.hook('error', (error, context: ErrorHookContext) => {
-    if (!context.event)
+    if (!context.event || isExcluded(context.event))
       return
     captureWideEventError(context.event, error)
     ;(context.event.context as Record<PropertyKey, unknown>)[ERROR_KEY] = error
@@ -51,6 +58,8 @@ export default defineNitroPlugin((nitroApp) => {
 
   nitroApp.hooks.hook('afterResponse', (event, response) => {
     const request = event as unknown as ServerEvent
+    if (isExcluded(request))
+      return
     const error = (request.context as Record<PropertyKey, unknown>)[ERROR_KEY]
     const record = emitWideEvent(
       request,
@@ -68,6 +77,18 @@ export default defineNitroPlugin((nitroApp) => {
       return drain(nitroApp, record)
   })
 })
+
+function isExcluded(event: WideEventLike): boolean {
+  const context = event.context as Record<PropertyKey, unknown>
+  const cached = context[EXCLUDED_KEY]
+  if (typeof cached === 'boolean')
+    return cached
+  const path = event.path ?? ''
+  const query = path.indexOf('?')
+  const excluded = config.exclude?.test(query === -1 ? path : path.slice(0, query)) ?? false
+  context[EXCLUDED_KEY] = excluded
+  return excluded
+}
 
 function routeTemplate(event: WideEventLike): string | undefined {
   const route = event.context.matchedRoute

--- a/packages/nuxt-wide-events/src/runtime/server/index.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/index.ts
@@ -30,11 +30,12 @@ const STATE_KEY = Symbol.for('@harlan-zw/nuxt-wide-events/state')
 const STARTED_AT_KEY = Symbol('startedAt')
 const REQUEST_ID_KEY = Symbol('requestId')
 const ERROR_KEY = Symbol('error')
+const COLLECTING = Symbol('collecting')
 const EMITTED = Symbol('emitted')
 
 type CollectingWideEvent = Record<string, WideEventValue | undefined>
 
-type WideEventState = CollectingWideEvent | typeof EMITTED
+type WideEventState = CollectingWideEvent | typeof COLLECTING | typeof EMITTED
 
 export function startWideEvent(event: WideEventLike, requestId?: string, startedAt?: number): void {
   const context = stateContext(event)
@@ -44,27 +45,67 @@ export function startWideEvent(event: WideEventLike, requestId?: string, started
   if (current)
     return
 
-  context[STATE_KEY] = createCollectingState()
+  context[STATE_KEY] = COLLECTING
   context[REQUEST_ID_KEY] = requestId ?? crypto.randomUUID()
   context[STARTED_AT_KEY] = startedAt ?? performance.now()
 }
 
-export function addWideEventFields(event: WideEventLike, fields: WideEventFields): void {
-  const state = collectingState(event)
+export function addWideEventFields(event: WideEventLike, fields: WideEventFields): void
+export function addWideEventFields(event: WideEventLike, fields: WideEventFields, owned = false): void {
+  const context = stateContext(event)
+  const current = context[STATE_KEY] as WideEventState | undefined
+  if (current === EMITTED)
+    throw new Error('The Wide Event was already emitted.')
+
+  const firstFields = current === undefined || current === COLLECTING
+  if (owned && firstFields && Object.getPrototypeOf(fields) !== Object.prototype)
+    throw new TypeError('Compiler-owned Wide Event Fields must be a plain object literal.')
+
+  const output = !owned && firstFields ? {} as CollectingWideEvent : undefined
+  let undefinedFields: string[] | undefined
   for (const field in fields) {
+    if (!Object.hasOwn(fields, field))
+      continue
     const value = fields[field as ConfiguredWideEventField]
+    if (value === undefined) {
+      if (owned) {
+        undefinedFields ??= []
+        undefinedFields.push(field)
+      }
+      continue
+    }
     if (!isWideEventValue(value))
       throw new TypeError(`Wide Event field "${field}" must be a string, number, boolean, or null.`)
-    state[field] = value
+    if (output)
+      output[field] = value
+    else if (!firstFields)
+      current[field] = value
+  }
+  if (undefinedFields) {
+    if (owned) {
+      for (const field of undefinedFields)
+        delete fields[field as ConfiguredWideEventField]
+    }
+  }
+
+  if (current === undefined) {
+    initializeMetadata(context)
+  }
+  if (current === undefined || current === COLLECTING) {
+    context[STATE_KEY] = owned ? fields : output!
   }
 }
 
 /** Record an error without ending Field collection. */
 export function captureWideEventError(event: WideEventLike, _error: unknown): void {
   const context = stateContext(event)
-  if (context[STATE_KEY] === EMITTED)
+  const current = context[STATE_KEY] as WideEventState | undefined
+  if (current === EMITTED)
     return
-  collectingState(event)
+  if (current === undefined) {
+    initializeMetadata(context)
+    context[STATE_KEY] = COLLECTING
+  }
   context[ERROR_KEY] = true
 }
 
@@ -81,11 +122,12 @@ export function emitWideEvent(
   if (current === EMITTED)
     return null
 
-  const state = current ?? initializeCollectingState(context)
-  const hasError = context[ERROR_KEY] === true
+  if (current === undefined)
+    initializeMetadata(context)
+  const state = current === undefined || current === COLLECTING ? {} : current
   const record = state as WideEventRecord
   record.timestamp = timestamp
-  record.level = hasError ? 'error' : 'info'
+  record.level = context[ERROR_KEY] === true ? 'error' : 'info'
   if (service !== undefined)
     record.service = service
   record.method = safeMethod(event.method)
@@ -98,30 +140,13 @@ export function emitWideEvent(
   return record
 }
 
-function collectingState(event: WideEventLike): CollectingWideEvent {
-  const context = stateContext(event)
-  const current = context[STATE_KEY] as WideEventState | undefined
-  if (current === EMITTED)
-    throw new Error('The Wide Event was already emitted.')
-  if (current)
-    return current
-  return initializeCollectingState(context)
-}
-
 function stateContext(event: WideEventLike): Record<PropertyKey, unknown> {
   return event.context as Record<PropertyKey, unknown>
 }
 
-function createCollectingState(): CollectingWideEvent {
-  return {}
-}
-
-function initializeCollectingState(context: Record<PropertyKey, unknown>): CollectingWideEvent {
-  const state = createCollectingState()
-  context[STATE_KEY] = state
+function initializeMetadata(context: Record<PropertyKey, unknown>): void {
   context[REQUEST_ID_KEY] = crypto.randomUUID()
   context[STARTED_AT_KEY] = performance.now()
-  return state
 }
 
 function isWideEventValue(value: unknown): value is WideEventValue {

--- a/packages/nuxt-wide-events/src/runtime/server/production-policy-plugin.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/production-policy-plugin.ts
@@ -2,6 +2,7 @@ import type { NitroApp } from 'nitropack/types'
 import type { WideEventLike, WideEventRecord } from './index'
 import config from '#wide-events/config'
 import { captureWideEventError, emitWideEvent, startWideEvent } from './index'
+import { shouldEmitWideEvent } from './production-policy'
 
 interface ErrorHookContext {
   event?: RequestEvent
@@ -13,10 +14,14 @@ interface RequestEvent extends WideEventLike {
   node?: { res?: { statusCode?: number } }
 }
 
-export default function wideEventPlugin(nitroApp: NitroApp): void {
+const EXCLUDED_KEY = Symbol('excluded')
+
+export default function wideEventPolicyPlugin(nitroApp: NitroApp): void {
   function output(event: WideEventLike, status: number, path?: string): Promise<void> | undefined {
+    if (isExcluded(event))
+      return
     const record = emitWideEvent(event, status, config.service, path)
-    if (!record)
+    if (!record || (config.sampling && !shouldEmitWideEvent(record, config.sampling)))
       return
     if (config.console)
       console.log(JSON.stringify(record))
@@ -26,11 +31,12 @@ export default function wideEventPlugin(nitroApp: NitroApp): void {
 
   nitroApp.hooks.hook('request', (event) => {
     const request = event as unknown as RequestEvent
-    startWideEvent(request)
+    if (!isExcluded(request))
+      startWideEvent(request)
   })
 
   nitroApp.hooks.hook('error', (error, context: ErrorHookContext) => {
-    if (!context.event)
+    if (!context.event || isExcluded(context.event))
       return
     captureWideEventError(context.event, error)
     const path = routeTemplate(context.event)
@@ -47,6 +53,18 @@ export default function wideEventPlugin(nitroApp: NitroApp): void {
       routeTemplate(request),
     )
   })
+}
+
+function isExcluded(event: WideEventLike): boolean {
+  const context = event.context as Record<PropertyKey, unknown>
+  const cached = context[EXCLUDED_KEY]
+  if (typeof cached === 'boolean')
+    return cached
+  const path = event.path ?? ''
+  const query = path.indexOf('?')
+  const excluded = config.exclude?.test(query === -1 ? path : path.slice(0, query)) ?? false
+  context[EXCLUDED_KEY] = excluded
+  return excluded
 }
 
 function routeTemplate(event: WideEventLike): string | undefined {

--- a/packages/nuxt-wide-events/src/runtime/server/production-policy.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/production-policy.ts
@@ -1,0 +1,17 @@
+import type { WideEventsRuntimeSampling } from '../../types'
+import type { WideEventRecord } from './index'
+
+export function shouldEmitWideEvent(
+  record: WideEventRecord,
+  sampling: WideEventsRuntimeSampling,
+  random: () => number = Math.random,
+): boolean {
+  if (sampling.duration !== undefined && record.durationMs >= sampling.duration)
+    return true
+  if (sampling.status !== undefined && record.status >= sampling.status)
+    return true
+  const rate = record.level === 'error' ? sampling.error ?? 100 : sampling.info ?? 100
+  if (rate <= 0)
+    return false
+  return rate >= 100 || random() * 100 < rate
+}

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
@@ -1,0 +1,88 @@
+import type { WideEventFields, WideEventLike, WideEventRecord } from './index'
+import { addWideEventFields, emitWideEvent, startWideEvent } from './index'
+
+export type StandaloneWideEventLevel = 'debug' | 'error' | 'info' | 'warn'
+
+export interface StandaloneWideEventRecord extends Omit<WideEventRecord, 'level'> {
+  level: StandaloneWideEventLevel
+}
+
+export interface StandaloneWideEvent extends WideEventLike {
+  emit: () => StandaloneWideEventRecord | null
+  setLevel: (level: StandaloneWideEventLevel) => void
+}
+
+interface StandaloneWideEventOptions {
+  output?: (record: StandaloneWideEventRecord) => void
+  sampling?: StandaloneWideEventSampling
+  service?: string
+}
+
+interface StandaloneWideEventSampling {
+  debug?: number
+  duration?: number
+  error?: number
+  info?: number
+  status?: number
+  warn?: number
+}
+
+export function createStandaloneWideEvent(
+  initialFields: WideEventFields | undefined,
+  options: StandaloneWideEventOptions,
+): StandaloneWideEvent {
+  const event = {
+    context: {},
+    method: 'UNKNOWN',
+  } as StandaloneWideEvent
+  let emitted = false
+  let level: StandaloneWideEventLevel = 'info'
+
+  startWideEvent(event)
+  if (initialFields)
+    addWideEventFields(event, initialFields)
+
+  event.setLevel = (nextLevel) => {
+    if (emitted)
+      throw new Error('The Wide Event was already emitted.')
+    level = parseLevel(nextLevel)
+  }
+  event.emit = () => {
+    const record = emitWideEvent(event, 200, options.service)
+    if (!record)
+      return null
+    emitted = true
+    const output = record as StandaloneWideEventRecord
+    output.level = level
+    if (options.sampling && !shouldEmitStandaloneWideEvent(output, options.sampling))
+      return null
+    options.output?.(output)
+    return output
+  }
+
+  return event
+}
+
+function shouldEmitStandaloneWideEvent(
+  record: StandaloneWideEventRecord,
+  sampling: StandaloneWideEventSampling,
+): boolean {
+  if (sampling.duration !== undefined && Number(record.durationMs) >= sampling.duration)
+    return true
+  if (sampling.status !== undefined && Number(record.status) >= sampling.status)
+    return true
+  const rate = sampling[record.level] ?? 100
+  return rate > 0 && (rate >= 100 || Math.random() * 100 < rate)
+}
+
+function parseLevel(input: StandaloneWideEventLevel): StandaloneWideEventLevel {
+  switch (input) {
+    case 'debug':
+    case 'error':
+    case 'info':
+    case 'warn':
+      return input
+    default:
+      throw new TypeError('Wide Event level must be debug, error, info, or warn.')
+  }
+}

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
@@ -1,0 +1,12 @@
+import type { WideEventFields } from './index'
+import type { StandaloneWideEvent } from './standalone-core'
+import config from '#wide-events/config'
+import { createStandaloneWideEvent } from './standalone-core'
+
+/** Create one development Wide Event for a background operation. */
+export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
+  return createStandaloneWideEvent(initialFields, {
+    ...(config.console ? { output: (record: unknown) => console.log('Wide Event', record) } : {}),
+    service: config.service,
+  })
+}

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-production.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-production.ts
@@ -1,0 +1,16 @@
+import type { WideEventsRuntimeConfig } from '../../types'
+import type { WideEventFields } from './index'
+import type { StandaloneWideEvent } from './standalone-core'
+import config from '#wide-events/config'
+import { createStandaloneWideEvent } from './standalone-core'
+
+const runtimeConfig = config as WideEventsRuntimeConfig
+
+/** Create one production Wide Event for a background operation. */
+export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
+  return createStandaloneWideEvent(initialFields, {
+    ...(runtimeConfig.console ? { output: (record: unknown) => console.log(JSON.stringify(record)) } : {}),
+    sampling: runtimeConfig.sampling,
+    service: runtimeConfig.service,
+  })
+}

--- a/packages/nuxt-wide-events/src/runtime/server/standalone.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone.ts
@@ -1,0 +1,16 @@
+import type { WideEventFields } from './index'
+import type { StandaloneWideEvent } from './standalone-core'
+import { createStandaloneWideEvent } from './standalone-core'
+
+export type {
+  StandaloneWideEvent,
+  StandaloneWideEventLevel,
+  StandaloneWideEventRecord,
+} from './standalone-core'
+
+/** Create one production Wide Event for a background operation. */
+export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
+  return createStandaloneWideEvent(initialFields, {
+    output: record => console.log(JSON.stringify(record)),
+  })
+}

--- a/packages/nuxt-wide-events/src/types.ts
+++ b/packages/nuxt-wide-events/src/types.ts
@@ -1,18 +1,56 @@
 export interface ModuleOptions {
   /** Emit Wide Events. */
   enabled?: boolean
+  /** Collect one Wide Event for each request. */
+  request?: boolean
   /** Fields that application code may add. Use dotted lower camel case paths. */
   fields?: string[]
   /** Add a stable service name to every Wide Event. */
   service?: string
+  /** Route glob patterns to exclude. */
+  exclude?: string[]
+  /** Reduce production Wide Event volume after the request completes. */
+  sampling?: WideEventSamplingConfig
   /** Write each Wide Event as one JSON line to stdout. */
   console?: boolean
   /** Call the wide-events:emit hook after each request. */
   drain?: boolean
 }
 
+export interface WideEventSamplingRates {
+  debug?: number
+  error?: number
+  info?: number
+  warn?: number
+}
+
+export interface WideEventTailSamplingCondition {
+  /** Keep requests with at least this duration in milliseconds. */
+  duration?: number
+  /** Keep requests with at least this status code. */
+  status?: number
+}
+
+export interface WideEventSamplingConfig {
+  /** Percentage of each level to keep, from 0 to 100. */
+  rates?: WideEventSamplingRates
+  /** Conditions that bypass percentage sampling. */
+  keep?: WideEventTailSamplingCondition[]
+}
+
+export interface WideEventsRuntimeSampling {
+  debug?: number
+  duration?: number
+  error?: number
+  info?: number
+  status?: number
+  warn?: number
+}
+
 export interface WideEventsRuntimeConfig {
   console: boolean
   drain: boolean
+  exclude?: RegExp
+  sampling?: WideEventsRuntimeSampling
   service?: string
 }

--- a/packages/nuxt-wide-events/tests/fixtures/basic/nuxt.config.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/nuxt.config.ts
@@ -1,6 +1,8 @@
 import process from 'node:process'
 
 const measureSize = process.env.NUXT_WIDE_EVENTS_MEASURE === 'true'
+const testPolicy = process.env.NUXT_WIDE_EVENTS_POLICY === 'true'
+const standaloneOnly = process.env.NUXT_WIDE_EVENTS_STANDALONE === 'true'
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-08-13',
@@ -14,7 +16,17 @@ export default defineNuxtConfig({
   wideEvents: {
     console: true,
     fields: ['cache.hit', 'user.id'],
+    request: !standaloneOnly,
     service: 'integration-fixture',
+    ...(testPolicy
+      ? {
+          exclude: ['/api/excluded/**'],
+          sampling: {
+            rates: { debug: 0, error: 0, info: 0, warn: 50 },
+            keep: [{ duration: 1000 }, { status: 400 }],
+          },
+        }
+      : {}),
   },
   ...(measureSize
     ? {

--- a/packages/nuxt-wide-events/tests/fixtures/basic/server/api/created.post.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/server/api/created.post.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  event.node.res.statusCode = 201
+  return { created: true }
+})

--- a/packages/nuxt-wide-events/tests/fixtures/basic/server/api/excluded/ping.get.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/server/api/excluded/ping.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ excluded: true }))

--- a/packages/nuxt-wide-events/tests/fixtures/basic/server/api/standalone.get.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/server/api/standalone.get.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler(() => {
+  const wideEvent = createWideEvent({ 'user.id': 'standalone_1' })
+  wideEvent.setLevel('warn')
+  return wideEvent.emit()
+})

--- a/packages/nuxt-wide-events/tests/fixtures/workers/server/api/created.post.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/workers/server/api/created.post.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 201)
+  return { created: true }
+})

--- a/packages/nuxt-wide-events/tests/integration/module.test.ts
+++ b/packages/nuxt-wide-events/tests/integration/module.test.ts
@@ -44,6 +44,11 @@ describe('nuxt module integration', () => {
         path: '/api/failure',
         status: 404,
       }),
+      expect.objectContaining({
+        method: 'POST',
+        path: '/api/created',
+        status: 201,
+      }),
     ])
     expect(record.missingStatus).toBe(404)
     expect(JSON.stringify(record.logs)).not.toContain('untrusted-request-id')
@@ -61,6 +66,31 @@ describe('nuxt module integration', () => {
       _tag: 'Err',
       output: expect.stringContaining('server/api/record.get.ts:3 Field "password" is not configured in wideEvents.fields.'),
     })
+  }, 60_000)
+
+  it('excludes matching routes and keeps sampled errors by status', async () => {
+    await runNuxt(['build', 'tests/fixtures/basic'], { NUXT_WIDE_EVENTS_POLICY: 'true' })
+
+    expect(await requestPolicyFixture()).toEqual([
+      expect.objectContaining({
+        level: 'error',
+        path: '/api/failure',
+        status: 404,
+      }),
+    ])
+  }, 60_000)
+
+  it('keeps standalone collection and removes request collection when disabled', async () => {
+    await runNuxt(['build', 'tests/fixtures/basic'], { NUXT_WIDE_EVENTS_STANDALONE: 'true' })
+
+    expect(await requestStandaloneFixture()).toEqual([
+      expect.objectContaining({
+        'level': 'warn',
+        'method': 'UNKNOWN',
+        'service': 'integration-fixture',
+        'user.id': 'standalone_1',
+      }),
+    ])
   }, 60_000)
 
   it('validates imported graph modules with a custom server directory', async () => {
@@ -139,6 +169,63 @@ async function requestBuiltFixture(): Promise<{ logs: Record<string, unknown>[],
     .finally(() => child.kill('SIGTERM'))
 }
 
+async function requestPolicyFixture(): Promise<Record<string, unknown>[]> {
+  const port = await availablePort()
+  const child = spawn(process.execPath, ['.output/server/index.mjs'], {
+    cwd: basicFixture,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      NO_COLOR: '1',
+      PORT: String(port),
+    },
+    stdio: 'pipe',
+  })
+  let output = ''
+  child.stdout.on('data', chunk => output += String(chunk))
+  child.stderr.on('data', chunk => output += String(chunk))
+
+  try {
+    await waitForServer(child, port, () => output)
+    await fetch(`http://127.0.0.1:${port}/api/record`)
+    await fetch(`http://127.0.0.1:${port}/api/excluded/ping?token=secret`)
+    await fetch(`http://127.0.0.1:${port}/api/failure`)
+    await waitFor(() => eventLogs(output).length === 1, child, () => output)
+    return eventLogs(output)
+  }
+  finally {
+    child.kill('SIGTERM')
+  }
+}
+
+async function requestStandaloneFixture(): Promise<Record<string, unknown>[]> {
+  const port = await availablePort()
+  const child = spawn(process.execPath, ['.output/server/index.mjs'], {
+    cwd: basicFixture,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      NO_COLOR: '1',
+      PORT: String(port),
+    },
+    stdio: 'pipe',
+  })
+  let output = ''
+  child.stdout.on('data', chunk => output += String(chunk))
+  child.stderr.on('data', chunk => output += String(chunk))
+
+  try {
+    await waitForServer(child, port, () => output)
+    output = ''
+    await fetch(`http://127.0.0.1:${port}/api/standalone`)
+    await waitFor(() => eventLogs(output).length === 1, child, () => output)
+    return eventLogs(output)
+  }
+  finally {
+    child.kill('SIGTERM')
+  }
+}
+
 async function runRequest(
   child: ChildProcessWithoutNullStreams,
   port: number,
@@ -150,7 +237,8 @@ async function runRequest(
   }).then(value => value.json())
   const missingStatus = await fetch(`http://127.0.0.1:${port}/api/failure`)
     .then(value => value.status)
-  await waitFor(() => eventLogs(output()).length === 2, child, output)
+  await fetch(`http://127.0.0.1:${port}/api/created`, { method: 'POST' })
+  await waitFor(() => eventLogs(output()).length === 3, child, output)
   return { logs: eventLogs(output()), missingStatus, response }
 }
 

--- a/packages/nuxt-wide-events/tests/integration/workers.test.ts
+++ b/packages/nuxt-wide-events/tests/integration/workers.test.ts
@@ -41,9 +41,11 @@ describe('cloudflare Workers integration', () => {
       output = ''
       const response = await fetch(`http://127.0.0.1:${port}/api/record?token=secret-query-token`)
         .then(value => value.json())
-      await waitFor(() => eventLogs(output).length === 1, child, () => output)
+      const created = await fetch(`http://127.0.0.1:${port}/api/created`, { method: 'POST' })
+      await waitFor(() => eventLogs(output).length === 2, child, () => output)
 
       expect(response).toEqual({ recorded: true })
+      expect(created.status).toBe(201)
       expect(eventLogs(output)).toEqual([
         expect.objectContaining({
           'level': 'info',
@@ -52,6 +54,11 @@ describe('cloudflare Workers integration', () => {
           'service': 'workers-fixture',
           'status': 200,
           'worker.ok': true,
+        }),
+        expect.objectContaining({
+          method: 'POST',
+          path: '/api/created',
+          status: 201,
         }),
       ])
       expect(JSON.stringify(eventLogs(output))).not.toContain('secret-query-token')

--- a/packages/nuxt-wide-events/tests/production-policy.test.ts
+++ b/packages/nuxt-wide-events/tests/production-policy.test.ts
@@ -1,0 +1,32 @@
+import type { WideEventRecord } from '../src/runtime/server/index'
+import { describe, expect, it } from 'vitest'
+import { shouldEmitWideEvent } from '../src/runtime/server/production-policy'
+
+const record: WideEventRecord = {
+  durationMs: 10,
+  level: 'info',
+  method: 'GET',
+  requestId: 'req_1',
+  status: 200,
+  timestamp: '2026-08-13T00:00:00.000Z',
+}
+
+describe('shouldEmitWideEvent', () => {
+  it('applies the configured percentage', () => {
+    const sampling = { info: 10 }
+
+    expect(shouldEmitWideEvent(record, sampling, () => 0.09)).toBe(true)
+    expect(shouldEmitWideEvent(record, sampling, () => 0.1)).toBe(false)
+    expect(shouldEmitWideEvent(record, { info: 0 }, () => 0)).toBe(false)
+    expect(shouldEmitWideEvent(record, { info: 100 }, () => 1)).toBe(true)
+  })
+
+  it('keeps matching duration or status before applying the rate', () => {
+    const sampling = { duration: 1000, error: 0, info: 0, status: 400 }
+
+    expect(shouldEmitWideEvent({ ...record, durationMs: 1000 }, sampling, () => 1)).toBe(true)
+    expect(shouldEmitWideEvent({ ...record, status: 400 }, sampling, () => 1)).toBe(true)
+    expect(shouldEmitWideEvent(record, sampling, () => 0)).toBe(false)
+    expect(shouldEmitWideEvent({ ...record, level: 'error' }, {}, () => 1)).toBe(true)
+  })
+})

--- a/packages/nuxt-wide-events/tests/runtime-config.test.ts
+++ b/packages/nuxt-wide-events/tests/runtime-config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWideEventsRuntimeConfig } from '../src/build/runtime-config'
+
+describe('resolveWideEventsRuntimeConfig', () => {
+  it('omits route and sampling policy by default', () => {
+    expect(resolveWideEventsRuntimeConfig({ console: true, drain: false })).toEqual({
+      console: true,
+      drain: false,
+    })
+  })
+
+  it('compiles route globs once and specializes observed sampling policy', () => {
+    const config = resolveWideEventsRuntimeConfig({
+      console: false,
+      drain: false,
+      exclude: ['/api/_nuxt_icon/**', '/health', '/users/?'],
+      sampling: {
+        rates: { debug: 0, error: 5, info: 10, warn: 50 },
+        keep: [{ duration: 1000 }, { duration: 2000 }, { status: 500 }, { status: 400 }],
+      },
+    })
+
+    expect(config.exclude).toBeInstanceOf(RegExp)
+    expect(config.exclude?.test('/api/_nuxt_icon/foo/bar')).toBe(true)
+    expect(config.exclude?.test('/api/_nuxt_icon')).toBe(false)
+    expect(config.exclude?.test('/health')).toBe(true)
+    expect(config.exclude?.test('/users/a')).toBe(true)
+    expect(config.exclude?.test('/users/ab')).toBe(false)
+    expect(config.sampling).toEqual({ debug: 0, duration: 1000, error: 5, info: 10, status: 400, warn: 50 })
+  })
+
+  it.each([
+    ['a negative rate', { sampling: { rates: { info: -1 } } }, 'wideEvents.sampling.rates.info'],
+    ['a rate over 100', { sampling: { rates: { error: 101 } } }, 'wideEvents.sampling.rates.error'],
+    ['a non-finite rate', { sampling: { rates: { warn: Infinity } } }, 'wideEvents.sampling.rates.warn'],
+    ['a negative duration', { sampling: { keep: [{ duration: -1 }] } }, 'wideEvents.sampling.keep[0].duration'],
+    ['a decimal status', { sampling: { keep: [{ status: 400.5 }] } }, 'wideEvents.sampling.keep[0].status'],
+  ])('rejects %s', (_label, input, expected) => {
+    expect(() => resolveWideEventsRuntimeConfig(input as never)).toThrow(expected)
+  })
+
+  it('keeps standalone rates for createWideEvent', () => {
+    expect(resolveWideEventsRuntimeConfig({
+      sampling: { rates: { debug: 1, error: 2, info: 3, warn: 4 } },
+    }).sampling).toEqual({ debug: 1, error: 2, info: 3, warn: 4 })
+  })
+})

--- a/packages/nuxt-wide-events/tests/runtime.test.ts
+++ b/packages/nuxt-wide-events/tests/runtime.test.ts
@@ -9,6 +9,12 @@ function event() {
   }
 }
 
+const addCompilerOwnedFields = addWideEventFields as unknown as (
+  request: ReturnType<typeof event>,
+  fields: Record<string, unknown>,
+  owned: true,
+) => void
+
 describe('wide Event runtime', () => {
   it('emits one structured record with configured fields', () => {
     const request = event()
@@ -55,6 +61,74 @@ describe('wide Event runtime', () => {
 
     expect(emitWideEvent(request, 200, undefined, undefined, 11, 'now')).not.toBeNull()
     expect(emitWideEvent(request, 200, undefined, undefined, 12, 'later')).toBeNull()
+  })
+
+  it('keeps the first request identity when start runs twice', () => {
+    const request = event()
+    startWideEvent(request, 'req_first', 10)
+    startWideEvent(request, 'req_second', 20)
+
+    expect(emitWideEvent(request, 200, undefined, undefined, 12.5, 'now')).toEqual(expect.objectContaining({
+      durationMs: 2.5,
+      requestId: 'req_first',
+    }))
+  })
+
+  it('combines Fields collected by separate server layers', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    addWideEventFields(request, { 'user.id': 'user_1' } as never)
+    addWideEventFields(request, { 'cart.itemCount': 2 } as never)
+
+    expect(emitWideEvent(request, 200, undefined, undefined, 12, 'now')).toEqual(expect.objectContaining({
+      'cart.itemCount': 2,
+      'user.id': 'user_1',
+    }))
+  })
+
+  it('does not mutate Fields from an untransformed caller', () => {
+    const request = event()
+    const fields = { 'user.id': 'user_1' }
+    startWideEvent(request, 'req_1', 10)
+    addWideEventFields(request, fields as never)
+
+    emitWideEvent(request, 200, 'shop', '/api/cart', 12, 'now')
+
+    expect(fields).toEqual({ 'user.id': 'user_1' })
+  })
+
+  it('skips an undefined Field during migration', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    addWideEventFields(request, {
+      'cart.itemCount': undefined,
+      'user.id': 'user_1',
+    } as never)
+
+    const record = emitWideEvent(request, 200, undefined, undefined, 12, 'now')!
+
+    expect(record['user.id']).toBe('user_1')
+    expect(Object.hasOwn(record, 'cart.itemCount')).toBe(false)
+  })
+
+  it('leaves Fields untouched when a later value is invalid', () => {
+    const request = event()
+    const fields = {
+      'cart.itemCount': undefined,
+      'user.id': { secret: true },
+    }
+    startWideEvent(request, 'req_1', 10)
+
+    expect(() => addWideEventFields(request, fields as never)).toThrow(/user.id/)
+    expect(Object.hasOwn(fields, 'cart.itemCount')).toBe(true)
+  })
+
+  it('rejects prototype injection on the compiler-owned first literal', () => {
+    const request = event()
+    const fields = Object.assign(Object.create({ password: 'secret' }), { 'user.id': 'user_1' })
+    startWideEvent(request, 'req_1', 10)
+
+    expect(() => addCompilerOwnedFields(request, fields, true)).toThrow(/plain object literal/)
   })
 
   it('does not copy error strings into a production record', () => {

--- a/packages/nuxt-wide-events/tests/source-validation.test.ts
+++ b/packages/nuxt-wide-events/tests/source-validation.test.ts
@@ -35,6 +35,8 @@ describe('validateWideEventSource', () => {
     ['a variable', 'addWideEventFields(event, fields)', 'DynamicFields'],
     ['a spread', 'addWideEventFields(event, { ...fields })', 'SpreadFields'],
     ['a computed field', 'addWideEventFields(event, { [field]: value })', 'ComputedField'],
+    ['a getter', 'addWideEventFields(event, { get "user.id"() { return input.userId } })', 'NonDataField'],
+    ['a method', 'addWideEventFields(event, { "user.id"() { return input.userId } })', 'NonDataField'],
   ])('rejects %s because the build cannot prove it safe', (_label, source, tag) => {
     const result = validateWideEventSource(source, 'server/api/unsafe.ts', fields)
 
@@ -53,6 +55,78 @@ describe('validateWideEventSource', () => {
     expect(result).toEqual({
       _tag: 'Err',
       issues: [expect.objectContaining({ _tag: 'UnknownField', field: 'token' })],
+    })
+  })
+
+  it('validates API calls in default parameter initializers', () => {
+    const result = validateWideEventSource(`
+      function read(input = addWideEventFields(event, { password: secret })) {
+        return input
+      }
+    `, 'server/api/default.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: [expect.objectContaining({ _tag: 'UnknownField', field: 'password' })],
+    })
+  })
+
+  it.each([
+    [
+      'a copied alias',
+      `
+        import { addWideEventFields } from '@harlan-zw/nuxt-wide-events/server'
+        const addFields = addWideEventFields
+        addFields(event, { password: secret })
+      `,
+    ],
+    [
+      'a sequence callee',
+      `
+        import { addWideEventFields } from '@harlan-zw/nuxt-wide-events/server'
+        ;(0, addWideEventFields)(event, { password: secret })
+      `,
+    ],
+    [
+      'Function.call',
+      `
+        import { addWideEventFields } from '@harlan-zw/nuxt-wide-events/server'
+        addWideEventFields.call(undefined, event, { password: secret })
+      `,
+    ],
+    [
+      'a server namespace member',
+      `
+        import * as wideEvents from '@harlan-zw/nuxt-wide-events/server'
+        wideEvents.addWideEventFields(event, { password: secret })
+      `,
+    ],
+    [
+      'a standalone namespace member',
+      `
+        import * as wideEvents from '@harlan-zw/nuxt-wide-events/standalone'
+        wideEvents.createWideEvent({ password: secret })
+      `,
+    ],
+  ])('rejects %s because API references must be direct calls', (_label, source) => {
+    const result = validateWideEventSource(source, 'server/api/indirect.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: expect.arrayContaining([expect.objectContaining({ _tag: 'InvalidApiReference' })]),
+    })
+  })
+
+  it.each([
+    `export { addWideEventFields } from '@harlan-zw/nuxt-wide-events/server'`,
+    `export * from '@harlan-zw/nuxt-wide-events/server'`,
+    `const wideEvents = await import('@harlan-zw/nuxt-wide-events/standalone')`,
+  ])('rejects an indirect API export or import', (source) => {
+    const result = validateWideEventSource(source, 'server/api/indirect-module.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: [expect.objectContaining({ _tag: 'InvalidApiReference' })],
     })
   })
 
@@ -105,19 +179,125 @@ describe('validateWideEventSource', () => {
       issues: [expect.objectContaining({ _tag: 'UnknownField', field: 'password' })],
     })
   })
+
+  it('validates configured initial standalone Fields', () => {
+    const result = validateWideEventSource(`
+      import { createWideEvent } from '@harlan-zw/nuxt-wide-events/standalone'
+      createWideEvent({ 'user.id': '123' })
+      createWideEvent()
+    `, 'server/jobs/sync.ts', fields)
+
+    expect(result).toEqual({ _tag: 'Ok' })
+  })
+
+  it.each([
+    ['an unknown Field', `createWideEvent({ token: input.token })`, 'UnknownField'],
+    ['a variable', `createWideEvent(fields)`, 'DynamicFields'],
+    ['a spread', `createWideEvent({ ...fields })`, 'SpreadFields'],
+    ['a computed Field', `createWideEvent({ [field]: value })`, 'ComputedField'],
+  ])('rejects standalone initial Fields containing %s', (_label, source, tag) => {
+    const result = validateWideEventSource(source, 'server/jobs/unsafe.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: [expect.objectContaining({ _tag: tag })],
+    })
+  })
+
+  it('validates an aliased standalone import within its lexical scope', () => {
+    const result = validateWideEventSource(`
+      import { createWideEvent as createEvent } from '@harlan-zw/nuxt-wide-events/standalone'
+      createEvent({ password: input.password })
+      function localScope(createEvent) {
+        createEvent({ token: input.token })
+      }
+    `, 'server/jobs/scoped.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: [expect.objectContaining({ _tag: 'UnknownField', field: 'password' })],
+    })
+  })
+
+  it('validates a standalone package import', () => {
+    const result = validateWideEventSource(`
+      import { createWideEvent as createEvent } from '@harlan-zw/nuxt-wide-events/standalone'
+      createEvent({ password: input.password })
+    `, 'server/jobs/import.ts', fields)
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      issues: [expect.objectContaining({ _tag: 'UnknownField', field: 'password' })],
+    })
+  })
+
+  it('ignores a local standalone factory with the same name', () => {
+    const result = validateWideEventSource(`
+      const createWideEvent = value => value
+      createWideEvent({ password: input.password })
+    `, 'server/jobs/local.ts', fields)
+
+    expect(result).toEqual({ _tag: 'Ok' })
+  })
 })
 
 describe('createWideEventValidationPlugin', () => {
-  it('validates transformed modules outside the Nuxt root without changing code', () => {
+  it('marks validated inline Fields as compiler-owned', () => {
     const plugin = createWideEventValidationPlugin('/app', fields)
     const valid = runTransform(plugin, `addWideEventFields(event, { 'user.id': '123' })`, '/workspace/shared/event.ts')
 
-    expect(valid).toBeNull()
+    expect(valid).toEqual({
+      code: `addWideEventFields(event, { 'user.id': '123' }, true)`,
+      map: null,
+    })
     expect(() => runTransform(
       plugin,
       'addWideEventFields(event, { password: input.password })',
       '/workspace/shared/event.ts',
     )).toThrow('../workspace/shared/event.ts:1 Field "password" is not configured')
+  })
+
+  it('marks validated imported aliases as compiler-owned', () => {
+    const plugin = createWideEventValidationPlugin('/app', fields)
+    const source = `import { addWideEventFields as addFields } from '@harlan-zw/nuxt-wide-events/server'\naddFields(event, { 'user.id': '123' })`
+
+    expect(runTransform(plugin, source, '/app/server/api/user.ts')).toEqual({
+      code: `import { addWideEventFields as addFields } from '@harlan-zw/nuxt-wide-events/server'\naddFields(event, { 'user.id': '123' }, true)`,
+      map: null,
+    })
+  })
+
+  it('preserves a trailing comma while marking Fields as compiler-owned', () => {
+    const plugin = createWideEventValidationPlugin('/app', fields)
+
+    expect(runTransform(
+      plugin,
+      `addWideEventFields(event, { 'user.id': '123' },)`,
+      '/app/server/api/user.ts',
+    )).toEqual({
+      code: `addWideEventFields(event, { 'user.id': '123' }, true,)`,
+      map: null,
+    })
+  })
+
+  it('does not mark compiler-owned Fields twice', () => {
+    const plugin = createWideEventValidationPlugin('/app', fields)
+
+    expect(runTransform(
+      plugin,
+      `addWideEventFields(event, { 'user.id': '123' }, true)`,
+      '/app/server/api/user.ts',
+    )).toBeNull()
+  })
+
+  it('preserves Unicode before a compiler-owned Field literal', () => {
+    const plugin = createWideEventValidationPlugin('/app', fields)
+    const source = `const label = '🦄'\naddWideEventFields(event, { 'user.id': label })`
+
+    expect(runTransform(plugin, source, '/app/server/api/user.ts')).toEqual({
+      code: `const label = '🦄'\naddWideEventFields(event, { 'user.id': label }, true)`,
+      map: null,
+    })
   })
 
   it('validates source ids with bundler queries', () => {
@@ -128,6 +308,16 @@ describe('createWideEventValidationPlugin', () => {
       'addWideEventFields(event, { password: input.password })',
       '/app/backend/api/record.ts?macro=true',
     )).toThrow('backend/api/record.ts:1 Field "password" is not configured')
+  })
+
+  it('validates standalone initial Fields in transformed modules', () => {
+    const plugin = createWideEventValidationPlugin('/app', fields)
+
+    expect(() => runTransform(
+      plugin,
+      'createWideEvent({ password: input.password })',
+      '/app/server/jobs/sync.ts',
+    )).toThrow('server/jobs/sync.ts:1 Field "password" is not configured')
   })
 })
 

--- a/packages/nuxt-wide-events/tests/standalone.test.ts
+++ b/packages/nuxt-wide-events/tests/standalone.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { addWideEventFields } from '../src/runtime/server/index'
+import { createWideEvent } from '../src/runtime/server/standalone'
+import { createStandaloneWideEvent } from '../src/runtime/server/standalone-core'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('standalone Wide Event', () => {
+  it('collects configured Fields and writes one JSON record', () => {
+    const output = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const wideEvent = createWideEvent({
+      'job.id': 'job_1',
+      'job.skipped': undefined,
+    } as never)
+
+    addWideEventFields(wideEvent, { 'job.outcome': 'completed' } as never)
+    wideEvent.setLevel('warn')
+    const record = wideEvent.emit()
+
+    expect(record).toEqual(expect.objectContaining({
+      'job.id': 'job_1',
+      'job.outcome': 'completed',
+      'level': 'warn',
+    }))
+    expect(Object.hasOwn(record!, 'job.skipped')).toBe(false)
+    expect(output).toHaveBeenCalledOnce()
+    expect(JSON.parse(output.mock.calls[0]![0] as string)).toEqual(record)
+  })
+
+  it('emits only once and rejects later Field mutation', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const wideEvent = createWideEvent()
+
+    expect(wideEvent.emit()).not.toBeNull()
+    expect(wideEvent.emit()).toBeNull()
+    expect(() => addWideEventFields(wideEvent, { 'job.id': 'late' } as never)).toThrow(/already emitted/)
+  })
+
+  it('rejects a non-primitive Field before output', () => {
+    const output = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    expect(() => createWideEvent({ 'job.data': { token: 'secret' } } as never)).toThrow(/must be a string/)
+    expect(output).not.toHaveBeenCalled()
+  })
+
+  it('rejects a level change after output', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const wideEvent = createWideEvent()
+    wideEvent.emit()
+
+    expect(() => wideEvent.setLevel('error')).toThrow(/already emitted/)
+  })
+
+  it('rejects an unknown level before output', () => {
+    const wideEvent = createWideEvent()
+
+    expect(() => wideEvent.setLevel('secret' as never)).toThrow(/level must be/)
+  })
+
+  it('copies initial Fields before later caller mutation', () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const fields = { 'job.id': 'job_1' } as never
+    const wideEvent = createWideEvent(fields)
+    ;(fields as { 'job.id': string })['job.id'] = 'changed'
+
+    expect(wideEvent.emit()).toEqual(expect.objectContaining({ 'job.id': 'job_1' }))
+  })
+
+  it('applies standalone levels and emits an object to development output', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    const output = vi.fn()
+    const sampled = createStandaloneWideEvent(undefined, {
+      output,
+      sampling: { debug: 0, warn: 100 },
+      service: 'worker',
+    })
+    sampled.setLevel('debug')
+
+    expect(sampled.emit()).toBeNull()
+    expect(output).not.toHaveBeenCalled()
+
+    const kept = createStandaloneWideEvent(undefined, {
+      output,
+      sampling: { warn: 100 },
+      service: 'worker',
+    })
+    kept.setLevel('warn')
+
+    expect(kept.emit()).toEqual(expect.objectContaining({ level: 'warn', service: 'worker' }))
+    expect(output).toHaveBeenCalledWith(expect.objectContaining({ level: 'warn', service: 'worker' }))
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Three active evlog consumers need background Wide Events, route exclusions, and sampling before they can migrate without changing log volume. The package now covers those paths while browser logging and dynamic payload shaping stay in each application.

AST-proven inline Field literals can transfer ownership to the runtime. The 20 Field path drops from 1.95 µs and 4,345 B to 0.864 µs and 1,137 B. Default Nitro gzip drops from 1,157 to 1,042 B.

gscdump still has 19 dynamic payload sites that need explicit Field schemas during migration.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).