### PR TITLE
chore(ci): keep four NuxtSEO runners warm

### DIFF
--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -15,7 +15,7 @@
 # unhead.unjs.io, request-indexing, harlanzw.com, and unlighthouse.dev stay on
 # GitHub-hosted runners.
 
-harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|5|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|4|5|6|12g|14g
 harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|32g|40g
 harlan-zw/gscdump.com|harlan-desktop-ci|1|5|6|12g|14g
 harlan-zw/mdream.dev|harlan-desktop-ci|1|3|6|12g|14g


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

NuxtSEO's two warm CI runners serialise its wider matrices whenever other pools hold the burst threshold. Keep four runners registered so Code, Lint, docs, and Nuxt DX checks can start together.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).