### PR TITLE
fix(nuxt-dx): make the size budget a report, not a gate

### DIFF
--- a/packages/nuxt-dx/src/cli/index.ts
+++ b/packages/nuxt-dx/src/cli/index.ts
@@ -36,6 +36,33 @@ async function readSnapshot(path: string): Promise<SizeBudgetSnapshot> {
   return parseSnapshot(source, path)
 }
 
+/**
+ * A baseline is usable, absent, or unreadable, and the last two are the same answer to the
+ * only question the caller asks: is there anything to compare against. Kept apart so the
+ * summary can say which one happened.
+ */
+type Baseline
+  = | { _tag: 'usable', snapshot: SizeBudgetSnapshot }
+    | { _tag: 'absent' }
+    | { _tag: 'unusable', reason: string }
+
+/**
+ * An unreadable baseline is a fact about the baseline, not about the build being checked.
+ * Truncated artifacts and reports written in an older format both land here, and a run that
+ * fails on either can never replace the baseline that broke it, so the branch stays stuck.
+ */
+async function readBaseline(path: string): Promise<Baseline> {
+  const source = await readSource(path)
+  if (source === undefined)
+    return { _tag: 'absent' }
+  try {
+    return { _tag: 'usable', snapshot: parseSnapshot(source, path) }
+  }
+  catch (error) {
+    return { _tag: 'unusable', reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
 function thresholdBytes(raw: string): number {
   const kilobytes = Number(raw)
   if (!Number.isFinite(kilobytes) || kilobytes < 0)
@@ -52,20 +79,22 @@ const compare = defineCommand({
     'base': { type: 'positional', description: 'Report from the build you are comparing against', required: true },
     'head': { type: 'positional', description: 'Report from the build you are checking', required: true },
     'threshold-kb': { type: 'string', description: 'Growth allowed for a single target, never cumulative, before this fails', default: String(DEFAULT_THRESHOLD_KB) },
-    'allow-missing-base': { type: 'boolean', description: 'Report that there is no baseline and pass, instead of failing', default: false },
+    'allow-missing-base': { type: 'boolean', description: 'Report that there is no baseline to compare against and pass, instead of failing. Covers a baseline that is absent, truncated, or written in a format this CLI cannot read', default: false },
   },
   async run({ args }) {
     try {
       const threshold = thresholdBytes(args['threshold-kb'])
-      const baseSource = await readSource(args.base)
-      if (baseSource === undefined && args['allow-missing-base']) {
-        process.stdout.write(`${formatMissingBaselineMarkdown(args.base)}\n`)
-        process.stderr.write(`${colors.yellow(`… no baseline report at ${args.base}, nothing compared`)}\n`)
+      const baseline = await readBaseline(args.base)
+      if (baseline._tag !== 'usable') {
+        const reason = baseline._tag === 'unusable' ? baseline.reason : undefined
+        if (!args['allow-missing-base']) {
+          throw new Error(`${reason ?? `No report at ${args.base}.`} Pass --allow-missing-base to treat a baseline you cannot compare against as a pass.`)
+        }
+        process.stdout.write(`${formatMissingBaselineMarkdown(args.base, reason)}\n`)
+        process.stderr.write(`${colors.yellow(`… ${reason ?? `no baseline report at ${args.base}`}, nothing compared`)}\n`)
         return
       }
-      if (baseSource === undefined)
-        throw new Error(`No report at ${args.base}. Pass --allow-missing-base to treat a missing baseline as a pass.`)
-      const diff = diffSnapshots(parseSnapshot(baseSource, args.base), await readSnapshot(args.head), threshold)
+      const diff = diffSnapshots(baseline.snapshot, await readSnapshot(args.head), threshold)
       // Markdown on stdout so it can be redirected straight into a step summary,
       // the verdict on stderr so a local run still reads as a pass or a fail.
       process.stdout.write(`${formatDiffMarkdown(diff)}\n`)

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -111,6 +111,17 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
   }
 }
 
+/**
+ * What paths in the report are relative to. The workspace root rather than the app root,
+ * because a monorepo app registers plugins and middleware from sibling layers and workspace
+ * packages that sit above it: relative to the app those stay absolute, and a report full of
+ * absolute paths only ever compares against a build on the same machine at the same prefix.
+ * Nuxt falls `workspaceDir` back to `rootDir` for a standalone app, where the two agree.
+ */
+function reportBaseDir(nuxt: Nuxt): string {
+  return nuxt.options.workspaceDir || nuxt.options.rootDir
+}
+
 async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefined> {
   const virtual = nuxt.vfs[src]
   if (virtual !== undefined)
@@ -143,7 +154,7 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
     if (!over.length)
       return
 
-    const report = formatBudgetReport(scope, over, nuxt.options.rootDir)
+    const report = formatBudgetReport(scope, over, reportBaseDir(nuxt))
     if (budgets.fail)
       throw new Error(`[nuxt-dx] ${report}`)
     logger.warn(report)
@@ -200,7 +211,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
 
   const writeSnapshot = reportPath === undefined
     ? undefined
-    : createSnapshotWriter(resolve(nuxt.options.rootDir, reportPath), nuxt.options.rootDir)
+    : createSnapshotWriter(resolve(nuxt.options.rootDir, reportPath), reportBaseDir(nuxt))
   /**
    * Every measurement is recorded, then judged. The report covers the whole build so
    * a later run can diff it, and it is written before the verdict so a failing budget

--- a/packages/nuxt-dx/src/size-budget/diff-report.ts
+++ b/packages/nuxt-dx/src/size-budget/diff-report.ts
@@ -45,14 +45,17 @@ function verdict(diff: SnapshotDiff): string {
 }
 
 /**
- * Nothing to compare against, which is the normal state of the first run on a branch and
- * of a branch whose baseline artifact has expired. Said out loud rather than passed over.
+ * Nothing to compare against, which is the normal state of the first run on a branch,
+ * of a branch whose baseline artifact has expired, and of the first run after the report
+ * format changed. Said out loud rather than passed over.
  */
-export function formatMissingBaselineMarkdown(path: string): string {
+export function formatMissingBaselineMarkdown(path: string, reason?: string): string {
   return [
     '### Bundle size budget',
     '',
-    `No baseline report was found at \`${path}\`, so there is nothing to compare this build against.`,
+    reason === undefined
+      ? `No baseline report was found at \`${path}\`, so there is nothing to compare this build against.`
+      : `The baseline report at \`${path}\` cannot be read, so there is nothing to compare this build against. ${reason}`,
     '',
     'This run leaves its own report behind, which the next one can measure against.',
   ].join('\n')

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -5,37 +5,47 @@ import { colors, formatTree } from 'consola/utils'
 import { SCOPE } from './scope'
 import { formatBytes } from './size'
 
-/** Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a warning. */
-export function displayId(id: string, rootDir: string): string {
+/**
+ * Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a
+ * warning, and an absolute path pins a report to the machine that wrote it.
+ *
+ * `baseDir` is the workspace root, not the app root, because a monorepo app registers
+ * runtime entries from sibling layers and workspace packages that sit above it. Stripping
+ * only the app root leaves those entries absolute, and two checkouts at different prefixes
+ * then pair with nothing: every entry reads as added, every baseline entry as removed.
+ * Anything outside the workspace keeps its absolute path, which is honest about being
+ * machine-specific and stays a substring of the path an override fragment matches against.
+ */
+export function displayId(id: string, baseDir: string): string {
   const normalized = id.replace(/\\/g, '/').replace(/^\0/, '').split('?')[0]!
-  const root = `${rootDir.replace(/\\/g, '/').replace(/\/$/, '')}/`
-  const relative = normalized.startsWith(root) ? normalized.slice(root.length) : normalized
+  const base = `${baseDir.replace(/\\/g, '/').replace(/\/$/, '')}/`
+  const relative = normalized.startsWith(base) ? normalized.slice(base.length) : normalized
   const fromPackages = relative.lastIndexOf('node_modules/')
   return fromPackages === -1 ? relative : relative.slice(fromPackages + 'node_modules/'.length)
 }
 
 /** The key that would widen this budget: the name when there is one, otherwise the file. */
-function overrideKey(verdict: BudgetVerdict, rootDir: string): string {
-  return verdict.name ?? displayId(verdict.path, rootDir)
+function overrideKey(verdict: BudgetVerdict, baseDir: string): string {
+  return verdict.name ?? displayId(verdict.path, baseDir)
 }
 
-function overrideSnippet(over: readonly BudgetVerdict[], rootDir: string): string {
+function overrideSnippet(over: readonly BudgetVerdict[], baseDir: string): string {
   const entries = over.map((verdict) => {
     // Round up to the next whole kB so the suggested budget actually clears the current size.
     const kilobytes = Math.ceil(verdict.measurement.totalBytes / 1024)
-    return `'${overrideKey(verdict, rootDir)}': ${kilobytes}`
+    return `'${overrideKey(verdict, baseDir)}': ${kilobytes}`
   })
   return `nuxtDx.sizeBudget.overridesKb = { ${entries.join(', ')} }`
 }
 
 /** Every byte charged to the target, so the listed sizes always sum to the reported total. */
-function breakdown(scope: BudgetScope, verdict: BudgetVerdict, rootDir: string): TreeItem[] {
+function breakdown(scope: BudgetScope, verdict: BudgetVerdict, baseDir: string): TreeItem[] {
   const { ownBytes, exclusiveBytes, exclusiveCount, heaviestDependencies } = verdict.measurement
   const rows: { bytes: number, label: string, muted: boolean }[] = [
     { bytes: ownBytes, label: SCOPE[scope].own, muted: true },
     ...heaviestDependencies.map(dependency => ({
       bytes: dependency.bytes,
-      label: displayId(dependency.id, rootDir),
+      label: displayId(dependency.id, baseDir),
       muted: false,
     })),
   ]
@@ -53,27 +63,27 @@ function breakdown(scope: BudgetScope, verdict: BudgetVerdict, rootDir: string):
   }))
 }
 
-export function formatBudgetReport(scope: BudgetScope, over: readonly BudgetVerdict[], rootDir: string): string {
+export function formatBudgetReport(scope: BudgetScope, over: readonly BudgetVerdict[], baseDir: string): string {
   const { noun, plural, bundle } = SCOPE[scope]
   const lines = [`${over.length} ${over.length === 1 ? noun : plural} over budget in the ${bundle} bundle`]
 
   for (const verdict of over) {
     const { name, owner, path, budgetBytes, measurement } = verdict
-    const file = displayId(path, rootDir)
+    const file = displayId(path, baseDir)
     const overshoot = formatBytes(measurement.totalBytes - budgetBytes)
     const label = name && name !== file ? `${colors.bold(name)}  ${colors.dim(file)}` : colors.bold(name ?? file)
     lines.push(
       '',
       `  ${label}${owner === undefined ? '' : colors.dim(`  Nuxt module: ${owner}`)}`,
       `  ${formatBytes(measurement.totalBytes)} bundled, ${colors.red(`${overshoot} over`)} the ${formatBytes(budgetBytes)} budget`,
-      formatTree(breakdown(scope, verdict, rootDir), { prefix: '    ' }).trimEnd(),
+      formatTree(breakdown(scope, verdict, baseDir), { prefix: '    ' }).trimEnd(),
     )
   }
 
   lines.push(
     '',
     colors.dim('  Defer heavy imports with `await import()`, or allow the size:'),
-    `    ${colors.cyan(overrideSnippet(over, rootDir))}`,
+    `    ${colors.cyan(overrideSnippet(over, baseDir))}`,
   )
   return lines.join('\n')
 }

--- a/packages/nuxt-dx/src/size-budget/snapshot.ts
+++ b/packages/nuxt-dx/src/size-budget/snapshot.ts
@@ -5,8 +5,12 @@ import { dirname } from 'node:path'
 import { displayId } from './report'
 import { isBudgetScope } from './scope'
 
-/** Bumped whenever the shape changes, so `compare` refuses a report it cannot read. */
-export const SNAPSHOT_VERSION = 2
+/**
+ * Bumped whenever the shape changes, so `compare` refuses a report it cannot read.
+ * Format 3 keys entries by a workspace-relative path, where format 2 left every entry
+ * above the app root absolute and so machine-specific.
+ */
+export const SNAPSHOT_VERSION = 3
 
 /**
  * Where the report lands, relative to the app root. Not `nuxt.options.buildDir`: that
@@ -33,7 +37,7 @@ export interface SnapshotEntry {
   name?: string
   /** Nuxt module that registered this runtime entry, when known. */
   owner?: string
-  /** Root-relative file or package path, so two checkouts of the same repo agree. */
+  /** Workspace-relative file or package path, so two checkouts of the same repo agree. */
   path: string
   /** Bytes of the target's own bundled files. */
   ownBytes: number
@@ -52,13 +56,13 @@ export function entryKey(entry: Pick<SnapshotEntry, 'scope' | 'name' | 'path'>):
   return `${entry.scope}:${entry.name ?? entry.path}`
 }
 
-function toEntry(scope: BudgetScope, target: MeasuredTarget, rootDir: string): SnapshotEntry {
+function toEntry(scope: BudgetScope, target: MeasuredTarget, baseDir: string): SnapshotEntry {
   const { ownBytes, exclusiveBytes, totalBytes } = target.measurement
   return {
     scope,
     ...(target.name === undefined ? {} : { name: target.name }),
     ...(target.owner === undefined ? {} : { owner: target.owner }),
-    path: displayId(target.path, rootDir),
+    path: displayId(target.path, baseDir),
     ownBytes,
     exclusiveBytes,
     totalBytes,
@@ -71,10 +75,10 @@ function toEntry(scope: BudgetScope, target: MeasuredTarget, rootDir: string): S
  * the whole report rather than waiting for a build-wide hook that a failed budget
  * would never reach.
  */
-export function createSnapshotWriter(file: string, rootDir: string) {
+export function createSnapshotWriter(file: string, baseDir: string) {
   const byScope = new Map<BudgetScope, SnapshotEntry[]>()
   return async (scope: BudgetScope, measured: readonly MeasuredTarget[]): Promise<void> => {
-    byScope.set(scope, measured.map(target => toEntry(scope, target, rootDir)))
+    byScope.set(scope, measured.map(target => toEntry(scope, target, baseDir)))
     const entries = [...byScope.values()]
       .flat()
       .sort((a, b) => entryKey(a).localeCompare(entryKey(b)))

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -16,6 +16,31 @@ describe('displayId', () => {
   it('strips rollup virtual prefixes and queries', () => {
     expect(displayId('\0/app/plugins/a.ts?v=1', '/app')).toBe('plugins/a.ts')
   })
+
+  it('shortens a sibling layer file, which sits above the app but inside the workspace', () => {
+    expect(displayId('/repo/layers/saas/app/plugins/a.ts', '/repo')).toBe('layers/saas/app/plugins/a.ts')
+    expect(displayId('/repo/apps/pro/plugins/a.ts', '/repo')).toBe('apps/pro/plugins/a.ts')
+  })
+
+  it('gives two checkouts of the same workspace the same path for every entry', () => {
+    const entries = ['layers/saas/app/plugins/a.ts', 'modules/features/src/runtime/b.ts', 'apps/pro/plugins/c.ts']
+    const hosted = entries.map(entry => displayId(`/home/runner/work/repo/${entry}`, '/home/runner/work/repo'))
+    const selfHosted = entries.map(entry => displayId(`/opt/ci/_work/repo/${entry}`, '/opt/ci/_work/repo'))
+    expect(hosted).toEqual(selfHosted)
+    expect(hosted.every(path => !path.startsWith('/'))).toBe(true)
+  })
+
+  it('keeps a hoisted dependency at its package path', () => {
+    expect(displayId('/repo/node_modules/.pnpm/chart@1/node_modules/chart/dist/index.mjs', '/repo')).toBe('chart/dist/index.mjs')
+  })
+
+  it('leaves a path outside the workspace absolute rather than guessing a way up to it', () => {
+    expect(displayId('/elsewhere/a.ts', '/repo')).toBe('/elsewhere/a.ts')
+  })
+
+  it('leaves a bare specifier alone', () => {
+    expect(displayId('virtual:nuxt/plugins', '/repo')).toBe('virtual:nuxt/plugins')
+  })
 })
 
 const verdict: BudgetVerdict = {

--- a/packages/nuxt-dx/tests/cli-compare.test.ts
+++ b/packages/nuxt-dx/tests/cli-compare.test.ts
@@ -1,0 +1,109 @@
+import type { SizeBudgetSnapshot } from '../src/size-budget/snapshot'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { runCommand } from 'citty'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { main } from '../src/cli/index'
+import { SNAPSHOT_VERSION } from '../src/size-budget/snapshot'
+
+function snapshot(totalBytes: number): SizeBudgetSnapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    entries: [{ scope: 'client', path: 'layers/saas/app/plugins/a.ts', ownBytes: 512, exclusiveBytes: totalBytes - 512, totalBytes }],
+  }
+}
+
+/**
+ * The CLI is only ever run as a process, so what it writes and the code it leaves behind
+ * are the whole contract. Both are captured here rather than asserted on internals.
+ */
+async function compare(args: string[]): Promise<{ code: number, stdout: string, stderr: string }> {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    stdout.push(String(chunk))
+    return true
+  })
+  const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    stderr.push(String(chunk))
+    return true
+  })
+  try {
+    await runCommand(main, { rawArgs: ['compare', ...args] })
+    return { code: process.exitCode ?? 0, stdout: stdout.join(''), stderr: stderr.join('') }
+  }
+  finally {
+    outSpy.mockRestore()
+    errSpy.mockRestore()
+  }
+}
+
+let dir: string
+let base: string
+let head: string
+const originalExitCode = process.exitCode
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'nuxt-dx-cli-'))
+  base = join(dir, 'base.json')
+  head = join(dir, 'head.json')
+  process.exitCode = 0
+})
+
+afterEach(() => {
+  process.exitCode = originalExitCode
+})
+
+describe('nuxt-dx compare', () => {
+  it('fails when one target grew past the threshold', async () => {
+    await writeFile(base, JSON.stringify(snapshot(10_000)))
+    await writeFile(head, JSON.stringify(snapshot(40_000)))
+    const { code, stdout } = await compare([base, head, '--threshold-kb', '10'])
+    expect(code).toBe(1)
+    expect(stdout).toContain('layers/saas/app/plugins/a.ts')
+  })
+
+  it('passes when nothing grew past the threshold', async () => {
+    await writeFile(base, JSON.stringify(snapshot(10_000)))
+    await writeFile(head, JSON.stringify(snapshot(11_000)))
+    expect((await compare([base, head, '--threshold-kb', '10'])).code).toBe(0)
+  })
+
+  it('treats a baseline written in an older format as no baseline, so the next run can replace it', async () => {
+    await writeFile(base, JSON.stringify({ ...snapshot(10_000), version: SNAPSHOT_VERSION - 1 }))
+    await writeFile(head, JSON.stringify(snapshot(400_000)))
+    const { code, stdout } = await compare([base, head, '--allow-missing-base'])
+    expect(code).toBe(0)
+    expect(stdout).toContain('cannot be read')
+    expect(stdout).toContain(`format ${SNAPSHOT_VERSION - 1}`)
+  })
+
+  it('treats a truncated baseline as no baseline', async () => {
+    await writeFile(base, '{"version":3,"entries":[')
+    await writeFile(head, JSON.stringify(snapshot(400_000)))
+    expect((await compare([base, head, '--allow-missing-base'])).code).toBe(0)
+  })
+
+  it('treats an absent baseline as no baseline', async () => {
+    await writeFile(head, JSON.stringify(snapshot(400_000)))
+    const { code, stdout } = await compare([base, head, '--allow-missing-base'])
+    expect(code).toBe(0)
+    expect(stdout).toContain('No baseline report was found')
+  })
+
+  it('refuses an unreadable baseline when it was not told to allow one', async () => {
+    await writeFile(base, JSON.stringify({ ...snapshot(10_000), version: SNAPSHOT_VERSION - 1 }))
+    await writeFile(head, JSON.stringify(snapshot(10_000)))
+    const { code, stderr } = await compare([base, head])
+    expect(code).toBe(2)
+    expect(stderr).toContain('--allow-missing-base')
+  })
+
+  it('fails without comparing when the head report is the unreadable one', async () => {
+    await writeFile(base, JSON.stringify(snapshot(10_000)))
+    await writeFile(head, 'not json')
+    expect((await compare([base, head, '--allow-missing-base'])).code).toBe(2)
+  })
+})


### PR DESCRIPTION
### Description

Two things, both found by the budget check taking down `main` on `nuxtseo.com`.

**It shouldn't have been able to.** The check is a report. It measures against a per-target threshold nobody picked for any particular plugin, using a baseline that is whatever the last green run happened to leave behind. That's useful information and a bad gate, and it spent a day blocking pushes. Growth now warns; `fail-on-breach: true` restores the gate for anyone who wants it. Exit code 2 still fails either way, since that means the two reports were never compared and nothing was checked.

The verdict moved into its own step after the artifact upload, so a breach leaves a summary, a comment and a fresh baseline behind. And the summary posts as one PR comment per app now, replaced in place rather than stacked, because a step summary is three clicks from where the review happens. Callers who can't grant `pull-requests: write` get a `::notice::` and keep the summary.

**Why it fired at all.** The report keys entries by path, and 86 of 103 entries in that build were absolute: `/home/runner/work/repo/layers/saas/app/plugins/…` in the baseline against `/opt/actions-runner/_work/repo/layers/…` in the head, after the workflow moved to a self-hosted runner. Nothing paired, so every entry read as added and every baseline entry as removed, and the diff reported the entire runtime as replaced.

`displayId` only stripped `rootDir`, which for `apps/pro` is the app directory. Everything a monorepo app registers from a sibling layer or workspace package sits above that and stayed absolute, despite the snapshot field claiming to be "root-relative so two checkouts of the same repo agree". Paths are now relative to `nuxt.options.workspaceDir`:

```
- /home/runner/work/repo/layers/saas/app/plugins/rpc-failure-report.client.ts
+ layers/saas/app/plugins/rpc-failure-report.client.ts
```

Anything genuinely outside the workspace stays absolute. That's honest about being machine-specific, and it keeps a suggested `overridesKb` key a substring of the path `budgetFor` matches against, which a `../../` prefix would not be.

Last: `compare --allow-missing-base` now covers a baseline it *cannot read*, not only one that is absent. A run that fails on a truncated artifact or an older-format report can never replace the baseline that failed it, so the branch stays stuck with no way out but deleting the artifact by hand, which is how I unblocked the repo that hit this. That's also the deliberate cost of `SNAPSHOT_VERSION` 2 to 3: first run after upgrading reports no comparable baseline and passes, next run has a format 3 baseline.

### Additional context

Not released here. `main` is on 0.0.6 while npm has 0.0.8, since the 0.0.7 and 0.0.8 release commits are still on `chore/vite-8-release` with the error overlay work. Wants rebasing onto whatever lands first rather than a release commit of its own, and `src/module.ts` is touched by both.

Two things I left alone:

- `budgetFor` still matches override fragments against the absolute path. It works, and it's what keeps the workspace-relative key paste-able, but "fragment of a path we don't show you" is a strange contract.
- `Download the baseline report` is still `continue-on-error: true`, so a genuinely broken artifact download is indistinguishable from a first run. Same shape of bug as the one this PR fixes in the CLI, just in the action, and I didn't want to widen this further.

The comment step is the part I'd look at hardest. It's untested beyond the action's parsed contract, since composite actions don't run outside Actions, and the sticky-comment lookup paginates every comment on the PR to find its own.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
