### PR TITLE
chore(release): nuxt-cf-jobs 0.0.6, nuxt-cloudflare 0.0.15, nuxt-wide-events 0.0.3

### DIFF
--- a/packages/nuxt-cf-jobs/package.json
+++ b/packages/nuxt-cf-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cf-jobs",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Experimental Nuxt module for typed Cloudflare queue jobs.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-wide-events",
   "type": "module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Minimal Nuxt Wide Events with build-time field enforcement.",
   "author": {
     "name": "Harlan Wilton",


### PR DESCRIPTION
### Description

Version bumps for the invocation-attribution work in #48. Publishing is tag-driven, so the bump has to be on `main` before the tags are pushed.

Three packages move together because the feature spans them: `nuxt-cf-jobs` writes the job marker, `nuxt-wide-events` gained the field-contribution hook, and `nuxt-cloudflare` declares and populates its `cf.*` and `d1.*` fields through that hook.

### Additional context

Tag order matters on publish. `nuxt-cf-jobs` depends on `@harlan-zw/nuxt-cloudflare` as `workspace:*`, which pack resolves to the exact version — so `nuxt-cloudflare-v0.0.15` has to reach npm before `nuxt-cf-jobs-v0.0.6`, or the published cf-jobs pins a version nobody can install. `nuxt-wide-events` is independent of both.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).