### PR TITLE
fix(nuxt-wide-events): format development output

### DIFF
--- a/packages/nuxt-wide-events/README.md
+++ b/packages/nuxt-wide-events/README.md
@@ -76,7 +76,7 @@ Default production performs no stack formatting, deep redaction, regular express
 
 Production errors include status only. All error strings remain absent because they can contain unapproved data.
 
-Development records include error messages and stacks. Development uses object output for easier inspection.
+Development records include error messages and stacks. Development uses compact terminal blocks with request metadata in the header and configured Fields in a tree.
 
 ## Background Operations
 

--- a/packages/nuxt-wide-events/src/runtime/server/development-plugin.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development-plugin.ts
@@ -1,7 +1,7 @@
 import type { WideEventLike } from './index'
 import { defineNitroPlugin } from 'nitropack/runtime'
 import config from '#wide-events/config'
-import { enrichDevelopmentWideEvent } from './development'
+import { enrichDevelopmentWideEvent, writeDevelopmentWideEvent } from './development'
 import { scheduleWideEventDrain } from './drain'
 import { captureWideEventError, emitWideEvent, startWideEvent } from './index'
 
@@ -53,7 +53,7 @@ export default defineNitroPlugin((nitroApp) => {
       return
     enrichDevelopmentWideEvent(record, error)
     if (config.console)
-      console.log('Wide Event', record)
+      writeDevelopmentWideEvent(record)
     if (config.drain)
       scheduleWideEventDrain(nitroApp, context.event, record)
   })
