### PR TITLE
fix(cloudflare): expose the D1 request stats it already collects (0.0.16)

### DIFF
--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/d1.ts
+++ b/packages/nuxt-cloudflare/src/d1.ts
@@ -1,6 +1,12 @@
 import type { D1RequestStats } from './d1-stats'
 import { recordD1Meta, recordD1Recovery, useD1Stats } from './d1-stats'
 
+// Re-exported from the `./d1` entry rather than given an export path of their
+// own: the counters are only meaningful alongside the session helpers that fill
+// them, and a caller reaching for `readD1Stats` already imports from here.
+export type { D1RequestStats } from './d1-stats'
+export { createD1Stats, readD1Stats, recordD1Meta, recordD1Recovery, REQUEST_D1_STATS, useD1Stats } from './d1-stats'
+
 export type D1WriteSafety
   = | { _tag: 'lock-only' }
     | { _tag: 'replay-safe' }

--- a/packages/nuxt-cloudflare/tests/d1.test.ts
+++ b/packages/nuxt-cloudflare/tests/d1.test.ts
@@ -363,3 +363,33 @@ describe('retryIdempotentD1Write', () => {
     expect(run).toHaveBeenCalledTimes(2)
   })
 })
+
+describe('request-scoped D1 stats', () => {
+  it('is reachable from the package entry, not just from inside the module', async () => {
+    // 0.0.15 collected these counters and exposed no way to read them, which
+    // left every consumer with no choice but to keep its own copy.
+    const entry = await import('../src/d1')
+    expect(typeof entry.readD1Stats).toBe('function')
+    expect(typeof entry.useD1Stats).toBe('function')
+    expect(typeof entry.createD1Stats).toBe('function')
+  })
+
+  it('counts queries and primary hops from what D1 reports', async () => {
+    const { createD1Stats, recordD1Meta, recordD1Recovery } = await import('../src/d1')
+    const stats = createD1Stats()
+
+    recordD1Meta(stats, { meta: { served_by_primary: true, served_by_region: 'OC', duration: 1.5 } })
+    recordD1Meta(stats, { meta: { served_by_primary: false, served_by_region: 'OC', duration: 0.5 } })
+    // Local D1 and `wrangler dev` send no `meta` at all; still a query.
+    recordD1Meta(stats, {})
+    recordD1Recovery(stats, { _tag: 'retrying' })
+    recordD1Recovery(stats, { _tag: 'stopped' })
+
+    expect(stats.queries).toBe(3)
+    expect(stats.primaryQueries).toBe(1)
+    expect(stats.region).toBe('OC')
+    expect(stats.durationMs).toBe(2)
+    expect(stats.recoveries).toBe(2)
+    expect(stats.unrecovered).toBe(1)
+  })
+})


### PR DESCRIPTION
### Description

0.0.15 added request-scoped D1 counters and folded them into the Wide Event, but `d1-stats.ts` was never re-exported and has no export path of its own. `readD1Stats`, `useD1Stats` and `D1RequestStats` were unreachable to every consumer — the internal Wide Event plugin worked, and nothing else could read a counter.

That defeats half the point. A consumer keeping its own copy of these counters had no way to drop it, which is exactly the duplication this was supposed to remove.

Re-exported from the `./d1` entry rather than a new export path: the counters are only meaningful next to the session helpers that fill them, and anyone reaching for `readD1Stats` already imports from there.

The test imports through the entry rather than the source file, so what regresses if this comes undone is the reachability itself, not just the functions.

### Additional context

My mistake, caught while checking what 0.0.15 meant for other consumers rather than by anything failing — the package built, typechecked, linted and tested green without the export, because nothing in the repo consumed it from outside.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).