### PR TITLE
chore(comark-content): bring the package under eslint

### DIFF
--- a/packages/comark-content/bench/run.mjs
+++ b/packages/comark-content/bench/run.mjs
@@ -1,6 +1,7 @@
+import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, relative, resolve } from 'node:path'
 import { performance } from 'node:perf_hooks'
@@ -32,7 +33,7 @@ const CONTENT_MARKERS = {
   ],
 }
 
-const parseArgs = (args) => {
+function parseArgs(args) {
   const variantIndex = args.indexOf('--variant')
   const variant = variantIndex === -1 ? 'candidate' : args[variantIndex + 1]
   if (variant !== 'baseline' && variant !== 'candidate')
@@ -40,35 +41,43 @@ const parseArgs = (args) => {
   return { variant }
 }
 
+// ANSI escape sequences are defined by the ESC control character and these exact byte ranges.
+// eslint-disable-next-line no-control-regex, regexp/no-obscure-range
 const stripAnsi = value => value.replaceAll(/\u001B\[[0-?]*[ -/]*[@-~]/g, '')
 
-const run = (command, args, options = {}) => new Promise((resolveRun, reject) => {
-  const startedAt = performance.now()
-  const child = spawn(command, args, {
-    cwd: options.cwd,
-    env: options.env,
-    stdio: ['ignore', 'pipe', 'pipe'],
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, reject) => {
+    const startedAt = performance.now()
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', (chunk) => {
+      output += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      output += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      const durationMs = performance.now() - startedAt
+      if (code === 0) {
+        resolveRun({ durationMs, output: stripAnsi(output) })
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}.\n${stripAnsi(output).slice(-8000)}`))
+    })
   })
-  let output = ''
-  child.stdout.on('data', (chunk) => { output += chunk })
-  child.stderr.on('data', (chunk) => { output += chunk })
-  child.on('error', reject)
-  child.on('close', (code) => {
-    const durationMs = performance.now() - startedAt
-    if (code === 0) {
-      resolveRun({ durationMs, output: stripAnsi(output) })
-      return
-    }
-    reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}.\n${stripAnsi(output).slice(-8000)}`))
-  })
-})
+}
 