@@ -74,7 +74,7 @@ export default defineNitroPlugin((nitroApp) => {
     if (error !== undefined)
       enrichDevelopmentWideEvent(record, error)
     if (config.console)
-      console.log('Wide Event', record)
+      writeDevelopmentWideEvent(record)
     if (config.drain)
       scheduleWideEventDrain(nitroApp, request, record)
   })

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -52,7 +52,7 @@ export function formatDevelopmentWideEvent(
   const scope = typeof record.scope === 'string' ? record.scope : undefined
   const tag = safeTerminalText(record.service ?? scope ?? 'Wide Event')
   const level = record.level.toUpperCase()
-  const request = record.method !== 'UNKNOWN' && record.path !== undefined
+  const request = record.path !== undefined
   const header = [
     paint(formatTimestamp(record.timestamp), ANSI.dim, colors),
     paint(level, levelColor(record.level), colors),
@@ -172,7 +172,7 @@ function safeTerminalText(value: string): string {
 
 function supportsColor(): boolean {
   const process = runtimeProcess()
-  return process !== undefined && !process.env.NO_COLOR && process.stdout?.isTTY !== false
+  return process !== undefined && process.env.NO_COLOR === undefined && process.stdout?.isTTY === true
 }
 
 function runtimeProcess(): {

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -1,6 +1,30 @@
 import type { WideEventRecord } from './index'
+import type { StandaloneWideEventLevel } from './standalone-core'
 
-export type DevelopmentWideEventRecord = WideEventRecord & Record<string, string | number | boolean | null | undefined>
+export interface DevelopmentWideEventRecord extends Record<string, string | number | boolean | null | undefined> {
+  durationMs: number
+  level: StandaloneWideEventLevel
+  method: string
+  requestId: string
+  status: number
+  timestamp: string
+  path?: string
+  service?: string
+}
+
+interface DevelopmentWideEventFormatOptions {
+  colors?: boolean
+}
+
+const ANSI = {
+  cyan: '\u001B[36m',
+  dim: '\u001B[2m',
+  gray: '\u001B[90m',
+  green: '\u001B[32m',
+  red: '\u001B[31m',
+  reset: '\u001B[0m',
+  yellow: '\u001B[33m',
+} as const
 
 export function enrichDevelopmentWideEvent(record: WideEventRecord, error: unknown): DevelopmentWideEventRecord {
   if (typeof error !== 'object' || error === null)
@@ -13,4 +37,150 @@ export function enrichDevelopmentWideEvent(record: WideEventRecord, error: unkno
   if (typeof input.stack === 'string')
     record['error.stack'] = input.stack
   return record
+}
+
+/** Format one Wide Event for compact development terminal output. */
+export function formatDevelopmentWideEvent(
+  record: DevelopmentWideEventRecord,
+  options: DevelopmentWideEventFormatOptions = {},
+): string {
+  const colors = options.colors ?? supportsColor()
+  const message = typeof record.devMessage === 'string'
+    ? safeTerminalText(record.devMessage)
+    : undefined
+  const messageLines = message?.split('\n')
+  const scope = typeof record.scope === 'string' ? record.scope : undefined
+  const tag = safeTerminalText(record.service ?? scope ?? 'Wide Event')
+  const level = record.level.toUpperCase()
+  const request = record.method !== 'UNKNOWN' && record.path !== undefined
+  const header = [
+    paint(formatTimestamp(record.timestamp), ANSI.dim, colors),
+    paint(level, levelColor(record.level), colors),
+    paint(`[${tag}]`, ANSI.cyan, colors),
+  ]
+
+  if (request) {
+    header.push(`${safeTerminalText(record.method)} ${safeTerminalText(record.path ?? '')}`)
+    header.push(paint(String(record.status), record.status >= 400 ? ANSI.red : ANSI.green, colors))
+    header.push(paint(`in ${formatDuration(record.durationMs)}`, ANSI.dim, colors))
+  }
+  if (messageLines?.[0])
+    header.push(messageLines[0])
+
+  const lines = [header.join(' ')]
+  if (messageLines && messageLines.length > 1)
+    lines.push(...indentMessageLines(messageLines.slice(1)))
+
+  const fields = Object.entries(record)
+    .filter(([key, value]) => value !== undefined && !isHeaderField(key))
+    .filter(([key]) => key !== 'devMessage' && !(key === 'scope' && scope !== undefined))
+    .sort(([left], [right]) => Number(left === 'requestId') - Number(right === 'requestId'))
+
+  for (const [index, [key, value]] of fields.entries()) {
+    if (value === undefined)
+      continue
+    lines.push(...formatField(key, value, index === fields.length - 1, colors))
+  }
+
+  return lines.join('\n')
+}
+
+/** Write one development Wide Event without framework console decoration. */
+export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): void {
+  const output = formatDevelopmentWideEvent(record)
+  const stdout = runtimeProcess()?.stdout
+  if (stdout?.write) {
+    stdout.write(`${output}\n`)
+    return
+  }
+  console.log(output)
+}
+
+function formatField(key: string, value: string | number | boolean | null, last: boolean, colors: boolean): string[] {
+  const branch = last ? '└─' : '├─'
+  const continuation = last ? '  ' : '│ '
+  const valueLines = safeTerminalText(String(value)).split('\n')
+  return [
+    `  ${paint(branch, ANSI.dim, colors)} ${paint(`${safeTerminalText(key)}:`, ANSI.cyan, colors)} ${valueLines[0] ?? ''}`,
+    ...valueLines.slice(1).map(line => `  ${paint(continuation, ANSI.dim, colors)}   ${line}`),
+  ]
+}
+
+function formatTimestamp(timestamp: string): string {
+  return timestamp.length >= 23 ? timestamp.slice(11, 23) : safeTerminalText(timestamp)
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1)
+    return '<1ms'
+  if (durationMs < 1000)
+    return `${Math.round(durationMs)}ms`
+  return `${(durationMs / 1000).toFixed(2)}s`
+}
+
+function indentMessageLines(lines: string[]): string[] {
+  const populated = lines.filter(Boolean)
+  const commonIndent = populated.length === 0
+    ? 0
+    : Math.min(...populated.map(line => line.length - line.trimStart().length))
+  return lines.map(line => `  ${line.slice(commonIndent)}`)
+}
+
+function isHeaderField(field: string): boolean {
+  switch (field) {
+    case 'durationMs':
+    case 'level':
+    case 'method':
+    case 'path':
+    case 'service':
+    case 'status':
+    case 'timestamp':
+      return true
+    default:
+      return false
+  }
+}
+
+function levelColor(level: StandaloneWideEventLevel): string {
+  switch (level) {
+    case 'debug':
+      return ANSI.gray
+    case 'error':
+      return ANSI.red
+    case 'warn':
+      return ANSI.yellow
+    default:
+      return ANSI.cyan
+  }
+}
+
+function paint(value: string, color: string, enabled: boolean): string {
+  return enabled ? `${color}${value}${ANSI.reset}` : value
+}
+
+function safeTerminalText(value: string): string {
+  let output = ''
+  for (const character of value) {
+    const code = character.charCodeAt(0)
+    if (character === '\n' || (code >= 32 && (code < 127 || code > 159)))
+      output += character
+    else
+      output += `\\u${code.toString(16).padStart(4, '0')}`
+  }
+  return output
+}
+
+function supportsColor(): boolean {
+  const process = runtimeProcess()
+  return process !== undefined && !process.env.NO_COLOR && process.stdout?.isTTY !== false
+}
+
+function runtimeProcess(): {
+  env: Record<string, string | undefined>
+  stdout?: { isTTY?: boolean, write?: (output: string) => unknown }
+} | undefined {
+  return Reflect.get(globalThis, 'process') as {
+    env: Record<string, string | undefined>
+    stdout?: { isTTY?: boolean, write?: (output: string) => unknown }
+  } | undefined
 }

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
@@ -1,10 +1,17 @@
-import type { WideEventFields, WideEventLike, WideEventRecord } from './index'
+import type { WideEventFields, WideEventLike, WideEventValue } from './index'
 import { addWideEventFields, emitWideEvent, startWideEvent } from './index'
 
 export type StandaloneWideEventLevel = 'debug' | 'error' | 'info' | 'warn'
 
-export interface StandaloneWideEventRecord extends Omit<WideEventRecord, 'level'> {
+export interface StandaloneWideEventRecord extends Record<string, WideEventValue | undefined> {
+  durationMs: number
   level: StandaloneWideEventLevel
+  method: string
+  requestId: string
+  status: number
+  timestamp: string
+  path?: string
+  service?: string
 }
 
 export interface StandaloneWideEvent extends WideEventLike {

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
@@ -1,12 +1,13 @@
 import type { WideEventFields } from './index'
 import type { StandaloneWideEvent } from './standalone-core'
 import config from '#wide-events/config'
+import { writeDevelopmentWideEvent } from './development'
 import { createStandaloneWideEvent } from './standalone-core'
 
 /** Create one development Wide Event for a background operation. */
 export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
   return createStandaloneWideEvent(initialFields, {
-    ...(config.console ? { output: (record: unknown) => console.log('Wide Event', record) } : {}),
+    ...(config.console ? { output: writeDevelopmentWideEvent } : {}),
     service: config.service,
   })
 }

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-drain.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-drain.ts
@@ -3,6 +3,7 @@ import type { WideEventFields } from './index'
 import type { DrainedStandaloneWideEvent } from './standalone-core'
 import { useNitroApp } from 'nitropack/runtime'
 import config from '#wide-events/config'
+import { writeDevelopmentWideEvent } from './development'
 import { drainWideEvent } from './drain'
 import { createDrainedStandaloneWideEvent } from './standalone-core'
 
@@ -14,7 +15,7 @@ export function createWideEvent(initialFields?: WideEventFields): DrainedStandal
     output: async (record) => {
       if (runtimeConfig.console) {
         if (import.meta.dev)
-          console.log('Wide Event', record)
+          writeDevelopmentWideEvent(record)
         else
           console.log(JSON.stringify(record))
       }

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { enrichDevelopmentWideEvent } from '../src/runtime/server/development'
+import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent } from '../src/runtime/server/development'
 
 describe('enrichDevelopmentWideEvent', () => {
   it('adds error details only to a development record', () => {
@@ -19,5 +19,44 @@ describe('enrichDevelopmentWideEvent', () => {
       'error.message': 'Database unavailable',
       'error.stack': expect.stringContaining('Database unavailable'),
     }))
+  })
+})
+
+describe('formatDevelopmentWideEvent', () => {
+  it('renders developer messages as compact terminal blocks', () => {
+    expect(formatDevelopmentWideEvent({
+      scope: 'ssr',
+      devMessage: 'server fetch completed\n  fetch   : GET /api/_auth/session\n  duration: 16ms\n  request : GET /',
+      timestamp: '2026-08-14T08:28:15.225Z',
+      level: 'debug',
+      method: 'UNKNOWN',
+      status: 200,
+      durationMs: 0.155,
+      requestId: 'req_1',
+    }, { colors: false })).toBe([
+      '08:28:15.225 DEBUG [ssr] server fetch completed',
+      '  fetch   : GET /api/_auth/session',
+      '  duration: 16ms',
+      '  request : GET /',
+      '  └─ requestId: req_1',
+    ].join('\n'))
+  })
+
+  it('renders request metadata and Fields without object inspection noise', () => {
+    expect(formatDevelopmentWideEvent({
+      'timestamp': '2026-08-14T08:28:15.225Z',
+      'level': 'warn',
+      'service': 'shop',
+      'method': 'GET',
+      'path': '/api/cart',
+      'status': 429,
+      'durationMs': 16.4,
+      'requestId': 'req_2',
+      'cart.itemCount': 2,
+    }, { colors: false })).toBe([
+      '08:28:15.225 WARN [shop] GET /api/cart 429 in 16ms',
+      '  ├─ cart.itemCount: 2',
+      '  └─ requestId: req_2',
+    ].join('\n'))
   })
 })

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -23,6 +23,42 @@ describe('enrichDevelopmentWideEvent', () => {
 })
 
 describe('formatDevelopmentWideEvent', () => {
+  it('keeps redirected output free of terminal color codes', () => {
+    const isTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    const noColor = process.env.NO_COLOR
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: undefined })
+    delete process.env.NO_COLOR
+
+    const output = (() => {
+      try {
+        return formatDevelopmentWideEvent({
+          timestamp: '2026-08-14T08:28:15.225Z',
+          level: 'info',
+          method: 'GET',
+          path: '/api/cart',
+          status: 200,
+          durationMs: 1,
+          requestId: 'req_1',
+        })
+      }
+      finally {
+        if (isTTY)
+          Object.defineProperty(process.stdout, 'isTTY', isTTY)
+        else
+          delete (process.stdout as { isTTY?: boolean }).isTTY
+        if (noColor === undefined)
+          delete process.env.NO_COLOR
+        else
+          process.env.NO_COLOR = noColor
+      }
+    })()
+
+    expect(output).toBe([
+      '08:28:15.225 INFO [Wide Event] GET /api/cart 200 in 1ms',
+      '  └─ requestId: req_1',
+    ].join('\n'))
+  })
+
   it('renders developer messages as compact terminal blocks', () => {
     expect(formatDevelopmentWideEvent({
       scope: 'ssr',
@@ -57,6 +93,21 @@ describe('formatDevelopmentWideEvent', () => {
       '08:28:15.225 WARN [shop] GET /api/cart 429 in 16ms',
       '  ├─ cart.itemCount: 2',
       '  └─ requestId: req_2',
+    ].join('\n'))
+  })
+
+  it('keeps request metadata for unsupported HTTP methods', () => {
+    expect(formatDevelopmentWideEvent({
+      timestamp: '2026-08-14T08:28:15.225Z',
+      level: 'info',
+      method: 'UNKNOWN',
+      path: '/webdav/files',
+      status: 405,
+      durationMs: 2,
+      requestId: 'req_3',
+    }, { colors: false })).toBe([
+      '08:28:15.225 INFO [Wide Event] UNKNOWN /webdav/files 405 in 2ms',
+      '  └─ requestId: req_3',
     ].join('\n'))
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Development Wide Events currently hit Node's object inspector, which turns a single fetch summary into a noisy `Wide Event { ... }` block. Print compact, colored terminal blocks instead, with request metadata in the header and configured Fields in a tree.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).