### PR TITLE
fix(cloudflare): call addWideEventFields with an object literal (0.0.17)

### DIFF
--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",
@@ -109,6 +109,7 @@
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
     "@cloudflare/workers-types": "catalog:",
+    "@harlan-zw/nuxt-wide-events": "workspace:*",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",
     "@types/node": "catalog:",

--- a/packages/nuxt-cloudflare/src/runtime/server/plugins/wide-events.ts
+++ b/packages/nuxt-cloudflare/src/runtime/server/plugins/wide-events.ts
@@ -21,9 +21,19 @@ import { readD1Stats } from '../../../d1-stats'
  * quietly makes twenty serial primary round trips looks identical to a fast one
  * in every other log line; these counters are what separate them.
  *
- * Registered by the module only when `@harlan-zw/nuxt-wide-events` is present,
- * and the fields are declared through `addWideEventFields` at build time, so
- * the consuming application never hand-lists them and cannot drift from them.
+ * ── The single object literal is load-bearing ──
+ *
+ * `@harlan-zw/nuxt-wide-events` parses every server file at build time and
+ * REJECTS an `addWideEventFields` call whose argument is not an object literal:
+ * no variables, no spreads, no computed keys. That is the guarantee the whole
+ * module rests on — a reviewer can read the allowlist and know nothing else can
+ * reach an event.
+ *
+ * So this cannot build its payload conditionally. Every key is present on every
+ * call, `null` where the value is unavailable, and the whole thing is one
+ * literal. An earlier version assembled a `Record` and passed the variable; it
+ * failed the CONSUMING application's build, which is the worst place for a
+ * module's mistake to surface.
  */
 export default (nitroApp: NitroApp): void => {
   nitroApp.hooks.hook('beforeResponse', (event: H3Event) => {
@@ -37,36 +47,32 @@ interface RequestCfProperties {
   httpProtocol?: unknown
 }
 
-export function recordCloudflareWideEventFields(event: H3Event): void {
-  const fields: Record<string, string | number | null> = {}
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null
+}
 
+export function recordCloudflareWideEventFields(event: H3Event): void {
+  // Only ever these three from `request.cf`. It also carries city, region,
+  // postal code and ASN — location data about a person, which has no place in a
+  // record written for every request.
   const cf = (event.context as { cloudflare?: { request?: { cf?: RequestCfProperties } } })
     .cloudflare
     ?.request
     ?.cf
-  if (cf) {
-    // Only ever these three. `request.cf` also carries city, region, postal code
-    // and ASN — location data about a person, which has no place in a record
-    // written for every request. The allowlist upstream would reject them
-    // anyway; naming the omission here so nobody adds them by reflex.
-    if (typeof cf.colo === 'string')
-      fields['cf.colo'] = cf.colo
-    if (typeof cf.country === 'string')
-      fields['cf.country'] = cf.country
-    if (typeof cf.httpProtocol === 'string')
-      fields['cf.httpProtocol'] = cf.httpProtocol
-  }
-
   const d1 = readD1Stats(event.context as unknown as Record<PropertyKey, unknown>)
-  if (d1) {
-    fields['d1.queries'] = d1.queries
-    fields['d1.primaryQueries'] = d1.primaryQueries
-    fields['d1.recoveries'] = d1.recoveries
-    fields['d1.unrecovered'] = d1.unrecovered
-    fields['d1.durationMs'] = Math.round(d1.durationMs)
-    fields['d1.region'] = d1.region
-  }
 
-  if (Object.keys(fields).length)
-    addWideEventFields(event, fields)
+  if (!cf && !d1)
+    return
+
+  addWideEventFields(event, {
+    'cf.colo': stringOrNull(cf?.colo),
+    'cf.country': stringOrNull(cf?.country),
+    'cf.httpProtocol': stringOrNull(cf?.httpProtocol),
+    'd1.queries': d1 ? d1.queries : null,
+    'd1.primaryQueries': d1 ? d1.primaryQueries : null,
+    'd1.recoveries': d1 ? d1.recoveries : null,
+    'd1.unrecovered': d1 ? d1.unrecovered : null,
+    'd1.durationMs': d1 ? Math.round(d1.durationMs) : null,
+    'd1.region': d1 ? d1.region : null,
+  })
 }

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -172,7 +172,9 @@ describe('setupCloudflareModule', () => {
     setupCloudflareModule({ bindingTypes: false, enabled: true }, nuxt)
 
     const plugins = (nuxt.options.nitro as { plugins?: string[] }).plugins ?? []
-    expect(plugins.some(plugin => plugin.includes('wide-events'))).toBe(false)
+    // Match the file, not a substring of the absolute path — a checkout
+    // directory containing "wide-events" made this pass for the wrong reason.
+    expect(plugins.some(plugin => /plugins[/\\]wide-events\.[jt]s$/.test(plugin))).toBe(false)
   })
 
   it('does not register the production Wrangler audit during development', () => {

--- a/packages/nuxt-cloudflare/tests/wide-events-source.test.ts
+++ b/packages/nuxt-cloudflare/tests/wide-events-source.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { validateWideEventSource } from '@harlan-zw/nuxt-wide-events/build'
+import { describe, expect, it } from 'vitest'
+
+// `@harlan-zw/nuxt-wide-events` parses server sources at build time and rejects
+// an `addWideEventFields` call that is not a plain object literal. That check
+// runs in the CONSUMING application's build, so a violation here does not fail
+// this package — it fails somebody else's deploy, which is exactly what 0.0.15
+// and 0.0.16 did.
+//
+// Running that same validator over our own plugin is the only way this repo can
+// see what a consumer sees.
+const PLUGIN = fileURLToPath(new URL('../src/runtime/server/plugins/wide-events.ts', import.meta.url))
+
+const DECLARED_FIELDS = new Set([
+  'cf.colo',
+  'cf.country',
+  'cf.httpProtocol',
+  'd1.durationMs',
+  'd1.primaryQueries',
+  'd1.queries',
+  'd1.recoveries',
+  'd1.region',
+  'd1.unrecovered',
+])
+
+describe('wide events plugin source', () => {
+  it('passes the validator that runs in a consuming application build', () => {
+    const source = readFileSync(PLUGIN, 'utf8')
+
+    expect(validateWideEventSource(source, PLUGIN, DECLARED_FIELDS)).toEqual({ _tag: 'Ok' })
+  })
+
+  it('rejects the dynamic-object shape that broke a consumer', () => {
+    // Pinning the failure mode, not just the fix: assembling a Record and
+    // passing the variable is the natural way to write this and the one the
+    // validator forbids.
+    const dynamic = `
+      import { addWideEventFields } from '#imports'
+      export function record(event) {
+        const fields = {}
+        fields['cf.colo'] = 'SYD'
+        addWideEventFields(event, fields)
+      }
+    `
+    expect(validateWideEventSource(dynamic, 'dynamic.ts', DECLARED_FIELDS)._tag).toBe('Err')
+  })
+
+  it('declares every field the plugin writes', () => {
+    // A field the plugin writes but the module never declares fails the
+    // consumer's build the same way; keep the two lists in step.
+    const source = readFileSync(PLUGIN, 'utf8')
+    const written = [...source.matchAll(/'((?:cf|d1)\.[A-Za-z]+)':/g)].map(m => m[1]!)
+
+    expect(written.length).toBeGreaterThan(0)
+    for (const field of written)
+      expect(DECLARED_FIELDS).toContain(field)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260811.1
+      '@harlan-zw/nuxt-wide-events':
+        specifier: workspace:*
+        version: link:../nuxt-wide-events
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))


### PR DESCRIPTION
### Description

**This unblocks production deploys on nuxtseo.com and prevents the same break on gscdump.com.**

`@harlan-zw/nuxt-wide-events` parses every server file at build time and rejects an `addWideEventFields` call whose argument is not a plain object literal — no variables, no spreads, no computed keys. That static guarantee is the entire reason its allowlist can be trusted.

The plugin I added in 0.0.15 assembled a `Record` conditionally and passed the variable:

```
ERROR [nuxt-wide-events] .../nuxt-cloudflare/dist/runtime/server/plugins/wide-events.js:29
addWideEventFields() requires an object literal.
```

That check runs in the **consuming** application's build. nuxtseo.com's `build (pro)` fails on it, which gates its whole deploy matrix; and gscdump.com already catalogs 0.0.15, so its next build breaks identically without anyone there having touched a thing.

Every key is now present on every call, `null` where unavailable, one literal.

### Additional context

The test runs wide-events' own `validateWideEventSource` over this plugin's source. That is the only way this repo can see what a consumer sees — 0.0.15 and 0.0.16 both built, typechecked, linted and tested green while shipping this. It needs `@harlan-zw/nuxt-wide-events` as a workspace devDependency, which is test-only and does not ship. A second case pins the dynamic-object shape itself, so the failure mode is covered rather than just the fix.

Three defects in three releases now, all the same shape: 0.0.15 collected D1 stats nothing could read, 0.0.6 exposed an option nothing could reach, and this one wrote code no consumer could compile. In-repo gates cannot see any of it, because this repo has no consumer standing where an application stands. Worth deciding whether a smoke consumer belongs in CI, because I do not think I would have caught the next one either.

Also hardens an assertion I wrote badly: it matched `wide-events` anywhere in an absolute path, so a checkout directory containing that string made it pass for the wrong reason. It only surfaced because this branch's worktree is named after it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).