-const commandOutput = async (command, args, cwd) => {
+async function commandOutput(command, args, cwd) {
   const result = await run(command, args, { cwd, env: process.env })
   return result.output.trim()
 }
 
-const assertEnvironment = async () => {
+async function assertEnvironment() {
   if (process.version !== NODE_VERSION)
     throw new Error(`Expected Node ${NODE_VERSION}, received ${process.version}.`)
   const pnpmVersion = await commandOutput('pnpm', ['--version'], process.cwd())
@@ -76,7 +85,7 @@ const assertEnvironment = async () => {
     throw new Error(`Expected pnpm ${PNPM_VERSION}, received ${pnpmVersion}.`)
 }
 
-const shouldCopy = (source) => {
+function shouldCopy(source) {
   const name = basename(source)
   if (['.git', '.nuxt', '.output', '.data', '.wrangler', '.cache', 'coverage', 'dist', 'node_modules'].includes(name))
     return false
@@ -85,7 +94,7 @@ const shouldCopy = (source) => {
   return true
 }
 
-const resetBuildState = async (siteRoot, sampleRoot, fontCacheRoot) => {
+async function resetBuildState(siteRoot, sampleRoot, fontCacheRoot) {
   await Promise.all([
     '.nuxt',
     '.output',
@@ -101,16 +110,18 @@ const resetBuildState = async (siteRoot, sampleRoot, fontCacheRoot) => {
   await cp(fontCacheRoot, join(siteRoot, FONT_CACHE_PATH), { recursive: true })
 }
 
-const benchmarkEnvironment = (sampleRoot) => ({
-  ...process.env,
-  CI: '1',
-  NUXT_TELEMETRY_DISABLED: '1',
-  XDG_CACHE_HOME: join(sampleRoot, 'cache'),
-  TMPDIR: join(sampleRoot, 'tmp'),
-  SENTRY_AUTH_TOKEN: '',
-})
+function benchmarkEnvironment(sampleRoot) {
+  return {
+    ...process.env,
+    CI: '1',
+    NUXT_TELEMETRY_DISABLED: '1',
+    XDG_CACHE_HOME: join(sampleRoot, 'cache'),
+    TMPDIR: join(sampleRoot, 'tmp'),
+    SENTRY_AUTH_TOKEN: '',
+  }
+}
 
-const parseContentResult = (output, phase) => {
+function parseContentResult(output, phase) {
   const matches = [...output.matchAll(/Processed (\d+) collections and (\d+) files in ([\d.]+)ms \((\d+) cached, (\d+) parsed\)/g)]
   const match = matches.at(-1)
   if (!match)
@@ -125,7 +136,7 @@ const parseContentResult = (output, phase) => {
   }
 }
 
-const walkFiles = async (root) => {
+async function walkFiles(root) {
   const files = []
   const visit = async (directory) => {
     const entries = await readdir(directory, { withFileTypes: true }).catch(error => error.code === 'ENOENT' ? [] : Promise.reject(error))
@@ -141,13 +152,13 @@ const walkFiles = async (root) => {
   return files
 }
 
-const directoryBytes = async (root) => {
+async function directoryBytes(root) {
   const files = await walkFiles(root)
   const sizes = await Promise.all(files.map(async path => (await stat(path)).size))
   return sizes.reduce((sum, size) => sum + size, 0)
 }
 
-const candidateFingerprint = async () => {
+async function candidateFingerprint() {
   const files = [join(PACKAGE_ROOT, 'package.json'), ...await walkFiles(join(PACKAGE_ROOT, 'src'))].sort()
   const hash = createHash('sha256')
   for (const path of files)
@@ -155,7 +166,7 @@ const candidateFingerprint = async () => {
   return hash.digest('hex')
 }
 
-const clientJavaScript = async (siteRoot, variant) => {
+async function clientJavaScript(siteRoot, variant) {
   const root = join(siteRoot, '.output/public')
   const files = (await walkFiles(root)).filter(path => path.endsWith('.js'))
   const markers = CONTENT_MARKERS[variant]
@@ -184,7 +195,7 @@ const clientJavaScript = async (siteRoot, variant) => {
   return { totalBytes, totalGzipBytes, contentBytes, contentGzipBytes, contentFiles }
 }
 
-const measureSsr = async (siteRoot, env, sample) => {
+async function measureSsr(siteRoot, env, sample) {
   const port = 19100 + sample
   const output = []
   const child = spawn('pnpm', [
@@ -234,7 +245,10 @@ const measureSsr = async (siteRoot, env, sample) => {
         process.kill(-child.pid, 'SIGTERM')
       }
       catch (error) {
+        // Throwing here discards any error raised by the try block, and skips the
+        // close wait below. Left as is because changing it changes bench behaviour.
         if (error.code !== 'ESRCH')
+          // eslint-disable-next-line no-unsafe-finally
           throw error
       }
     }
@@ -242,7 +256,7 @@ const measureSsr = async (siteRoot, env, sample) => {
   }
 }
 
-const median = (values) => {
+function median(values) {
   const sorted = [...values].sort((left, right) => left - right)
   const middle = Math.floor(sorted.length / 2)
   return sorted.length % 2 === 0
@@ -269,7 +283,7 @@ const getPath = (value, path) => path.reduce((current, key) => current[key], val
 
 const medians = samples => Object.fromEntries(metricPaths.map(path => [path.join('.'), median(samples.map(sample => getPath(sample, path)))]))
 
-const main = async () => {
+async function main() {
   const { variant } = parseArgs(process.argv.slice(2))
   await assertEnvironment()
   await mkdir(RESULTS_ROOT, { recursive: true })
@@ -385,4 +399,7 @@ const main = async () => {
   }
 }
 
-await main()
+main().catch((error) => {
+  process.stderr.write(`${error.stack ?? error}\n`)
+  process.exitCode = 1
+})

--- a/packages/comark-content/bench/site-harlanzw/run.mjs
+++ b/packages/comark-content/bench/site-harlanzw/run.mjs
@@ -1,8 +1,9 @@
+import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, dirname, join, relative, resolve } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 
@@ -20,7 +21,7 @@ const RESULTS_ROOT = resolve(import.meta.dirname, 'results')
 const BROWSER_SAMPLE_PATH = resolve(import.meta.dirname, 'browser-sample.js')
 const RESULT_MARKER = '__COMARK_SITE_BENCHMARK__'
 
-const parseArgs = (args) => {
+function parseArgs(args) {
   const variantIndex = args.indexOf('--variant')
   const variant = variantIndex === -1 ? 'both' : args[variantIndex + 1]
   if (!['baseline', 'candidate', 'both'].includes(variant))
@@ -32,35 +33,43 @@ const parseArgs = (args) => {
   return { samples, variants: variant === 'both' ? ['baseline', 'candidate'] : [variant] }
 }
 
+// ANSI escape sequences are defined by the ESC control character and these exact byte ranges.
+// eslint-disable-next-line no-control-regex, regexp/no-obscure-range
 const stripAnsi = value => value.replaceAll(/\u001B\[[0-?]*[ -/]*[@-~]/g, '')
 
-const run = (command, args, options = {}) => new Promise((resolveRun, reject) => {
-  const startedAt = performance.now()
-  const child = spawn(command, args, {
-    cwd: options.cwd,
-    detached: options.detached,
-    env: options.env,
-    stdio: options.input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, reject) => {
+    const startedAt = performance.now()
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      detached: options.detached,
+      env: options.env,
+      stdio: options.input === undefined ? ['ignore', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', (chunk) => {
+      output += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      output += chunk
+    })
+    if (options.input !== undefined)
+      child.stdin.end(options.input)
+    child.on('error', reject)
+    child.on('close', (code) => {
+      const result = { code, durationMs: performance.now() - startedAt, output: stripAnsi(output) }
+      if (code === 0 || options.allowFailure) {
+        resolveRun(result)
+        return
+      }
+      reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}.\n${result.output.slice(-30000)}`))
+    })
   })
-  let output = ''
-  child.stdout.on('data', (chunk) => { output += chunk })
-  child.stderr.on('data', (chunk) => { output += chunk })
-  if (options.input !== undefined)
-    child.stdin.end(options.input)
-  child.on('error', reject)
-  child.on('close', (code) => {
-    const result = { code, durationMs: performance.now() - startedAt, output: stripAnsi(output) }
-    if (code === 0 || options.allowFailure) {
-      resolveRun(result)
-      return
-    }
-    reject(new Error(`${command} ${args.join(' ')} failed with exit code ${code}.\n${result.output.slice(-30000)}`))
-  })
-})
+}
 
 const commandOutput = async (command, args, cwd) => (await run(command, args, { cwd, env: process.env })).output.trim()
 
-const assertEnvironment = async () => {
+async function assertEnvironment() {
   if (process.version !== NODE_VERSION)
     throw new Error(`Expected Node ${NODE_VERSION}, received ${process.version}.`)
   const pnpmVersion = await commandOutput('pnpm', ['--version'], process.cwd())
@@ -69,7 +78,7 @@ const assertEnvironment = async () => {
   await commandOutput('dev-browser', ['--help'], process.cwd())
 }
 
-const extractRevision = async (revision, destination) => {
+async function extractRevision(revision, destination) {
   await mkdir(destination, { recursive: true })
   await new Promise((resolveExtract, reject) => {
     const archive = spawn('git', ['archive', '--format=tar', revision], { cwd: SITE_REPOSITORY, stdio: ['ignore', 'pipe', 'pipe'] })
@@ -80,11 +89,11 @@ const extractRevision = async (revision, destination) => {
     archive.stdout.pipe(extract.stdin)
     archive.on('error', reject)
     extract.on('error', reject)
-    extract.on('close', (code) => code === 0 ? resolveExtract() : reject(new Error(`Could not extract ${revision}.\n${errors}`)))
+    extract.on('close', code => code === 0 ? resolveExtract() : reject(new Error(`Could not extract ${revision}.\n${errors}`)))
   })
 }
 
-const walkFiles = async (root) => {
+async function walkFiles(root) {
   const files = []
   const visit = async (directory) => {
     const entries = await readdir(directory, { withFileTypes: true }).catch(error => error.code === 'ENOENT' ? [] : Promise.reject(error))
@@ -102,7 +111,7 @@ const walkFiles = async (root) => {
 
 const directoryBytes = async root => (await Promise.all((await walkFiles(root)).map(async path => (await stat(path)).size))).reduce((sum, size) => sum + size, 0)
 
-const packageFingerprint = async () => {
+async function packageFingerprint() {
   const paths = [join(PACKAGE_ROOT, 'package.json'), ...await walkFiles(join(PACKAGE_ROOT, 'src'))].sort()
   const hash = createHash('sha256')
   for (const path of paths)
@@ -110,7 +119,7 @@ const packageFingerprint = async () => {
   return hash.digest('hex')
 }
 
-const prepareCandidate = async (siteRoot, temporaryRoot) => {
+async function prepareCandidate(siteRoot, temporaryRoot) {
   const packed = await run('pnpm', ['pack', '--pack-destination', temporaryRoot], { cwd: PACKAGE_ROOT, env: process.env })
   const tarball = (await readdir(temporaryRoot)).find(file => file.endsWith('.tgz'))
   if (!tarball)
@@ -123,13 +132,13 @@ const prepareCandidate = async (siteRoot, temporaryRoot) => {
   await writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`)
   const configPath = join(siteRoot, 'nuxt.config.ts')
   const config = await readFile(configPath, 'utf8')
-  if (!config.includes("'@harlan-zw/comark-content'"))
+  if (!config.includes('\'@harlan-zw/comark-content\''))
     throw new Error('Candidate revision does not use comark-content.')
   if (!config.includes('content: {'))
-    await writeFile(configPath, config.replace("\n  css: ['~/assets/css/main.css'],", "\n  content: { highlight: true },\n\n  css: ['~/assets/css/main.css'],"))
+    await writeFile(configPath, config.replace('\n  css: [\'~/assets/css/main.css\'],', '\n  content: { highlight: true },\n\n  css: [\'~/assets/css/main.css\'],'))
 }
 
-const prepareBaseline = async (siteRoot) => {
+async function prepareBaseline(siteRoot) {
   const packagePath = join(siteRoot, 'package.json')
   const packageJson = JSON.parse(await readFile(packagePath, 'utf8'))
   delete packageJson.devDependencies['@harlan-zw/comark-content']
@@ -141,14 +150,14 @@ const prepareBaseline = async (siteRoot) => {
 
   const workspacePath = join(siteRoot, 'pnpm-workspace.yaml')
   const workspace = await readFile(workspacePath, 'utf8')
-  await writeFile(workspacePath, workspace.replace("allowBuilds:\n", "allowBuilds:\n  better-sqlite3: true\n"))
+  await writeFile(workspacePath, workspace.replace('allowBuilds:\n', 'allowBuilds:\n  better-sqlite3: true\n'))
 
   const configPath = join(siteRoot, 'nuxt.config.ts')
   const config = (await readFile(configPath, 'utf8'))
-    .replace("'@harlan-zw/comark-content',", "'@nuxt/content',")
+    .replace('\'@harlan-zw/comark-content\',', '\'@nuxt/content\',')
     .replace('failOnError: true', 'failOnError: false')
     .replace(
-      "  content: {\n    highlight: true,\n  },",
+      '  content: {\n    highlight: true,\n  },',
       `  content: {
     database: {
       type: 'd1',
@@ -178,19 +187,19 @@ const prepareBaseline = async (siteRoot) => {
   await writeFile(configPath, config)
 
   const contentConfigPath = join(siteRoot, 'content.config.ts')
-  await writeFile(contentConfigPath, (await readFile(contentConfigPath, 'utf8')).replace("'@harlan-zw/comark-content'", "'@nuxt/content'"))
+  await writeFile(contentConfigPath, (await readFile(contentConfigPath, 'utf8')).replace('\'@harlan-zw/comark-content\'', '\'@nuxt/content\''))
 
   const contentUtilityPath = join(siteRoot, 'app/utils/content.ts')
   await writeFile(contentUtilityPath, (await readFile(contentUtilityPath, 'utf8'))
-    .replace("'@harlan-zw/comark-content'", "'@nuxt/content'")
+    .replace('\'@harlan-zw/comark-content\'', '\'@nuxt/content\'')
     .replace('body.nodes.flatMap', 'body.value.flatMap'))
 
   const rssPath = join(siteRoot, 'server/utils/rss.ts')
-  await writeFile(rssPath, (await readFile(rssPath, 'utf8')).replace("'@harlan-zw/comark-content/server'", "'@nuxt/content/server'"))
+  await writeFile(rssPath, (await readFile(rssPath, 'utf8')).replace('\'@harlan-zw/comark-content/server\'', '\'@nuxt/content/server\''))
 
   const typesPath = join(siteRoot, 'shared/types.ts')
   await writeFile(typesPath, (await readFile(typesPath, 'utf8'))
-    .replace("import type { PageCollectionItemBase } from '@harlan-zw/comark-content'", "import type { PagesCollectionItem } from '@nuxt/content'")
+    .replace('import type { PageCollectionItemBase } from \'@harlan-zw/comark-content\'', 'import type { PagesCollectionItem } from \'@nuxt/content\'')
     .replace('export interface SitePage extends PageCollectionItemBase', 'export interface SitePage extends PagesCollectionItem'))
 
   const historicalContentPage = await commandOutput('git', ['show', '403cdca^:app/utils/content-page.ts'], SITE_REPOSITORY)
@@ -202,7 +211,7 @@ const prepareBaseline = async (siteRoot) => {
     .replaceAll('ContentProse', 'Prose'))
 }
 
-const startWorker = async (siteRoot, port, env) => {
+async function startWorker(siteRoot, port, env) {
   const output = []
   const child = spawn('pnpm', [
     'exec',
@@ -232,7 +241,7 @@ const startWorker = async (siteRoot, port, env) => {
   throw new Error(`Worker did not start.\n${stripAnsi(Buffer.concat(output).toString()).slice(-4000)}`)
 }
 
-const stopWorker = async (worker) => {
+async function stopWorker(worker) {
   if (!worker.child.pid)
     return
   try {
@@ -248,7 +257,7 @@ const stopWorker = async (worker) => {
   ])
 }
 
-const startChrome = async (profileRoot, port) => {
+async function startChrome(profileRoot, port) {
   const child = spawn('/usr/bin/google-chrome', [
     '--headless=new',
     '--disable-background-networking',
@@ -280,7 +289,7 @@ const startChrome = async (profileRoot, port) => {
   throw new Error('Benchmark Chrome did not start.')
 }
 
-const stopChrome = async (chrome) => {
+async function stopChrome(chrome) {
   if (!chrome.child.pid)
     return
   try {
@@ -296,7 +305,7 @@ const stopChrome = async (chrome) => {
   ])
 }
 
-const browserSample = async ({ sample, temporaryRoot, url, variant }) => {
+async function browserSample({ sample, temporaryRoot, url, variant }) {
   const source = (await readFile(BROWSER_SAMPLE_PATH, 'utf8'))
     .replace('__TARGET_URL__', url)
     .replace('__VARIANT__', variant)
@@ -331,7 +340,7 @@ const browserSample = async ({ sample, temporaryRoot, url, variant }) => {
   }
 }
 
-const median = (values) => {
+function median(values) {
   const sorted = [...values].sort((left, right) => left - right)
   const middle = Math.floor(sorted.length / 2)
   return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
@@ -353,7 +362,7 @@ const metricPaths = [
 const getPath = (value, path) => path.reduce((current, key) => current?.[key], value)
 const medians = samples => Object.fromEntries(metricPaths.map(path => [path.join('.'), median(samples.map(sample => getPath(sample, path)).filter(value => typeof value === 'number'))]))
 
-const benchmarkVariant = async (variant, requestedSamples) => {
+async function benchmarkVariant(variant, requestedSamples) {
   const revision = SITE_REVISIONS[variant]
   const temporaryRoot = await mkdtemp(join(tmpdir(), `comark-site-harlanzw-${variant}-`))
   const siteRoot = join(temporaryRoot, 'site')
@@ -445,7 +454,7 @@ const benchmarkVariant = async (variant, requestedSamples) => {
   }
 }
 
-const main = async () => {
+async function main() {
   const { samples, variants } = parseArgs(process.argv.slice(2))
   await assertEnvironment()
   await mkdir(RESULTS_ROOT, { recursive: true })
@@ -453,4 +462,7 @@ const main = async () => {
     await benchmarkVariant(variant, samples)
 }
 
-await main()
+main().catch((error) => {
+  process.stderr.write(`${error.stack ?? error}\n`)
+  process.exitCode = 1
+})

--- a/packages/comark-content/eslint.config.mjs
+++ b/packages/comark-content/eslint.config.mjs
@@ -1,0 +1,15 @@
+import antfu from '@antfu/eslint-config'
+
+export default antfu({
+  type: 'lib',
+  ignores: [
+    // Template evaluated inside a browser automation harness. It relies on
+    // injected globals and `__PLACEHOLDER__` tokens, so it is not valid standalone JS.
+    'bench/site-harlanzw/browser-sample.js',
+  ],
+  rules: {
+    'no-console': 'off',
+    'no-use-before-define': 'off',
+    'ts/explicit-function-return-type': 'off',
+  },
+})

--- a/packages/comark-content/package.json
+++ b/packages/comark-content/package.json
@@ -2,6 +2,7 @@
   "name": "@harlan-zw/comark-content",
   "type": "module",
   "version": "0.0.17",
+  "packageManager": "pnpm@11.2.1",
   "description": "Markdown-only Nuxt content powered by Comark.",
   "author": {
     "name": "Harlan Wilton",
@@ -22,10 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "pnpm@11.2.1",
   "sideEffects": false,
-  "main": "./dist/module.mjs",
-  "types": "./dist/module.d.mts",
   "exports": {
     ".": {
       "types": "./dist/module.d.mts",
@@ -36,6 +34,8 @@
       "import": "./dist/runtime/server/index.js"
     }
   },
+  "main": "./dist/module.mjs",
+  "types": "./dist/module.d.mts",
   "files": [
     "dist"
   ],
@@ -47,6 +47,8 @@
     "bench:site:harlanzw": "node ./bench/site-harlanzw/run.mjs",
     "build": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt-module-build build",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "prepack": "pnpm run build",
     "test": "vitest run",
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz && node --input-type=module -e \"await import('./dist/runtime/core/navigation.js')\"",
@@ -59,11 +61,13 @@
   "dependencies": {
     "@nuxt/kit": "catalog:",
     "comark": "catalog:",
-    "rangi": "^2.2.0"
+    "rangi": "catalog:"
   },
   "devDependencies": {
+    "@antfu/eslint-config": "catalog:",
     "@nuxt/module-builder": "catalog:",
     "@types/node": "catalog:",
+    "eslint": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",

--- a/packages/comark-content/src/components.ts
+++ b/packages/comark-content/src/components.ts
@@ -1,53 +1,56 @@
 import { isAbsolute, join, relative, sep } from 'node:path'
 import { componentCandidates, componentMatchesTag } from './runtime/components/names'
 
-type NuxtLayer = { config?: { srcDir?: string, dir?: { app?: string } } }
+interface NuxtLayer { config?: { srcDir?: string, dir?: { app?: string } } }
 
-export const contentComponentDirectories = (layers: ReadonlyArray<NuxtLayer>) => [...layers]
-  .reverse()
-  .flatMap((layer) => {
-    const srcDir = layer.config?.srcDir
-    if (!srcDir)
-      return []
-    const appDir = layer.config?.dir?.app ?? 'app'
-    return [
-      join(srcDir, appDir, 'components/content'),
-      join(srcDir, 'components/content'),
-    ]
-  })
+export function contentComponentDirectories(layers: ReadonlyArray<NuxtLayer>) {
+  return [...layers]
+    .reverse()
+    .flatMap((layer) => {
+      const srcDir = layer.config?.srcDir
+      if (!srcDir)
+        return []
+      const appDir = layer.config?.dir?.app ?? 'app'
+      return [
+        join(srcDir, appDir, 'components/content'),
+        join(srcDir, 'components/content'),
+      ]
+    })
+}
 
-export type ScannedComponent = {
+export interface ScannedComponent {
   pascalName: string
   filePath: string
   export?: string
   global?: boolean | 'sync'
 }
 
-const kebabCase = (value: string) => value
-  .replaceAll(/([a-z\d])([A-Z])/g, '$1-$2')
-  .replaceAll(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
-  .toLowerCase()
+function kebabCase(value: string) {
+  return value
+    .replaceAll(/([a-z\d])([A-Z])/g, '$1-$2')
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+}
 
-const isWithin = (directory: string, filePath: string) => {
+function isWithin(directory: string, filePath: string) {
   const path = relative(directory, filePath)
   return path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path)
 }
 
-export const localizeNuxtUiProseComponents = <T extends ScannedComponent>(components: ReadonlyArray<T>): T[] => components.map(component => component.filePath
-  .replaceAll('\\', '/')
-  .includes('/@nuxt/ui/dist/runtime/components/prose/')
-  ? { ...component, global: false }
-  : component)
+export function localizeNuxtUiProseComponents<T extends ScannedComponent>(components: ReadonlyArray<T>): T[] {
+  return components.map(component => component.filePath
+    .replaceAll('\\', '/')
+    .includes('/@nuxt/ui/dist/runtime/components/prose/')
+    ? { ...component, global: false }
+    : component)
+}
 
-export type SelectedContentComponent = {
+export interface SelectedContentComponent {
   tag: string
   component: ScannedComponent
 }
 
-export const selectContentComponents = (
-  tags: ReadonlySet<string>,
-  scannedComponents: ReadonlyArray<ScannedComponent>,
-): SelectedContentComponent[] => {
+export function selectContentComponents(tags: ReadonlySet<string>, scannedComponents: ReadonlyArray<ScannedComponent>): SelectedContentComponent[] {
   const components = new Map(scannedComponents.map(component => [component.pascalName, component]))
   return [...tags].sort().flatMap((tag) => {
     const component = componentCandidates(tag).map(name => components.get(name)).find(Boolean)
@@ -56,10 +59,7 @@ export const selectContentComponents = (
   })
 }
 
-export const addUnprefixedContentAliases = <T extends ScannedComponent & { kebabName: string }>(
-  components: ReadonlyArray<T>,
-  directories: ReadonlyArray<string>,
-): T[] => {
+export function addUnprefixedContentAliases<T extends ScannedComponent & { kebabName: string }>(components: ReadonlyArray<T>, directories: ReadonlyArray<string>): T[] {
   const names = new Set(components.map(component => component.pascalName))
   return components.flatMap((component) => {
     if (!component.pascalName.startsWith('Content') || !directories.some(directory => isWithin(directory, component.filePath)))
@@ -72,11 +72,7 @@ export const addUnprefixedContentAliases = <T extends ScannedComponent & { kebab
   })
 }
 
-export const renderComponentManifest = (
-  tags: ReadonlySet<string>,
-  scannedComponents: ReadonlyArray<ScannedComponent>,
-  templateDir: string,
-) => {
+export function renderComponentManifest(tags: ReadonlySet<string>, scannedComponents: ReadonlyArray<ScannedComponent>, templateDir: string) {
   const selected = selectContentComponents(tags, scannedComponents)
   const imports = selected.map(({ component }, index) => {
     const importPath = isAbsolute(component.filePath)

--- a/packages/comark-content/src/config.ts
+++ b/packages/comark-content/src/config.ts
@@ -1,9 +1,9 @@
-export type StandardSchemaIssue = {
+export interface StandardSchemaIssue {
   message: string
   path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>
 }
 
-export type StandardSchema = {
+export interface StandardSchema {
   '~standard'?: {
     version: number
     vendor: string
@@ -26,18 +26,18 @@ export type CollectionSource = string | {
   repository?: GitRepository
 }
 
-export type CollectionDefinition<TSchema extends StandardSchema | undefined = StandardSchema | undefined> = {
+export interface CollectionDefinition<TSchema extends StandardSchema | undefined = StandardSchema | undefined> {
   type: 'page'
   source?: CollectionSource
   schema?: TSchema
   indexes?: Array<{ columns: string[] }>
 }
 
-export type ContentConfig<TCollections extends Record<string, CollectionDefinition> = Record<string, CollectionDefinition>> = {
+export interface ContentConfig<TCollections extends Record<string, CollectionDefinition> = Record<string, CollectionDefinition>> {
   collections: TCollections
 }
 
-export const defineCollection = <const TSchema extends StandardSchema | undefined>(definition: CollectionDefinition<TSchema>): CollectionDefinition<TSchema> => {
+export function defineCollection<const TSchema extends StandardSchema | undefined>(definition: CollectionDefinition<TSchema>): CollectionDefinition<TSchema> {
   if (definition.type !== 'page')
     throw new TypeError('Markdown page collections are the only supported collection type.')
   const source = typeof definition.source === 'string' ? definition.source : definition.source?.include
@@ -48,19 +48,19 @@ export const defineCollection = <const TSchema extends StandardSchema | undefine
 
 export const defineContentConfig = <const TCollections extends Record<string, CollectionDefinition>>(config: ContentConfig<TCollections>) => config
 
-export const assertSupportedOptions = (options: Record<string, unknown>, source: string) => {
+export function assertSupportedOptions(options: Record<string, unknown>, source: string) {
   if (!('database' in options))
     return
   throw new TypeError(`${source}:1:1 Database adapters are outside the Markdown-only comark-content boundary.`)
 }
 
-export type ContentDeploymentCache = {
+export interface ContentDeploymentCache {
   preset: unknown
   moduleInstalled: boolean
   workersCache?: unknown
 }
 
-export const assertCloudflareCacheModule = (integration: ContentDeploymentCache, source: string) => {
+export function assertCloudflareCacheModule(integration: ContentDeploymentCache, source: string) {
   if (typeof integration.preset !== 'string' || !integration.preset.startsWith('cloudflare'))
     return
   if (!integration.moduleInstalled)

--- a/packages/comark-content/src/core/asset.ts
+++ b/packages/comark-content/src/core/asset.ts
@@ -5,34 +5,38 @@ import { createNavigationSource, createSearchSections } from '../runtime/core/na
 
 export const encodeCollectionAsset = (value: unknown): Uint8Array => gzipSync(JSON.stringify(value), { level: 9 })
 
-export type GeneratedContentAsset = {
+export interface GeneratedContentAsset {
   path: string
   data: Uint8Array
 }
 
-export type ContentAssetPlan = {
+export interface ContentAssetPlan {
   collectionNames: string[]
   assets: GeneratedContentAsset[]
 }
 
 const bodyAssetName = (id: string) => `${createHash('sha256').update(id).digest('hex').slice(0, 32)}.json.gz`
 
-const canonicalContent = (collections: Record<string, PageCollectionItemBase[]>) => JSON.stringify(collections, (key, value) => {
-  if (key === '_source')
-    return undefined
-  if (!value || typeof value !== 'object' || Array.isArray(value))
-    return value
-  return Object.fromEntries(Object.keys(value).sort().map(name => [name, value[name]]))
-})
+function canonicalContent(collections: Record<string, PageCollectionItemBase[]>) {
+  return JSON.stringify(collections, (key, value) => {
+    if (key === '_source')
+      return undefined
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      return value
+    return Object.fromEntries(Object.keys(value).sort().map(name => [name, value[name]]))
+  })
+}
 
-export const createContentRevision = (buildId: string, collections: Record<string, PageCollectionItemBase[]>) => createHash('sha256')
-  .update('comark-content-assets-v1\0')
-  .update(buildId)
-  .update('\0')
-  .update(canonicalContent(collections))
-  .digest('hex')
+export function createContentRevision(buildId: string, collections: Record<string, PageCollectionItemBase[]>) {
+  return createHash('sha256')
+    .update('comark-content-assets-v1\0')
+    .update(buildId)
+    .update('\0')
+    .update(canonicalContent(collections))
+    .digest('hex')
+}
 
-export const projectCollectionAssets = (name: string, items: PageCollectionItemBase[]): GeneratedContentAsset[] => {
+export function projectCollectionAssets(name: string, items: PageCollectionItemBase[]): GeneratedContentAsset[] {
   const index: IndexedContentDocument[] = []
   const navigation: NavigationCollectionItem[] = []
   const bodyAssets: GeneratedContentAsset[] = []
@@ -52,7 +56,7 @@ export const projectCollectionAssets = (name: string, items: PageCollectionItemB
   ]
 }
 
-export const createContentAssetPlan = (collections: Record<string, PageCollectionItemBase[]>): ContentAssetPlan => {
+export function createContentAssetPlan(collections: Record<string, PageCollectionItemBase[]>): ContentAssetPlan {
   const collectionNames = Object.keys(collections)
   return {
     collectionNames,

--- a/packages/comark-content/src/core/cache.ts
+++ b/packages/comark-content/src/core/cache.ts
@@ -1,20 +1,21 @@
 import type { MarkdownDocument } from 'comark'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import process from 'node:process'
 
 export const CACHE_VERSION = 'comark-content:3:comark-0.6.2:rangi-2.2.0:github-aa-v1'
 
-export type CacheEntry = {
+export interface CacheEntry {
   digest: string
   document: MarkdownDocument
 }
 
-export type IngestionCache = {
+export interface IngestionCache {
   version: string
   entries: Record<string, CacheEntry>
 }
 
-export const readCache = async (path: string): Promise<IngestionCache> => {
+export async function readCache(path: string): Promise<IngestionCache> {
   const source = await readFile(path, 'utf8').catch(error => error.code === 'ENOENT' ? undefined : Promise.reject(error))
   if (!source)
     return { version: CACHE_VERSION, entries: {} }
@@ -22,7 +23,7 @@ export const readCache = async (path: string): Promise<IngestionCache> => {
   return parsed.version === CACHE_VERSION ? parsed : { version: CACHE_VERSION, entries: {} }
 }
 
-export const writeCache = async (path: string, cache: IngestionCache) => {
+export async function writeCache(path: string, cache: IngestionCache) {
   await mkdir(dirname(path), { recursive: true })
   const temporary = `${path}.${process.pid}.tmp`
   await writeFile(temporary, `${JSON.stringify(cache)}\n`)

--- a/packages/comark-content/src/core/ingest.ts
+++ b/packages/comark-content/src/core/ingest.ts
@@ -9,6 +9,7 @@ import { createMarkdownParser } from 'comark'
 import headings from 'comark/plugins/headings'
 import rangi from 'comark/plugins/rangi'
 import toc from 'comark/plugins/toc'
+import { contentHookCollection, contentHookFile, parserOptions } from '../hooks'
 import { collectComponentTags } from '../runtime/components/names'
 import { generatedTitle } from '../runtime/core/path'
 import { CACHE_VERSION, readCache, writeCache } from './cache'
@@ -17,15 +18,14 @@ import { contentRangiLanguages, contentRangiTheme, normalizeRangiThemeVariables 
 import { prepareRemoteSource } from './remote'
 import { err, ok, sourceError } from './result'
 import { resolveCollectionSource, scanSource } from './source'
-import { contentHookCollection, contentHookFile, parserOptions } from '../hooks'
 
-export type LoadedCollection = {
+export interface LoadedCollection {
   name: string
   rootDir: string
   definition: CollectionDefinition
 }
 
-export type IngestionResult = {
+export interface IngestionResult {
   collections: Record<string, PageCollectionItemBase[]>
   parsedFiles: number
   cachedFiles: number
@@ -46,9 +46,7 @@ const plainParser = createMarkdownParser({
   ],
 })
 
-export const createContentParser = async (
-  options: Pick<IngestionOptions, 'highlight'> = {},
-) => {
+export async function createContentParser(options: Pick<IngestionOptions, 'highlight'> = {}) {
   if (!options.highlight)
     return plainParser
   const highlight = typeof options.highlight === 'object' ? options.highlight : {}
@@ -67,7 +65,7 @@ export const createContentParser = async (
   return async (source: string) => normalizeRangiThemeVariables(await parse(source))
 }
 
-const errorLocation = (cause: unknown, markdown: string) => {
+function errorLocation(cause: unknown, markdown: string) {
   if (!cause || typeof cause !== 'object')
     return { line: 1, column: 1 }
   const value = cause as Record<string, unknown>
@@ -80,14 +78,14 @@ const errorLocation = (cause: unknown, markdown: string) => {
   }
 }
 
-const issueKey = (issue: StandardSchemaIssue) => {
+function issueKey(issue: StandardSchemaIssue) {
   const part = issue.path?.[0]
   if (typeof part === 'object' && part && 'key' in part)
     return String(part.key)
   return part === undefined ? undefined : String(part)
 }
 
-const frontmatterLocation = (source: string, issue: StandardSchemaIssue) => {
+function frontmatterLocation(source: string, issue: StandardSchemaIssue) {
   const key = issueKey(issue)
   if (!key)
     return { line: 1, column: 1 }
@@ -95,7 +93,7 @@ const frontmatterLocation = (source: string, issue: StandardSchemaIssue) => {
   return { line: line === -1 ? 1 : line + 1, column: 1 }
 }
 
-const parseSchemaResult = (result: unknown) => {
+function parseSchemaResult(result: unknown) {
   if (!result || typeof result !== 'object')
     return { value: result as Record<string, unknown> }
   const record = result as Record<string, unknown>
@@ -105,24 +103,23 @@ const parseSchemaResult = (result: unknown) => {
   }
 }
 
-const applySchema = async (definition: CollectionDefinition, frontmatter: Record<string, unknown>) => {
+async function applySchema(definition: CollectionDefinition, frontmatter: Record<string, unknown>) {
   const validate = definition.schema?.['~standard']?.validate
   return validate ? parseSchemaResult(await validate(frontmatter)) : { value: frontmatter }
 }
 
 const digest = (source: string, parser: string) => createHash('sha256').update(CACHE_VERSION).update('\0').update(parser).update('\0').update(source).digest('hex')
 
-const contentHighlightFingerprint = (highlight: ContentHighlight | undefined) => JSON.stringify(
-  highlight ?? false,
-  (_key, value) => value instanceof RegExp
-    ? { _tag: 'RegExp', source: value.source, flags: value.flags }
-    : value,
-)
+function contentHighlightFingerprint(highlight: ContentHighlight | undefined) {
+  return JSON.stringify(
+    highlight ?? false,
+    (_key, value) => value instanceof RegExp
+      ? { _tag: 'RegExp', source: value.source, flags: value.flags }
+      : value,
+  )
+}
 
-export const ingestCollections = async (
-  loadedCollections: LoadedCollection[],
-  options: IngestionOptions,
-): Promise<Result<IngestionResult>> => {
+export async function ingestCollections(loadedCollections: LoadedCollection[], options: IngestionOptions): Promise<Result<IngestionResult>> {
   const cache = await readCache(options.cacheFile)
   const nextCache = { version: CACHE_VERSION, entries: {} as typeof cache.entries }
   const collections: Record<string, PageCollectionItemBase[]> = {}

--- a/packages/comark-content/src/core/path.ts
+++ b/packages/comark-content/src/core/path.ts
@@ -2,13 +2,15 @@ import { posix } from 'node:path'
 
 const SEMVER = /^v?\d+\.\d+\.\d+(?:[-+].*)?$/
 
-const stripOrder = (part: string) => SEMVER.test(part)
-  ? part
-  : part.replace(/^\d+\./, '')
+function stripOrder(part: string) {
+  return SEMVER.test(part)
+    ? part
+    : part.replace(/^\d+\./, '')
+}
 
 export const sourceStem = (key: string) => key.replace(/\.md$/i, '')
 
-export const contentPath = (key: string, prefix = '') => {
+export function contentPath(key: string, prefix = '') {
   const parts = sourceStem(key).split('/').map(stripOrder)
   const last = parts.at(-1)?.toLowerCase()
   if (last === 'index')

--- a/packages/comark-content/src/core/rangi.ts
+++ b/packages/comark-content/src/core/rangi.ts
@@ -4,7 +4,7 @@ import { githubDark, githubLight } from 'rangi/themes'
 
 const dotenvValue: ShjLanguageDefinition = [
   [/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/g, 'str'],
-  [/\$\{?[A-Za-z_]\w*(?:(?::-?|\?)[^}]*)?\}?/g, 'var'],
+  [/\$\{?[A-Z_]\w*(?:(?::|\?)[^}]*)?\}?/gi, 'var'],
   [/\b(?:true|false)\b/gi, 'bool'],
   [/\b-?\d+(?:\.\d+)?\b/g, 'num'],
 ]
@@ -12,7 +12,7 @@ const dotenvValue: ShjLanguageDefinition = [
 const dotenv: ShjLanguageDefinition = [
   [/#.*$/gm, 'cmnt'],
   [/^\s*export\b/gm, 'kwd'],
-  [/\b[A-Za-z_]\w*(?=\s*=)/g, 'var'],
+  [/\b[A-Z_]\w*(?=\s*=)/gi, 'var'],
   [/=/g, 'oper'],
   [/(?<==)[ \t]*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^#\r\n]+)/g, 'str', dotenvValue],
 ]
@@ -24,14 +24,14 @@ const robotsValue: ShjLanguageDefinition = [
 
 const robots: ShjLanguageDefinition = [
   [/#.*$/gm, 'cmnt'],
-  [/^[A-Za-z][\w-]*(?=\s*:)/gm, 'kwd'],
+  [/^[A-Z][\w-]*(?=\s*:)/gim, 'kwd'],
   [/:/g, 'oper'],
   [/(?<=:)[^#\r\n]+/g, 'str', robotsValue],
 ]
 
 export const contentRangiLanguages: ShjLanguages = {
   dotenv,
-  env: dotenv,
+  'env': dotenv,
   robots,
   'robots-txt': robots,
   'robots.txt': robots,
@@ -48,11 +48,11 @@ export const contentRangiTheme = {
   dark: githubDark,
 } satisfies ShjThemePair
 
-const addThemeVariables = (node: Node, inRangi = false): void => {
+function addThemeVariables(node: Node, inRangi = false): void {
   if (typeof node === 'string' || node[0] === null)
     return
   const [tag, attributes, ...children] = node
-  const rangi = inRangi || tag === 'pre' && typeof attributes.class === 'string' && attributes.class.split(/\s+/).includes('rangi')
+  const rangi = inRangi || (tag === 'pre' && typeof attributes.class === 'string' && attributes.class.split(/\s+/).includes('rangi'))
   if (rangi && tag === 'span' && typeof attributes.style === 'string' && !attributes.style.includes('--shiki-light:')) {
     const light = /(?:^|;)color:([^;]+)/.exec(attributes.style)?.[1]
     if (light)
@@ -62,7 +62,7 @@ const addThemeVariables = (node: Node, inRangi = false): void => {
     addThemeVariables(child as Node, rangi)
 }
 
-export const normalizeRangiThemeVariables = (document: MarkdownDocument): MarkdownDocument => {
+export function normalizeRangiThemeVariables(document: MarkdownDocument): MarkdownDocument {
   for (const node of document.nodes)
     addThemeVariables(node)
   return document

--- a/packages/comark-content/src/core/remote.ts
+++ b/packages/comark-content/src/core/remote.ts
@@ -4,9 +4,10 @@ import { spawn } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
 import { mkdir, rename, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import process from 'node:process'
 import { err, ok, sourceError } from './result'
 
-export type RemoteSource = {
+export interface RemoteSource {
   repository: GitRepository
   include: string
   exclude?: string | string[]
@@ -23,15 +24,13 @@ const runCommand: Command = (command, args, options) => new Promise((resolve, re
   child.on('close', code => code === 0 ? resolve() : reject(new Error(error.trim() || `${command} exited with ${code}.`)))
 })
 
-const repositoryDetails = (repository: GitRepository) => typeof repository === 'string'
-  ? { url: repository, reference: undefined, token: undefined }
-  : { url: repository.url, reference: repository.tag ?? repository.branch, token: repository.auth?.token }
+function repositoryDetails(repository: GitRepository) {
+  return typeof repository === 'string'
+    ? { url: repository, reference: undefined, token: undefined }
+    : { url: repository.url, reference: repository.tag ?? repository.branch, token: repository.auth?.token }
+}
 
-export const prepareRemoteSource = async (
-  source: RemoteSource,
-  cacheRoot: string,
-  command: Command = runCommand,
-): Promise<Result<string>> => {
+export async function prepareRemoteSource(source: RemoteSource, cacheRoot: string, command: Command = runCommand): Promise<Result<string>> {
   const repository = repositoryDetails(source.repository)
   const key = createHash('sha256').update(repository.url).update('\0').update(repository.reference ?? 'HEAD').digest('hex').slice(0, 20)
   const target = join(cacheRoot, key)
@@ -48,7 +47,7 @@ export const prepareRemoteSource = async (
         GIT_CONFIG_COUNT: '1',
         GIT_CONFIG_KEY_0: 'http.extraHeader',
         GIT_CONFIG_VALUE_0: `Authorization: Bearer ${repository.token}`,
-    }
+      }
     : process.env
   const clone = (cloneEnv: NodeJS.ProcessEnv) => command('git', args, { env: cloneEnv })
     .then(() => ok(undefined), cause => err(cause))

--- a/packages/comark-content/src/core/result.ts
+++ b/packages/comark-content/src/core/result.ts
@@ -3,18 +3,13 @@ import type { ContentError, Result } from '../runtime/types'
 export const ok = <T>(value: T): Result<T> => ({ _tag: 'Ok', value })
 export const err = <T = never>(error: ContentError): Result<T> => ({ _tag: 'Err', error })
 
-export const sourceError = (
-  tag: ContentError['_tag'],
-  source: string,
-  line: number,
-  column: number,
-  detail: string,
-  cause?: unknown,
-): ContentError => ({
-  _tag: tag,
-  source,
-  line,
-  column,
-  message: `${source}:${line}:${column} ${detail}`,
-  cause,
-})
+export function sourceError(tag: ContentError['_tag'], source: string, line: number, column: number, detail: string, cause?: unknown): ContentError {
+  return {
+    _tag: tag,
+    source,
+    line,
+    column,
+    message: `${source}:${line}:${column} ${detail}`,
+    cause,
+  }
+}

--- a/packages/comark-content/src/core/source.ts
+++ b/packages/comark-content/src/core/source.ts
@@ -2,7 +2,7 @@ import type { CollectionDefinition, CollectionSource } from '../config'
 import { readdir } from 'node:fs/promises'
 import { isAbsolute, join, posix, relative, resolve } from 'node:path'
 
-export type ResolvedSource = {
+export interface ResolvedSource {
   cwd: string
   include: string
   exclude: string[]
@@ -12,7 +12,7 @@ export type ResolvedSource = {
 
 const escapeRegex = (value: string) => value.replaceAll(/[|\\{}()[\]^$+?.]/g, '\\$&')
 
-export const globRegex = (glob: string) => {
+export function globRegex(glob: string) {
   let source = ''
   for (let index = 0; index < glob.length; index++) {
     const character = glob[index]
@@ -49,13 +49,13 @@ export const globRegex = (glob: string) => {
   return new RegExp(`^${source}$`)
 }
 
-const sourceBase = (include: string) => {
+function sourceBase(include: string) {
   const wildcard = include.search(/[*?{]/)
   const directory = wildcard === -1 ? posix.dirname(include) : include.slice(0, wildcard).replace(/[^/]*$/, '')
   return directory === '.' ? '' : directory.replace(/^\/+|\/+$/g, '')
 }
 
-export const resolveCollectionSource = (definition: CollectionDefinition, rootDir: string, remoteCwd?: string): ResolvedSource => {
+export function resolveCollectionSource(definition: CollectionDefinition, rootDir: string, remoteCwd?: string): ResolvedSource {
   const source = definition.source ?? '**/*.md'
   if (typeof source === 'string') {
     return {
@@ -77,7 +77,7 @@ export const resolveCollectionSource = (definition: CollectionDefinition, rootDi
   }
 }
 
-export const scanSource = async (source: ResolvedSource) => {
+export async function scanSource(source: ResolvedSource) {
   const include = globRegex(source.include)
   const excludes = source.exclude.map(globRegex)
   const base = sourceBase(source.include)

--- a/packages/comark-content/src/hooks.ts
+++ b/packages/comark-content/src/hooks.ts
@@ -46,12 +46,12 @@ export interface ContentHookPage extends PageCollectionItemBase {
   rawbody: string
 }
 
-export type ContentHook = {
+export interface ContentHook {
   beforeParse?: (context: FileBeforeParseHook) => void | Promise<void>
   afterParse?: (context: FileAfterParseHook) => void | Promise<void>
 }
 
-const fieldType = (value: unknown): ContentHookCollection['fields'][string] => {
+function fieldType(value: unknown): ContentHookCollection['fields'][string] {
   if (typeof value === 'string')
     return 'string'
   if (typeof value === 'number')
@@ -61,40 +61,42 @@ const fieldType = (value: unknown): ContentHookCollection['fields'][string] => {
   return 'json'
 }
 
-export const contentHookCollection = (
-  name: string,
-  definition: CollectionDefinition,
-  content: Record<string, unknown> = {},
-): ContentHookCollection => ({
-  name,
-  type: 'page',
-  tableName: `_content_${name}`,
-  private: false,
-  source: definition.source,
-  fields: Object.fromEntries(Object.entries(content).map(([key, value]) => [key, fieldType(value)])),
-  indexes: definition.indexes,
-})
+export function contentHookCollection(name: string, definition: CollectionDefinition, content: Record<string, unknown> = {}): ContentHookCollection {
+  return {
+    name,
+    type: 'page',
+    tableName: `_content_${name}`,
+    private: false,
+    source: definition.source,
+    fields: Object.fromEntries(Object.entries(content).map(([key, value]) => [key, fieldType(value)])),
+    indexes: definition.indexes,
+  }
+}
 
-export const contentHookFile = (id: string, path: string, body: string): ContentHookFile => ({
-  id,
-  body,
-  path,
-  dirname: path.slice(0, Math.max(0, path.lastIndexOf('/'))),
-  extension: '.md',
-  collectionType: 'page',
-})
+export function contentHookFile(id: string, path: string, body: string): ContentHookFile {
+  return {
+    id,
+    body,
+    path,
+    dirname: path.slice(0, Math.max(0, path.lastIndexOf('/'))),
+    extension: '.md',
+    collectionType: 'page',
+  }
+}
 
-export const parserOptions = (): FileBeforeParseHook['parserOptions'] => ({
-  pathMeta: { forceLeadingSlash: true },
-  markdown: {
-    compress: false,
-    mdc: false,
-    toc: { depth: 3, searchDepth: 3 },
-    tags: {},
-    remarkPlugins: {},
-    rehypePlugins: {},
-  },
-})
+export function parserOptions(): FileBeforeParseHook['parserOptions'] {
+  return {
+    pathMeta: { forceLeadingSlash: true },
+    markdown: {
+      compress: false,
+      mdc: false,
+      toc: { depth: 3, searchDepth: 3 },
+      tags: {},
+      remarkPlugins: {},
+      rehypePlugins: {},
+    },
+  }
+}
 
 declare module '@nuxt/schema' {
   interface NuxtHooks {

--- a/packages/comark-content/src/module.ts
+++ b/packages/comark-content/src/module.ts
@@ -1,12 +1,12 @@
+import type { NitroConfig } from 'nitropack/types'
 import type { ContentConfig } from './config'
 import type { LoadedCollection } from './core/ingest'
 import type { ContentHighlight } from './highlight'
-import type { NitroConfig } from 'nitropack/types'
-import process from 'node:process'
 import { existsSync } from 'node:fs'
 import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { performance } from 'node:perf_hooks'
+import process from 'node:process'
 import {
   addComponent,
   addImports,
@@ -20,8 +20,8 @@ import {
   updateTemplates,
   useLogger,
 } from '@nuxt/kit'
-import { assertCloudflareCacheModule, assertSupportedOptions } from './config'
 import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtUiProseComponents, renderComponentManifest } from './components'
+import { assertCloudflareCacheModule, assertSupportedOptions } from './config'
 import { createContentAssetPlan, createContentRevision } from './core/asset'
 import { ingestCollections } from './core/ingest'
 import { excludeNuxtContentSitemapSource } from './sitemap'
@@ -48,12 +48,12 @@ declare module '@nuxt/schema' {
 
 const contentConfigNames = ['content.config.ts', 'content.config.mts', 'content.config.js', 'content.config.mjs']
 
-const layerRoot = (layer: Record<string, unknown>) => {
+function layerRoot(layer: Record<string, unknown>) {
   const config = layer.config as Record<string, unknown> | undefined
   return String(config?.rootDir ?? layer.cwd ?? '')
 }
 
-const loadCollections = async (layers: ReadonlyArray<Record<string, unknown>>): Promise<LoadedCollection[]> => {
+async function loadCollections(layers: ReadonlyArray<Record<string, unknown>>): Promise<LoadedCollection[]> {
   const collections = new Map<string, LoadedCollection>()
   for (const layer of [...layers].reverse()) {
     const rootDir = layerRoot(layer)

--- a/packages/comark-content/src/runtime/client.ts
+++ b/packages/comark-content/src/runtime/client.ts
@@ -1,19 +1,20 @@
-import type { CollectionItem, CollectionName, ContentNavigationItem, ContentSearchSection } from './types'
 import type { QueryRequest } from './shared/protocol'
-import { createQueryBuilder } from './core/query'
+import type { CollectionItem, CollectionName, ContentNavigationItem, ContentSearchSection } from './types'
 import { useRuntimeConfig } from '#imports'
+import { createQueryBuilder } from './core/query'
 
 type Fetch = <T>(path: string, options:
   | { method: 'POST', body: QueryRequest }
-  | { method: 'GET', query: Record<string, string> }
-) => Promise<T>
+  | { method: 'GET', query: Record<string, string> }) => Promise<T>
 
-const request = <T>(body: QueryRequest): Promise<T> => (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<T>('/__comark_content/query', {
-  method: 'POST',
-  body,
-})
+function request<T>(body: QueryRequest): Promise<T> {
+  return (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<T>('/__comark_content/query', {
+    method: 'POST',
+    body,
+  })
+}
 
-const contentGetPath = (resource: string, collection: string) => {
+function contentGetPath(resource: string, collection: string) {
   const revision = useRuntimeConfig().public.comarkContentRevision
   if (typeof revision !== 'string' || !revision)
     throw new TypeError('comark-content:1:1 The content revision is unavailable.')
@@ -22,21 +23,23 @@ const contentGetPath = (resource: string, collection: string) => {
 
 export const queryCollection = <TName extends CollectionName | string>(collection: TName) => createQueryBuilder<CollectionItem<TName>>(plan => request({ _tag: 'Query', collection, plan }))
 
-export const queryCollectionNavigation = <TName extends CollectionName | string>(collection: TName, fields: string[] = []) => (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<ContentNavigationItem[]>(
-  contentGetPath('navigation', collection),
-  { method: 'GET', query: { fields: fields.join(',') } },
-)
+export function queryCollectionNavigation<TName extends CollectionName | string>(collection: TName, fields: string[] = []) {
+  return (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<ContentNavigationItem[]>(
+    contentGetPath('navigation', collection),
+    { method: 'GET', query: { fields: fields.join(',') } },
+  )
+}
 
-export const queryCollectionItemSurroundings = <TName extends CollectionName | string>(
-  collection: TName,
-  path: string,
-  options: { fields?: string[] } = {},
-) => (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<[ContentNavigationItem | null, ContentNavigationItem | null]>(
-  contentGetPath('surroundings', collection),
-  { method: 'GET', query: { path, fields: (options.fields ?? []).join(',') } },
-)
+export function queryCollectionItemSurroundings<TName extends CollectionName | string>(collection: TName, path: string, options: { fields?: string[] } = {}) {
+  return (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<[ContentNavigationItem | null, ContentNavigationItem | null]>(
+    contentGetPath('surroundings', collection),
+    { method: 'GET', query: { path, fields: (options.fields ?? []).join(',') } },
+  )
+}
 
-export const queryCollectionSearchSections = <TName extends CollectionName | string>(collection: TName) => (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<ContentSearchSection[]>(
-  contentGetPath('search', collection),
-  { method: 'GET', query: {} },
-)
+export function queryCollectionSearchSections<TName extends CollectionName | string>(collection: TName) {
+  return (globalThis as typeof globalThis & { $fetch: Fetch }).$fetch<ContentSearchSection[]>(
+    contentGetPath('search', collection),
+    { method: 'GET', query: {} },
+  )
+}

--- a/packages/comark-content/src/runtime/components/ContentRenderer.ts
+++ b/packages/comark-content/src/runtime/components/ContentRenderer.ts
@@ -1,8 +1,8 @@
-import type { Component } from 'vue'
 import type { MarkdownDocument } from 'comark'
+import type { Component } from 'vue'
 import type { PageCollectionItemBase } from '../types'
-import contentComponents from '#comark-content/components'
 import { defineComponent, useAttrs } from 'vue'
+import contentComponents from '#comark-content/components'
 import { renderContentRoot, renderNodes } from './render'
 
 const resolveTag = (tag: string): string | Component => contentComponents[tag]?.component ?? tag

--- a/packages/comark-content/src/runtime/components/names.ts
+++ b/packages/comark-content/src/runtime/components/names.ts
@@ -1,15 +1,46 @@
 import type { Node } from 'comark'
 
 export const htmlTags = new Set([
-  'a', 'blockquote', 'br', 'code', 'del', 'details', 'div', 'em', 'figcaption',
-  'figure', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'hr', 'iframe', 'img',
-  'li', 'ol', 'p', 'pre', 'span', 'strong', 'summary', 'table', 'tbody', 'td',
-  'template', 'th', 'thead', 'tr', 'ul',
+  'a',
+  'blockquote',
+  'br',
+  'code',
+  'del',
+  'details',
+  'div',
+  'em',
+  'figcaption',
+  'figure',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'hr',
+  'iframe',
+  'img',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  'span',
+  'strong',
+  'summary',
+  'table',
+  'tbody',
+  'td',
+  'template',
+  'th',
+  'thead',
+  'tr',
+  'ul',
 ])
 
 const pascalCase = (value: string) => value.split(/[-_:]/).filter(Boolean).map(part => part[0]?.toUpperCase() + part.slice(1)).join('')
 
-export const componentCandidates = (tag: string): string[] => {
+export function componentCandidates(tag: string): string[] {
   const name = pascalCase(tag)
   if (htmlTags.has(tag))
     return [`ContentProse${name}`, `Prose${name}`]
@@ -21,7 +52,7 @@ export const componentCandidates = (tag: string): string[] => {
   return candidates
 }
 
-export const componentMatchesTag = (tag: string, componentName: string): boolean => {
+export function componentMatchesTag(tag: string, componentName: string): boolean {
   const candidates = componentCandidates(tag)
   if (candidates.includes(componentName) || candidates.some(candidate => `Content${candidate}` === componentName))
     return true
@@ -29,7 +60,7 @@ export const componentMatchesTag = (tag: string, componentName: string): boolean
   return componentName.startsWith('Content') && componentName.slice('Content'.length).toLowerCase() === normalizedTag
 }
 
-export const collectComponentTags = (nodes: readonly Node[]): string[] => {
+export function collectComponentTags(nodes: readonly Node[]): string[] {
   const tags = new Set<string>()
   const visit = (node: Node) => {
     if (typeof node === 'string' || node[0] === null)

--- a/packages/comark-content/src/runtime/components/render.ts
+++ b/packages/comark-content/src/runtime/components/render.ts
@@ -1,21 +1,21 @@
-import type { Component, VNode, VNodeChild } from 'vue'
 import type { Node } from 'comark'
+import type { Component, VNode, VNodeChild } from 'vue'
 import { createCommentVNode, h } from 'vue'
 import { htmlTags } from './names'
 
-type RenderOptions = {
+interface RenderOptions {
   source: string
   unwrap?: string[]
   resolveTag?: (tag: string) => string | Component
 }
 
-const scalarProperty = (value: unknown) => {
+function scalarProperty(value: unknown) {
   if (typeof value !== 'string' || !/^(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)$/.test(value))
     return value
   return JSON.parse(value)
 }
 
-const componentProps = (node: Exclude<Node, string>, attributes: Record<string, unknown>, options: RenderOptions, nativeTag: boolean) => {
+function componentProps(node: Exclude<Node, string>, attributes: Record<string, unknown>, options: RenderOptions, nativeTag: boolean) {
   const props: Record<string, unknown> = { __node: node }
   for (const [name, value] of Object.entries(attributes)) {
     if (!name.startsWith(':')) {
@@ -37,7 +37,7 @@ const componentProps = (node: Exclude<Node, string>, attributes: Record<string, 
   return props
 }
 
-const renderNode = (node: Node, options: RenderOptions, key: string, parentTag?: string): VNodeChild => {
+function renderNode(node: Node, options: RenderOptions, key: string, parentTag?: string): VNodeChild {
   if (typeof node === 'string')
     return node
   if (node[0] === null)
@@ -74,7 +74,7 @@ const renderNode = (node: Node, options: RenderOptions, key: string, parentTag?:
   return h(resolved, { ...componentProps(node, props, options, htmlTags.has(tag)), key }, slots)
 }
 
-export const renderNodes = (nodes: readonly Node[], options: RenderOptions): VNodeChild[] => {
+export function renderNodes(nodes: readonly Node[], options: RenderOptions): VNodeChild[] {
   const unwrap = new Set(options.unwrap)
   return nodes.flatMap((node, index) => {
     if (typeof node !== 'string' && node[0] && unwrap.has(node[0]))
@@ -83,6 +83,8 @@ export const renderNodes = (nodes: readonly Node[], options: RenderOptions): VNo
   })
 }
 
-export const renderContentRoot = (nodes: VNodeChild[], attributes: Record<string, unknown>): VNode | VNodeChild[] => Object.keys(attributes).length
-  ? h('div', attributes, nodes)
-  : nodes
+export function renderContentRoot(nodes: VNodeChild[], attributes: Record<string, unknown>): VNode | VNodeChild[] {
+  return Object.keys(attributes).length
+    ? h('div', attributes, nodes)
+    : nodes
+}

--- a/packages/comark-content/src/runtime/core/navigation.ts
+++ b/packages/comark-content/src/runtime/core/navigation.ts
@@ -2,11 +2,13 @@ import type { Node } from 'comark'
 import type { ContentNavigationItem, ContentSearchSection, NavigationCollectionItem, PageCollectionItemBase } from '../types'
 import { generatedTitle } from './path'
 
-const text = (node: Node): string => typeof node === 'string'
-  ? node
-  : node.slice(2).map(child => text(child as Node)).join('')
+function text(node: Node): string {
+  return typeof node === 'string'
+    ? node
+    : node.slice(2).map(child => text(child as Node)).join('')
+}
 
-const navigationItem = (page: NavigationCollectionItem, fields: string[]): ContentNavigationItem => {
+function navigationItem(page: NavigationCollectionItem, fields: string[]): ContentNavigationItem {
   const navigation = page.navigation
   const metadata = typeof navigation === 'object' && navigation ? navigation : {}
   return {
@@ -17,11 +19,13 @@ const navigationItem = (page: NavigationCollectionItem, fields: string[]): Conte
   }
 }
 
-export const createNavigationSource = (page: PageCollectionItemBase): NavigationCollectionItem => Object.fromEntries(
-  Object.entries(page).filter(([key]) => !['body', 'id', 'extension', '_source', 'seo', 'sitemap', 'robots'].includes(key)),
-) as NavigationCollectionItem
+export function createNavigationSource(page: PageCollectionItemBase): NavigationCollectionItem {
+  return Object.fromEntries(
+    Object.entries(page).filter(([key]) => !['body', 'id', 'extension', '_source', 'seo', 'sitemap', 'robots'].includes(key)),
+  ) as NavigationCollectionItem
+}
 
-export const createNavigation = (pages: NavigationCollectionItem[], fields: string[] = []): ContentNavigationItem[] => {
+export function createNavigation(pages: NavigationCollectionItem[], fields: string[] = []): ContentNavigationItem[] {
   const included = pages.filter(page => page.navigation !== false).sort((left, right) => left.stem.localeCompare(right.stem))
   type TreeItem = ContentNavigationItem & { _sort: string, children?: TreeItem[] }
   const byPath = new Map<string, TreeItem>()
@@ -73,7 +77,7 @@ export const createNavigation = (pages: NavigationCollectionItem[], fields: stri
   return project(roots)
 }
 
-export const createSurroundings = (pages: NavigationCollectionItem[], path: string, fields: string[] = []): [ContentNavigationItem | null, ContentNavigationItem | null] => {
+export function createSurroundings(pages: NavigationCollectionItem[], path: string, fields: string[] = []): [ContentNavigationItem | null, ContentNavigationItem | null] {
   const ordered = pages.filter(page => page.navigation !== false).sort((left, right) => left.stem.localeCompare(right.stem))
   const index = ordered.findIndex(page => page.path === path)
   const project = (page?: NavigationCollectionItem) => page
@@ -82,39 +86,41 @@ export const createSurroundings = (pages: NavigationCollectionItem[], path: stri
   return index === -1 ? [null, null] : [project(ordered[index - 1]), project(ordered[index + 1])]
 }
 
-const appendText = (section: ContentSearchSection, value: string) => {
+function appendText(section: ContentSearchSection, value: string) {
   const next = value.trim()
   if (next)
     section.content = `${section.content} ${next}`.trim()
 }
 
-export const createSearchSections = (pages: PageCollectionItemBase[]): ContentSearchSection[] => pages.flatMap((page) => {
-  const sections: ContentSearchSection[] = []
-  const titles: string[] = []
-  let current: ContentSearchSection | undefined
-  let preface = ''
-  for (const node of page.body.nodes) {
-    if (typeof node !== 'string' && typeof node[0] === 'string' && /^h[1-6]$/.test(node[0])) {
-      const level = Number(node[0].slice(1))
-      const title = text(node)
-      titles.splice(level - 1)
-      current = {
-        id: `${page.path}#${String(node[1].id ?? '')}`,
-        title,
-        titles: [...titles],
-        content: '',
-        level,
+export function createSearchSections(pages: PageCollectionItemBase[]): ContentSearchSection[] {
+  return pages.flatMap((page) => {
+    const sections: ContentSearchSection[] = []
+    const titles: string[] = []
+    let current: ContentSearchSection | undefined
+    let preface = ''
+    for (const node of page.body.nodes) {
+      if (typeof node !== 'string' && typeof node[0] === 'string' && /^h[1-6]$/.test(node[0])) {
+        const level = Number(node[0].slice(1))
+        const title = text(node)
+        titles.splice(level - 1)
+        current = {
+          id: `${page.path}#${String(node[1].id ?? '')}`,
+          title,
+          titles: [...titles],
+          content: '',
+          level,
+        }
+        sections.push(current)
+        if (sections.length === 1)
+          appendText(current, preface)
+        titles[level - 1] = title
+        continue
       }
-      sections.push(current)
-      if (sections.length === 1)
-        appendText(current, preface)
-      titles[level - 1] = title
-      continue
+      if (current)
+        appendText(current, text(node))
+      else
+        preface = `${preface} ${text(node)}`.trim()
     }
-    if (current)
-      appendText(current, text(node))
-    else
-      preface = `${preface} ${text(node)}`.trim()
-  }
-  return sections
-})
+    return sections
+  })
+}

--- a/packages/comark-content/src/runtime/core/path.ts
+++ b/packages/comark-content/src/runtime/core/path.ts
@@ -1,4 +1,4 @@
-export const generatedTitle = (path: string) => {
+export function generatedTitle(path: string) {
   const part = path.split('/').filter(Boolean).at(-1) || 'Home'
   return part.split(/[-_]/).filter(Boolean).map(word => word[0]?.toUpperCase() + word.slice(1)).join(' ')
 }

--- a/packages/comark-content/src/runtime/core/query.ts
+++ b/packages/comark-content/src/runtime/core/query.ts
@@ -3,16 +3,16 @@ import type { IndexedContentDocument, PageCollectionItemBase } from '../types'
 export type QueryOperator = '=' | '<>' | 'LIKE' | 'IS NULL'
 export type QueryDirection = 'ASC' | 'DESC'
 
-export type QueryOperation =
-  | { _tag: 'Path', value: string }
-  | { _tag: 'Where', field: string, operator: QueryOperator, value?: unknown }
-  | { _tag: 'Order', field: string, direction: QueryDirection }
-  | { _tag: 'Limit', value: number }
-  | { _tag: 'Select', fields: string[] }
+export type QueryOperation
+  = | { _tag: 'Path', value: string }
+    | { _tag: 'Where', field: string, operator: QueryOperator, value?: unknown }
+    | { _tag: 'Order', field: string, direction: QueryDirection }
+    | { _tag: 'Limit', value: number }
+    | { _tag: 'Select', fields: string[] }
 
-export type QueryPlan = { operations: QueryOperation[] }
+export interface QueryPlan { operations: QueryOperation[] }
 
-export type CollectionQuery<TItem extends Record<string, unknown>> = {
+export interface CollectionQuery<TItem extends Record<string, unknown>> {
   path: (path: string) => CollectionQuery<TItem>
   where: (field: string, operator: QueryOperator, value?: unknown) => CollectionQuery<TItem>
   order: (field: string, direction?: QueryDirection) => CollectionQuery<TItem>
@@ -26,7 +26,7 @@ const fieldValue = (item: Record<string, unknown>, field: string) => field.split
 
 const likePattern = (value: unknown) => new RegExp(`^${String(value).replaceAll(/[|\\{}()[\]^$+?.]/g, '\\$&').replaceAll('%', '.*').replaceAll('_', '.')}$`, 'i')
 
-const matches = (item: Record<string, unknown>, operation: Extract<QueryOperation, { _tag: 'Where' }>) => {
+function matches(item: Record<string, unknown>, operation: Extract<QueryOperation, { _tag: 'Where' }>) {
   const value = fieldValue(item, operation.field)
   if (operation.operator === '=')
     return value === operation.value
@@ -37,7 +37,7 @@ const matches = (item: Record<string, unknown>, operation: Extract<QueryOperatio
   return likePattern(operation.value).test(String(value ?? ''))
 }
 
-const compare = (left: unknown, right: unknown) => {
+function compare(left: unknown, right: unknown) {
   if (left === right)
     return 0
   if (left === null || left === undefined)
@@ -49,7 +49,7 @@ const compare = (left: unknown, right: unknown) => {
     : String(left).localeCompare(String(right))
 }
 
-export const executeQueryPlan = <TItem extends Record<string, unknown>>(items: TItem[], plan: QueryPlan): TItem[] => {
+export function executeQueryPlan<TItem extends Record<string, unknown>>(items: TItem[], plan: QueryPlan): TItem[] {
   let result = [...items]
   const filters = plan.operations.filter((operation): operation is Extract<QueryOperation, { _tag: 'Where' | 'Path' }> => operation._tag === 'Where' || operation._tag === 'Path')
   for (const filter of filters) {
@@ -77,9 +77,7 @@ export const executeQueryPlan = <TItem extends Record<string, unknown>>(items: T
   return result
 }
 
-export const createQueryBuilder = <TItem extends Record<string, unknown>>(
-  execute: (plan: QueryPlan) => Promise<TItem[]>,
-): CollectionQuery<TItem> => {
+export function createQueryBuilder<TItem extends Record<string, unknown>>(execute: (plan: QueryPlan) => Promise<TItem[]>): CollectionQuery<TItem> {
   const operations: QueryOperation[] = []
   const builder: CollectionQuery<TItem> = {
     path(value) {
@@ -110,14 +108,12 @@ export const createQueryBuilder = <TItem extends Record<string, unknown>>(
 
 export const createCollectionQuery = <TItem extends Record<string, unknown>>(items: TItem[]) => createQueryBuilder<TItem>(async plan => executeQueryPlan(items, plan))
 
-const usesBodyForPlanning = (operation: QueryOperation) => (operation._tag === 'Where' || operation._tag === 'Order')
-  && (operation.field === 'body' || operation.field.startsWith('body.'))
+function usesBodyForPlanning(operation: QueryOperation) {
+  return (operation._tag === 'Where' || operation._tag === 'Order')
+    && (operation.field === 'body' || operation.field.startsWith('body.'))
+}
 
-export const executeIndexedQueryPlan = async <TItem extends PageCollectionItemBase>(
-  index: IndexedContentDocument<TItem>[],
-  plan: QueryPlan,
-  loadBody: (bodyAsset: string) => Promise<TItem['body']>,
-): Promise<TItem[]> => {
+export async function executeIndexedQueryPlan<TItem extends PageCollectionItemBase>(index: IndexedContentDocument<TItem>[], plan: QueryPlan, loadBody: (bodyAsset: string) => Promise<TItem['body']>): Promise<TItem[]> {
   if (plan.operations.some(usesBodyForPlanning))
     throw new TypeError('<request>:1:1 Markdown body fields cannot filter or order a collection query.')
   const select = plan.operations.findLast((operation): operation is Extract<QueryOperation, { _tag: 'Select' }> => operation._tag === 'Select')
@@ -139,7 +135,6 @@ export const executeIndexedQueryPlan = async <TItem extends PageCollectionItemBa
     : hydrated
 }
 
-export const createIndexedCollectionQuery = <TItem extends PageCollectionItemBase>(
-  index: IndexedContentDocument<TItem>[],
-  loadBody: (bodyAsset: string) => Promise<TItem['body']>,
-) => createQueryBuilder<TItem>(plan => executeIndexedQueryPlan(index, plan, loadBody))
+export function createIndexedCollectionQuery<TItem extends PageCollectionItemBase>(index: IndexedContentDocument<TItem>[], loadBody: (bodyAsset: string) => Promise<TItem['body']>) {
+  return createQueryBuilder<TItem>(plan => executeIndexedQueryPlan(index, plan, loadBody))
+}

--- a/packages/comark-content/src/runtime/core/sitemap.ts
+++ b/packages/comark-content/src/runtime/core/sitemap.ts
@@ -1,19 +1,21 @@
 import type { ContentDocumentMetadata } from '../types'
 
-export type ContentSitemapEntry = {
+export interface ContentSitemapEntry {
   loc: string
   lastmod?: string
   [key: string]: unknown
 }
 
-export const createSitemapEntries = (pages: ContentDocumentMetadata[]): ContentSitemapEntry[] => pages.flatMap((page) => {
-  if (page.sitemap === false || page.robots === false)
-    return []
-  const metadata = typeof page.sitemap === 'object' && page.sitemap ? page.sitemap : {}
-  const lastmod = page.updatedAt ?? page.publishedAt
-  return [{
-    loc: page.path,
-    ...(lastmod ? { lastmod: String(lastmod) } : {}),
-    ...metadata,
-  }]
-})
+export function createSitemapEntries(pages: ContentDocumentMetadata[]): ContentSitemapEntry[] {
+  return pages.flatMap((page) => {
+    if (page.sitemap === false || page.robots === false)
+      return []
+    const metadata = typeof page.sitemap === 'object' && page.sitemap ? page.sitemap : {}
+    const lastmod = page.updatedAt ?? page.publishedAt
+    return [{
+      loc: page.path,
+      ...(lastmod ? { lastmod: String(lastmod) } : {}),
+      ...metadata,
+    }]
+  })
+}

--- a/packages/comark-content/src/runtime/server/api/navigation.get.ts
+++ b/packages/comark-content/src/runtime/server/api/navigation.get.ts
@@ -1,8 +1,8 @@
+import { defineEventHandler } from '#imports'
 import { createNavigation } from '../../core/navigation'
 import { parseNavigationRequest } from '../../shared/protocol'
 import { sendCacheableContent } from '../cache'
 import { loadNavigationCollection } from '../storage'
-import { defineEventHandler } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const node = event.node

--- a/packages/comark-content/src/runtime/server/api/query.post.ts
+++ b/packages/comark-content/src/runtime/server/api/query.post.ts
@@ -1,7 +1,7 @@
+import { defineEventHandler, readBody } from '#imports'
 import { executeIndexedQueryPlan } from '../../core/query'
 import { parseQueryRequest } from '../../shared/protocol'
 import { loadCollectionIndex, loadDocumentBody } from '../storage'
-import { defineEventHandler, readBody } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const request = parseQueryRequest(await readBody(event))

--- a/packages/comark-content/src/runtime/server/api/search.get.ts
+++ b/packages/comark-content/src/runtime/server/api/search.get.ts
@@ -1,7 +1,7 @@
+import { defineEventHandler } from '#imports'
 import { parseSearchRequest } from '../../shared/protocol'
 import { sendCacheableContent } from '../cache'
 import { loadSearchSections } from '../storage'
-import { defineEventHandler } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const request = parseSearchRequest(event.context.params?.collection)

--- a/packages/comark-content/src/runtime/server/api/surroundings.get.ts
+++ b/packages/comark-content/src/runtime/server/api/surroundings.get.ts
@@ -1,8 +1,8 @@
+import { defineEventHandler } from '#imports'
 import { createSurroundings } from '../../core/navigation'
 import { parseSurroundingsRequest } from '../../shared/protocol'
 import { sendCacheableContent } from '../cache'
 import { loadNavigationCollection } from '../storage'
-import { defineEventHandler } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const node = event.node

--- a/packages/comark-content/src/runtime/server/asset.ts
+++ b/packages/comark-content/src/runtime/server/asset.ts
@@ -1,9 +1,7 @@
-export const decodeCollectionAsset = <T>(value: Uint8Array, collection: string): Promise<T> => {
+export function decodeCollectionAsset<T>(value: Uint8Array, collection: string): Promise<T> {
   const source = Uint8Array.from(value).buffer
   const stream = new Blob([source]).stream().pipeThrough(new DecompressionStream('gzip'))
-  return new Response(stream).text()
-    .then(text => JSON.parse(text) as T)
-    .catch((cause) => {
-      throw new TypeError(`${collection}.json.gz:1:1 Could not decode the generated collection asset.`, { cause })
-    })
+  return new Response(stream).text().then(text => JSON.parse(text) as T).catch((cause) => {
+    throw new TypeError(`${collection}.json.gz:1:1 Could not decode the generated collection asset.`, { cause })
+  })
 }

--- a/packages/comark-content/src/runtime/server/cache.ts
+++ b/packages/comark-content/src/runtime/server/cache.ts
@@ -1,13 +1,13 @@
 import { createCacheableContentResponse } from '../shared/protocol'
 
-type CacheableEvent = {
+interface CacheableEvent {
   node?: {
     req?: { headers: Record<string, string | string[] | undefined> }
     res?: { statusCode: number, setHeader: (name: string, value: string) => void }
   }
 }
 
-export const sendCacheableContent = <T>(event: CacheableEvent, value: T): T | null => {
+export function sendCacheableContent<T>(event: CacheableEvent, value: T): T | null {
   const node = event.node
   if (!node?.req || !node.res)
     throw new TypeError('<request>:1:1 Expected a Nitro request context.')
@@ -15,6 +15,9 @@ export const sendCacheableContent = <T>(event: CacheableEvent, value: T): T | nu
   const response = createCacheableContentResponse(
     value,
     Array.isArray(header) ? header.join(',') : header,
+    // Keep the bare global. Nitro replaces `process.env.NODE_ENV` at build time, so an
+    // explicit `node:process` import would change what the server bundle resolves to.
+    // eslint-disable-next-line node/prefer-global/process
     process.env.NODE_ENV === 'development' ? { _tag: 'NoStore' } : { _tag: 'Immutable' },
   )
   node.res.statusCode = response.status

--- a/packages/comark-content/src/runtime/server/index.ts
+++ b/packages/comark-content/src/runtime/server/index.ts
@@ -5,19 +5,18 @@ import { loadCollectionIndex, loadDocumentBody, loadNavigationCollection, loadSe
 
 export type { Collections, ContentNavigationItem, ContentSearchSection, PageCollectionItemBase, PageCollections, TocLink } from '../types'
 
-export const queryCollection = <TName extends CollectionName | string>(_event: unknown, collection: TName) => createQueryBuilder<CollectionItem<TName>>(async plan => executeIndexedQueryPlan(
-  await loadCollectionIndex(collection),
-  plan,
-  asset => loadDocumentBody(collection, asset),
-) as Promise<CollectionItem<TName>[]>)
+export function queryCollection<TName extends CollectionName | string>(_event: unknown, collection: TName) {
+  return createQueryBuilder<CollectionItem<TName>>(async plan => executeIndexedQueryPlan(
+    await loadCollectionIndex(collection),
+    plan,
+    asset => loadDocumentBody(collection, asset),
+  ) as Promise<CollectionItem<TName>[]>)
+}
 
 export const queryCollectionNavigation = async <TName extends CollectionName | string>(_event: unknown, collection: TName, fields: string[] = []) => createNavigation(await loadNavigationCollection(collection), fields)
 
-export const queryCollectionItemSurroundings = async <TName extends CollectionName | string>(
-  _event: unknown,
-  collection: TName,
-  path: string,
-  options: { fields?: string[] } = {},
-) => createSurroundings(await loadNavigationCollection(collection), path, options.fields)
+export async function queryCollectionItemSurroundings<TName extends CollectionName | string>(_event: unknown, collection: TName, path: string, options: { fields?: string[] } = {}) {
+  return createSurroundings(await loadNavigationCollection(collection), path, options.fields)
+}
 
 export const queryCollectionSearchSections = async <TName extends CollectionName | string>(_event: unknown, collection: TName) => loadSearchSections(collection)

--- a/packages/comark-content/src/runtime/server/plugins/sitemap.ts
+++ b/packages/comark-content/src/runtime/server/plugins/sitemap.ts
@@ -1,6 +1,6 @@
+import { defineNitroPlugin } from 'nitropack/runtime'
 import { createSitemapEntries } from '../../core/sitemap'
 import { loadCollectionIndex, loadCollectionNames } from '../storage'
-import { defineNitroPlugin } from 'nitropack/runtime'
 
 export default defineNitroPlugin((nitroApp) => {
   const hooks = nitroApp.hooks as typeof nitroApp.hooks & {

--- a/packages/comark-content/src/runtime/server/storage-core.ts
+++ b/packages/comark-content/src/runtime/server/storage-core.ts
@@ -3,15 +3,15 @@ import { decodeCollectionAsset } from './asset'
 
 export type ContentAssetReader = (path: string) => Promise<Uint8Array | null | undefined>
 
-const collectionName = /^[A-Za-z][A-Za-z0-9_]*$/
+const collectionName = /^[A-Z]\w*$/i
 const bodyAssetName = /^[a-f0-9]{32}\.json\.gz$/
 
-const assertCollectionName = (name: string) => {
+function assertCollectionName(name: string) {
   if (!collectionName.test(name))
     throw new TypeError(`<request>:1:1 Invalid collection name "${name}".`)
 }
 
-export const createContentStorage = (readAsset: ContentAssetReader) => {
+export function createContentStorage(readAsset: ContentAssetReader) {
   const loadAsset = async <T>(path: string, missingMessage: string): Promise<T> => {
     const value = await readAsset(`${path}.json.gz`)
     if (!value)

--- a/packages/comark-content/src/runtime/shared/protocol.ts
+++ b/packages/comark-content/src/runtime/shared/protocol.ts
@@ -1,14 +1,13 @@
-import type { QueryPlan, QueryOperation } from '../core/query'
+import type { QueryOperation, QueryPlan } from '../core/query'
 
-export type QueryRequest =
-  { _tag: 'Query', collection: string, plan: QueryPlan }
+export interface QueryRequest { _tag: 'Query', collection: string, plan: QueryPlan }
 
-export type NavigationRequest = {
+export interface NavigationRequest {
   collection: string
   fields: string[]
 }
 
-export type SearchRequest = {
+export interface SearchRequest {
   collection: string
 }
 
@@ -16,27 +15,27 @@ export type SurroundingsRequest = NavigationRequest & {
   path: string
 }
 
-export type CacheableContentResponse<T> =
-  | { _tag: 'Fresh', status: 200, body: T, headers: Record<string, string> }
-  | { _tag: 'NotModified', status: 304, body: null, headers: Record<'cache-control' | 'cloudflare-cdn-cache-control' | 'etag', string> }
+export type CacheableContentResponse<T>
+  = | { _tag: 'Fresh', status: 200, body: T, headers: Record<string, string> }
+    | { _tag: 'NotModified', status: 304, body: null, headers: Record<'cache-control' | 'cloudflare-cdn-cache-control' | 'etag', string> }
 
-export type ContentCachePolicy =
-  | { _tag: 'Immutable' }
-  | { _tag: 'NoStore' }
+export type ContentCachePolicy
+  = | { _tag: 'Immutable' }
+    | { _tag: 'NoStore' }
 
 const operators = new Set(['=', '<>', 'LIKE', 'IS NULL'])
 const directions = new Set(['ASC', 'DESC'])
-const collectionName = /^[A-Za-z][A-Za-z0-9_]*$/
-const fieldName = /^[A-Za-z_][A-Za-z0-9_]*$/
+const collectionName = /^[A-Z]\w*$/i
+const fieldName = /^[A-Z_]\w*$/i
 const forbiddenFields = new Set(['__proto__', 'constructor', 'prototype'])
 
-const parseCollection = (collection: unknown): string => {
+function parseCollection(collection: unknown): string {
   if (typeof collection !== 'string' || collection.length > 128 || !collectionName.test(collection))
     throw new TypeError('<request>:1:1 Expected a valid collection name.')
   return collection
 }
 
-const parseFields = (fields: unknown, subject: string): string[] => {
+function parseFields(fields: unknown, subject: string): string[] {
   if (fields !== undefined && typeof fields !== 'string')
     throw new TypeError(`<request>:1:1 Expected comma-separated ${subject} fields.`)
   const requestedFields = fields ? fields.split(',') : []
@@ -45,19 +44,19 @@ const parseFields = (fields: unknown, subject: string): string[] => {
   return [...new Set(requestedFields)]
 }
 
-export const parseNavigationRequest = (collection: unknown, fields: unknown): NavigationRequest => {
+export function parseNavigationRequest(collection: unknown, fields: unknown): NavigationRequest {
   return { collection: parseCollection(collection), fields: parseFields(fields, 'navigation') }
 }
 
 export const parseSearchRequest = (collection: unknown): SearchRequest => ({ collection: parseCollection(collection) })
 
-export const parseSurroundingsRequest = (collection: unknown, path: unknown, fields: unknown): SurroundingsRequest => {
+export function parseSurroundingsRequest(collection: unknown, path: unknown, fields: unknown): SurroundingsRequest {
   if (typeof path !== 'string' || path.length > 2048 || !path.startsWith('/'))
     throw new TypeError('<request>:1:1 Expected an absolute content path.')
   return { collection: parseCollection(collection), path, fields: parseFields(fields, 'surroundings') }
 }
 
-const createContentEtag = (value: unknown): string => {
+function createContentEtag(value: unknown): string {
   const source = JSON.stringify(value)
   let hash = 0x811C9DC5
   for (let index = 0; index < source.length; index++) {
@@ -67,15 +66,13 @@ const createContentEtag = (value: unknown): string => {
   return `W/"${source.length.toString(36)}-${(hash >>> 0).toString(36)}"`
 }
 
-const matchesContentEtag = (header: string | undefined, etag: string): boolean => header
-  ?.split(',')
-  .some(candidate => candidate.trim() === etag || candidate.trim() === '*') ?? false
+function matchesContentEtag(header: string | undefined, etag: string): boolean {
+  return header
+    ?.split(',')
+    .some(candidate => candidate.trim() === etag || candidate.trim() === '*') ?? false
+}
 
-export const createCacheableContentResponse = <T>(
-  value: T,
-  ifNoneMatch?: string,
-  policy: ContentCachePolicy = { _tag: 'Immutable' },
-): CacheableContentResponse<T> => {
+export function createCacheableContentResponse<T>(value: T, ifNoneMatch?: string, policy: ContentCachePolicy = { _tag: 'Immutable' }): CacheableContentResponse<T> {
   if (policy._tag === 'NoStore') {
     return {
       _tag: 'Fresh',
@@ -98,7 +95,7 @@ export const createCacheableContentResponse = <T>(
     : { _tag: 'Fresh', status: 200, body: value, headers }
 }
 
-const isOperation = (value: unknown): value is QueryOperation => {
+function isOperation(value: unknown): value is QueryOperation {
   if (!value || typeof value !== 'object')
     return false
   const operation = value as Record<string, unknown>
@@ -113,16 +110,17 @@ const isOperation = (value: unknown): value is QueryOperation => {
   return operation._tag === 'Select' && Array.isArray(operation.fields) && operation.fields.every(field => typeof field === 'string')
 }
 
-export const parseQueryRequest = (value: unknown): QueryRequest => {
+export function parseQueryRequest(value: unknown): QueryRequest {
   if (!value || typeof value !== 'object')
     throw new TypeError('<request>:1:1 Expected a comark-content query object.')
   const request = value as Record<string, unknown>
   const collection = parseCollection(request.collection)
   if (request._tag === 'Query') {
     const plan = request.plan as Record<string, unknown> | undefined
-    if (!Array.isArray(plan?.operations) || !plan.operations.every(isOperation))
+    const operations = plan?.operations
+    if (!Array.isArray(operations) || !operations.every(isOperation))
       throw new TypeError('<request>:1:1 Expected valid query operations.')
-    return { _tag: 'Query', collection, plan: plan as QueryPlan }
+    return { _tag: 'Query', collection, plan: { operations } }
   }
   throw new TypeError('<request>:1:1 Unsupported comark-content query.')
 }

--- a/packages/comark-content/src/runtime/types.ts
+++ b/packages/comark-content/src/runtime/types.ts
@@ -51,12 +51,12 @@ export interface ContentDocumentMetadata {
   [key: string]: unknown
 }
 
-export type IndexedContentDocument<TItem extends PageCollectionItemBase = PageCollectionItemBase> = {
+export interface IndexedContentDocument<TItem extends PageCollectionItemBase = PageCollectionItemBase> {
   metadata: ContentDocumentMetadata & Omit<TItem, 'body'>
   bodyAsset: string
 }
 
-export type NavigationCollectionItem = {
+export interface NavigationCollectionItem {
   path: string
   stem: string
   title: string
@@ -88,7 +88,7 @@ export interface ContentSearchSection {
   level: number
 }
 
-export type SourceLocation = {
+export interface SourceLocation {
   source: string
   line: number
   column: number
@@ -100,6 +100,6 @@ export type ContentError = SourceLocation & {
   cause?: unknown
 }
 
-export type Result<T, E = ContentError> =
-  | { _tag: 'Ok', value: T }
-  | { _tag: 'Err', error: E }
+export type Result<T, E = ContentError>
+  = | { _tag: 'Ok', value: T }
+    | { _tag: 'Err', error: E }

--- a/packages/comark-content/src/sitemap.ts
+++ b/packages/comark-content/src/sitemap.ts
@@ -5,7 +5,7 @@ interface SitemapOptions {
 
 const NUXT_CONTENT_SOURCE = '@nuxt/content@v3:urls'
 
-export const excludeNuxtContentSitemapSource = (options: SitemapOptions | undefined): SitemapOptions => {
+export function excludeNuxtContentSitemapSource(options: SitemapOptions | undefined): SitemapOptions {
   if (options?.excludeAppSources === true)
     return options
   const excluded = options?.excludeAppSources ?? []

--- a/packages/comark-content/test/fixtures.ts
+++ b/packages/comark-content/test/fixtures.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-export const writeFixture = async (root: string, path: string, source: string) => {
+export async function writeFixture(root: string, path: string, source: string) {
   const target = join(root, path)
   await mkdir(join(target, '..'), { recursive: true })
   await writeFile(target, source)

--- a/packages/comark-content/test/ingest.test.ts
+++ b/packages/comark-content/test/ingest.test.ts
@@ -1,15 +1,15 @@
+import type { MarkdownDocument } from 'comark'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { MarkdownDocument } from 'comark'
 import { defineCollection } from '../src/config'
 import { createContentParser, ingestCollections } from '../src/core/ingest'
 import { writeFixture } from './fixtures'
 
 const temporaryRoots: string[] = []
 
-const temporaryRoot = async () => {
+async function temporaryRoot() {
   const root = await mkdtemp(join(tmpdir(), 'comark-content-ingest-'))
   temporaryRoots.push(root)
   return root
@@ -19,7 +19,7 @@ afterEach(async () => {
   await Promise.all(temporaryRoots.splice(0).map(root => rm(root, { recursive: true, force: true })))
 })
 
-describe('Markdown ingestion', () => {
+describe('markdown ingestion', () => {
   it('highlights fenced code when requested', async () => {
     const parse = await createContentParser({ highlight: true })
     const document = await parse('```ts{1} [app.ts]\nconst ready = true\n```')
@@ -54,13 +54,7 @@ describe('Markdown ingestion', () => {
     expect(document.nodes[0]).toMatchObject([
       'pre',
       expect.any(Object),
-      ['code', expect.any(Object), ['span', expect.any(Object),
-        ['span', { style: '--shiki-light:#cf222e;--shiki-default:#cf222e;color:#cf222e;--shiki-dark:#ff7b72' }, 'const'],
-        expect.any(String),
-        expect.any(Array),
-        expect.any(String),
-        expect.any(Array),
-      ]],
+      ['code', expect.any(Object), ['span', expect.any(Object), ['span', { style: '--shiki-light:#cf222e;--shiki-default:#cf222e;color:#cf222e;--shiki-dark:#ff7b72' }, 'const'], expect.any(String), expect.any(Array), expect.any(String), expect.any(Array)]],
     ])
   })
 
@@ -97,10 +91,12 @@ describe('Markdown ingestion', () => {
       'pre',
       { class: expect.stringContaining('shj-lang-dotenv') },
       ['code', expect.any(Object), [
-        'span', expect.any(Object),
+        'span',
+        expect.any(Object),
         ['span', { class: expect.stringContaining('shj-cmnt') }, '# Keep escaped newlines'],
       ], expect.any(String), [
-        'span', expect.any(Object),
+        'span',
+        expect.any(Object),
         ['span', { class: expect.stringContaining('shj-var') }, 'GOOGLE_PRIVATE_KEY'],
         ['span', { class: expect.stringContaining('shj-oper') }, '='],
         ['span', { class: expect.stringContaining('shj-str') }, '"-----BEGIN PRIVATE KEY-----\\nMIIEvQ...\\n-----END PRIVATE KEY-----\\n"'],
@@ -110,13 +106,15 @@ describe('Markdown ingestion', () => {
       'pre',
       { class: expect.stringContaining('shj-lang-robots.txt') },
       ['code', expect.any(Object), [
-        'span', expect.any(Object),
+        'span',
+        expect.any(Object),
         ['span', { class: expect.stringContaining('shj-kwd') }, 'User-agent'],
         ['span', { class: expect.stringContaining('shj-oper') }, ':'],
         ['span', { class: expect.stringContaining('shj-str') }, ' '],
         ['span', { class: expect.stringContaining('shj-oper') }, '*'],
       ], expect.any(String), [
-        'span', expect.any(Object),
+        'span',
+        expect.any(Object),
         ['span', { class: expect.stringContaining('shj-kwd') }, 'Disallow'],
         ['span', { class: expect.stringContaining('shj-oper') }, ':'],
         ['span', { class: expect.stringContaining('shj-str') }, ' /private/'],
@@ -138,14 +136,7 @@ describe('Markdown ingestion', () => {
     expect(result.value.collections.pages?.[0]?.body.nodes[0]).toMatchObject([
       'pre',
       { class: expect.stringContaining('rangi') },
-      ['code', { class: 'language-csharp' }, ['span', expect.any(Object),
-        ['span', { class: expect.stringContaining('shj-kwd') }, 'var'],
-        expect.any(String),
-        expect.any(Array),
-        expect.any(String),
-        expect.any(Array),
-        expect.any(String),
-      ]],
+      ['code', { class: 'language-csharp' }, ['span', expect.any(Object), ['span', { class: expect.stringContaining('shj-kwd') }, 'var'], expect.any(String), expect.any(Array), expect.any(String), expect.any(Array), expect.any(String)]],
     ])
   })
 

--- a/packages/comark-content/test/navigation.test.ts
+++ b/packages/comark-content/test/navigation.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PageCollectionItemBase } from '../src/runtime/types'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { queryCollectionItemSurroundings, queryCollectionNavigation, queryCollectionSearchSections } from '../src/runtime/client'
 import { createNavigation, createNavigationSource, createSearchSections, createSurroundings } from '../src/runtime/core/navigation'
 import { createSitemapEntries } from '../src/runtime/core/sitemap'

--- a/packages/comark-content/test/options.test.ts
+++ b/packages/comark-content/test/options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { assertCloudflareCacheModule, assertSupportedOptions, defineCollection } from '../src/config'
 import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtUiProseComponents, selectContentComponents } from '../src/components'
+import { assertCloudflareCacheModule, assertSupportedOptions, defineCollection } from '../src/config'
 
 describe('configuration boundary', () => {
   it('finds unprefixed content component directories in layer priority order', () => {

--- a/packages/comark-content/test/remote.test.ts
+++ b/packages/comark-content/test/remote.test.ts
@@ -10,7 +10,7 @@ import { writeFixture } from './fixtures'
 const exec = promisify(execFile)
 const temporaryRoots: string[] = []
 
-const temporaryRoot = async () => {
+async function temporaryRoot() {
   const root = await mkdtemp(join(tmpdir(), 'comark-content-remote-'))
   temporaryRoots.push(root)
   return root

--- a/packages/comark-content/test/renderer.test.ts
+++ b/packages/comark-content/test/renderer.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest'
 import type { Node } from 'comark'
 import type { VNode } from 'vue'
+import { describe, expect, it } from 'vitest'
 import { componentCandidates, componentMatchesTag } from '../src/runtime/components/names'
 import { renderContentRoot, renderNodes } from '../src/runtime/components/render'
 
-describe('Comark rendering', () => {
+describe('comark rendering', () => {
   it('renders direct nodes and removes internal source attributes', () => {
     const nodes: Node[] = [['p', { class: 'lead', $: { line: 4 } }, 'Hello ', ['strong', {}, 'world']]]
     const rendered = renderNodes(nodes, { source: '/content/page.md' })
@@ -82,7 +82,7 @@ describe('Comark rendering', () => {
 
   it('preserves static HTML attributes when Comark marks them as bound', () => {
     const proseLink = { name: 'ProseA' }
-    const node: Node = ['a', { href: 'https://example.com', ':target': '_blank' }, 'Example']
+    const node: Node = ['a', { 'href': 'https://example.com', ':target': '_blank' }, 'Example']
     const [rendered] = renderNodes([node], { source: '/content/page.md', resolveTag: () => proseLink }) as VNode[]
 
     expect(rendered?.props).toMatchObject({ href: 'https://example.com', target: '_blank' })
@@ -93,7 +93,7 @@ describe('Comark rendering', () => {
     const node: Node = ['study-iceberg', { 'ui-rows': '1000', 'hidden-pct': '27.5', 'compact': 'true', 'label': 'Rows' }]
     const [rendered] = renderNodes([node], { source: '/content/page.md', resolveTag: () => widget }) as VNode[]
 
-    expect(rendered?.props).toMatchObject({ 'ui-rows': 1000, 'hidden-pct': 27.5, compact: true, label: 'Rows' })
+    expect(rendered?.props).toMatchObject({ 'ui-rows': 1000, 'hidden-pct': 27.5, 'compact': true, 'label': 'Rows' })
   })
 
   it('renders an inline head reference as text', () => {

--- a/packages/comark-content/test/storage.test.ts
+++ b/packages/comark-content/test/storage.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import type { PageCollectionItemBase } from '../src/runtime/types'
+import { describe, expect, it } from 'vitest'
 import { createContentAssetPlan, createContentRevision, encodeCollectionAsset } from '../src/core/asset'
 import { createIndexedCollectionQuery } from '../src/runtime/core/query'
 import { decodeCollectionAsset } from '../src/runtime/server/asset'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ catalogs:
     pino:
       specifier: ^10.3.1
       version: 10.3.1
+    rangi:
+      specifier: ^2.2.0
+      version: 2.2.0
     rollup:
       specifier: ^4.62.4
       version: 4.62.4
@@ -137,15 +140,21 @@ importers:
         specifier: 'catalog:'
         version: 0.6.2(rangi@2.2.0)
       rangi:
-        specifier: ^2.2.0
+        specifier: 'catalog:'
         version: 2.2.0
     devDependencies:
+      '@antfu/eslint-config':
+        specifier: 'catalog:'
+        version: 9.3.0(@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3))(@typescript-eslint/utils@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.1(jiti@2.7.0)
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   nuxt: ^4.5.2
   pathe: ^2.0.3
   pino: ^10.3.1
+  rangi: ^2.2.0
   rollup: ^4.62.4
   typescript: ^5.9.3
   unbuild: ^3.6.1


### PR DESCRIPTION
### Description

`packages/comark-content` had no `eslint.config.mjs` and no `lint` script, so the root `pnpm -r --if-present run lint` walked straight past it. Adding both puts it in line with the other seven packages and turns up 320 violations, 267 of which `--fix` handled.

The config matches `nuxt-wide-events`: `type: 'lib'` with `no-console`, `no-use-before-define` and `ts/explicit-function-return-type` off.

Two things needed real changes rather than reformatting:

- `src/core/cache.ts` and `src/core/remote.ts` now `import process from 'node:process'`, and both bench runners import `Buffer` from `node:buffer`. That is what the sibling bench and CLI scripts already do, so no rule disable was needed.
- `ts/consistent-type-definitions` turned `type QueryPlan` into `interface QueryPlan` in `src/runtime/core/query.ts`. Interfaces do not get the implicit index signature a type alias gets, so `plan as QueryPlan` in `parseQueryRequest` stopped compiling. Rather than cast twice, the parser now builds `{ operations }` from the array it just validated. Only `plan.operations` is read downstream, so nothing else sees a difference, and it drops an unsound cast on untrusted request input.

### Additional context

Three things left with scoped disables instead of fixes:

- `src/runtime/server/cache.ts` keeps the bare `process.env.NODE_ENV`. Nitro substitutes that expression at build time, and an explicit `node:process` import would change what the server bundle resolves to, which would move the dev vs prod cache-header branch.
- `bench/run.mjs` rethrows from inside a `finally`, which discards whatever the `try` threw and skips the close wait below it. That reads like a real bug, but fixing it changes how the bench tears down its worker, so it is only flagged.
- The ANSI strip regex in both bench runners needs the ESC control character and those exact byte ranges, so `no-control-regex` and `regexp/no-obscure-range` are off for that one line.

`bench/site-harlanzw/browser-sample.js` is ignored outright. It is a template read as text and evaluated inside a browser automation harness, with `__SAMPLE__` placeholders and injected `browser` and `saveScreenshot` globals, so it never parses as standalone JS.

The pnpm catalog rule also moved `rangi` out of the package and into the root catalog, which is why `pnpm-workspace.yaml` and the lockfile move.

Question: worth adding `test:attw` here too? Every other package has it and this one does not, but that felt like a separate change.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).