### PR TITLE
fix(nuxt-dx): make the size budget report, not gate

### DIFF
--- a/.github/actions/nuxt-dx-budget/action.yml
+++ b/.github/actions/nuxt-dx-budget/action.yml
@@ -1,5 +1,5 @@
 name: Nuxt DX size budget
-description: Diff this build's size budget report against the base branch, summarise what moved, and fail when a runtime entry grows past the threshold.
+description: Diff this build's size budget report against the base branch and report what moved, as a step summary and a pull request comment.
 
 inputs:
   report-path:
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: .nuxt/dx/size-budget.json
   threshold-kb:
-    description: Growth allowed for a single target, never cumulative, before this fails.
+    description: Growth a single target may take, never cumulative, before the summary calls it out.
     required: false
     default: '10'
   artifact-name:
@@ -22,8 +22,16 @@ inputs:
     description: Directory the app was built in.
     required: false
     default: .
+  comment:
+    description: 'Post the summary as a pull request comment, replacing this action''s previous one. Needs `pull-requests: write`; skipped with a notice when the token cannot write.'
+    required: false
+    default: 'true'
+  fail-on-breach:
+    description: Fail the job when a target grew past the threshold. Off by default, so growth is reported rather than blocking.
+    required: false
+    default: 'false'
   github-token:
-    description: 'Token used to list workflow runs and download the baseline artifact. Needs `actions: read`.'
+    description: 'Token used to list workflow runs, download the baseline artifact, and comment. Needs `actions: read`, plus `pull-requests: write` to comment.'
     required: false
     default: ${{ github.token }}
 
@@ -65,20 +73,60 @@ runs:
         run-id: ${{ steps.baseline.outputs.run-id }}
         github-token: ${{ inputs.github-token }}
 
+    # The comparison always runs to completion and always publishes. Whether a breach is
+    # allowed to fail the job is decided in the step after this one, so a breach still
+    # leaves a summary, a comment, and a new baseline behind.
     - name: Compare against the baseline
+      id: compare
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         BASE_REPORT: ${{ runner.temp }}/nuxt-dx-baseline/${{ steps.baseline.outputs.report-file }}
         HEAD_REPORT: ${{ inputs.report-path }}
         THRESHOLD_KB: ${{ inputs.threshold-kb }}
+        SUMMARY_FILE: ${{ runner.temp }}/nuxt-dx-summary.md
       run: |
         set -uo pipefail
         npx --no-install nuxt-dx compare "$BASE_REPORT" "$HEAD_REPORT" \
-          --threshold-kb "$THRESHOLD_KB" --allow-missing-base | tee -a "$GITHUB_STEP_SUMMARY"
-        exit "${PIPESTATUS[0]}"
+          --threshold-kb "$THRESHOLD_KB" --allow-missing-base > "$SUMMARY_FILE"
+        code="$?"
+        cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+        cat "$SUMMARY_FILE"
+        echo "exit-code=$code" >> "$GITHUB_OUTPUT"
+        echo "summary-file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
 
-    # Uploaded even when the comparison failed, so the next run on this branch still has
+    # One comment per app, replaced in place, so a ten-push pull request carries the
+    # current numbers rather than ten stale copies of them.
+    - name: Comment the summary on the pull request
+      if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' && steps.compare.outputs.exit-code != '2' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        PR: ${{ github.event.pull_request.number }}
+        MARKER: <!-- nuxt-dx-size-budget:${{ inputs.artifact-name }} -->
+        SUMMARY_FILE: ${{ steps.compare.outputs.summary-file }}
+      run: |
+        set -uo pipefail
+        body="$(printf '%s\n\n%s\n' "$MARKER" "$(cat "$SUMMARY_FILE")")"
+        # `$ENV.MARKER` keeps the marker out of the jq program text, where its `<!-- -->`
+        # and quotes would need escaping through two layers.
+        existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+          --jq 'map(select(.body | startswith($ENV.MARKER))) | .[0].id // empty' 2>/dev/null || true)
+        if [ -n "$existing" ]; then
+          method=PATCH
+          target="repos/$REPO/issues/comments/$existing"
+        else
+          method=POST
+          target="repos/$REPO/issues/$PR/comments"
+        fi
+        if ! gh api -X "$method" "$target" -f body="$body" > /dev/null 2>&1; then
+          # A fork pull request gets a read-only token, and not every caller grants
+          # `pull-requests: write`. The summary is already published either way.
+          echo "::notice::Could not comment on #$PR, so the size budget is in the step summary only. Grant \`pull-requests: write\` to comment."
+        fi
+
+    # Uploaded even when the comparison broke, so the next run on this branch still has
     # something to measure against.
     - name: Keep this report as the next baseline
       if: ${{ !cancelled() }}
@@ -88,3 +136,25 @@ runs:
         path: ${{ inputs.working-directory }}/${{ inputs.report-path }}
         if-no-files-found: error
         retention-days: 30
+
+    # Last, so a failure here never costs the summary, the comment, or the baseline.
+    # Exit code 2 means nothing was compared, which is a broken step rather than a breach
+    # and fails regardless of what this action was asked to do about growth.
+    - name: Apply the verdict
+      shell: bash
+      env:
+        CODE: ${{ steps.compare.outputs.exit-code }}
+        FAIL_ON_BREACH: ${{ inputs.fail-on-breach }}
+      run: |
+        set -uo pipefail
+        if [ "$CODE" = "2" ]; then
+          echo "::error::nuxt-dx compare could not compare the two reports. See the log above."
+          exit 1
+        fi
+        if [ "$CODE" != "0" ] && [ "$FAIL_ON_BREACH" = "true" ]; then
+          echo "::error::A target grew past the threshold. See the size budget summary."
+          exit 1
+        fi
+        if [ "$CODE" != "0" ]; then
+          echo "::warning::A target grew past the threshold. Reporting only, since \`fail-on-breach\` is off."
+        fi

--- a/packages/nuxt-dx/tests/action.test.ts
+++ b/packages/nuxt-dx/tests/action.test.ts
@@ -16,6 +16,7 @@ interface ActionStep {
   'uses'?: string
   'run'?: string
   'if'?: string
+  'env'?: Record<string, string>
   'continue-on-error'?: boolean
 }
 
@@ -92,9 +93,11 @@ describe('nuxt-dx-budget action', () => {
   it('replaces its own pull request comment instead of stacking them', () => {
     const comment = step('Comment the summary on the pull request')
     expect(comment.if).toContain('pull_request')
-    // Keyed by artifact name, so a matrix of apps gets one comment each.
     expect(comment.run).toContain('$ENV.MARKER')
-    expect(source).toContain('MARKER: <!-- nuxt-dx-size-budget:${{ inputs.artifact-name }} -->')
+    // An HTML comment, so readers never see it, keyed by artifact name so a matrix
+    // of apps gets one comment each rather than fighting over one.
+    expect(comment.env!.MARKER).toMatch(/^<!-- nuxt-dx-size-budget:/)
+    expect(comment.env!.MARKER).toContain('inputs.artifact-name')
     expect(comment.run).toContain('PATCH')
   })
 

--- a/packages/nuxt-dx/tests/action.test.ts
+++ b/packages/nuxt-dx/tests/action.test.ts
@@ -65,10 +65,41 @@ describe('nuxt-dx-budget action', () => {
     expect(step('Compare against the baseline').run).toContain('--allow-missing-base')
   })
 
-  it('writes the diff to the step summary and fails on the comparison, not on tee', () => {
-    const run = step('Compare against the baseline').run!
-    expect(run).toContain('"$GITHUB_STEP_SUMMARY"')
-    expect(run).toMatch(/exit "\$\{PIPESTATUS\[0\]\}"/)
+  it('writes the diff to the step summary', () => {
+    expect(step('Compare against the baseline').run).toContain('"$GITHUB_STEP_SUMMARY"')
+  })
+
+  it('reports growth without failing the job unless asked to', () => {
+    expect(action.inputs['fail-on-breach']!.default).toBe('false')
+    // The comparison itself never decides the job's fate, so a breach still leaves a
+    // summary, a comment and a new baseline behind.
+    expect(step('Compare against the baseline').run).not.toMatch(/^\s*exit\b/m)
+    const verdict = step('Apply the verdict').run!
+    expect(verdict).toContain('FAIL_ON_BREACH')
+    expect(verdict).toContain('::warning::')
+  })
+
+  it('still fails when the two reports could not be compared at all', () => {
+    // Exit code 2 is a broken step, not growth, so no input makes it passable.
+    expect(step('Apply the verdict').run).toMatch(/CODE" = "2"[\s\S]*?exit 1/)
+  })
+
+  it('decides the verdict after the baseline is uploaded, so a failure keeps it', () => {
+    const names = action.runs.steps.map(candidate => candidate.name)
+    expect(names.indexOf('Apply the verdict')).toBeGreaterThan(names.indexOf('Keep this report as the next baseline'))
+  })
+
+  it('replaces its own pull request comment instead of stacking them', () => {
+    const comment = step('Comment the summary on the pull request')
+    expect(comment.if).toContain('pull_request')
+    // Keyed by artifact name, so a matrix of apps gets one comment each.
+    expect(comment.run).toContain('$ENV.MARKER')
+    expect(source).toContain('MARKER: <!-- nuxt-dx-size-budget:${{ inputs.artifact-name }} -->')
+    expect(comment.run).toContain('PATCH')
+  })
+
+  it('leaves the summary alone when it cannot comment, rather than failing', () => {
+    expect(step('Comment the summary on the pull request').run).toContain('::notice::')
   })
 
   it('leaves this build\'s report behind even when the comparison failed', () => {


### PR DESCRIPTION
### Description

The size budget check took `main` down on `nuxtseo.com` for a day. #56 fixed the reason it fired. This fixes the reason it was able to block anything.

The check is a report. It measures against a per-target threshold nobody picked for any particular plugin, using a baseline that is whatever the last green run happened to leave behind. That is useful information and a bad gate. Growth now warns:

```
::warning::A target grew past the threshold. Reporting only, since `fail-on-breach` is off.
```

`fail-on-breach: true` restores the old behaviour for anyone who wants the gate. Exit code 2 still fails either way, since that means the two reports were never compared and nothing was checked.

The verdict moved into its own step after the artifact upload, so a breach leaves a summary, a comment and a fresh baseline behind. Previously `exit "${PIPESTATUS[0]}"` sat in the compare step, which is also why a breach and a broken comparison were indistinguishable to the job.

The summary also posts as one pull request comment per app now, replaced in place rather than stacked, keyed by `artifact-name` so a matrix gets one each. A step summary is three clicks from where the review happens. Callers who cannot grant `pull-requests: write` get a `::notice::` and keep the summary.

### Additional context

Split out of #56, which was squash-merged while these two commits were still in flight during yesterday's GitHub write outage, so they never made it into that merge.

The comment step is the part worth looking at hardest. Composite actions do not run outside Actions, so it is covered only by assertions on the parsed action contract, and the sticky-comment lookup paginates every comment on the pull request to find its own. I exercised the two shell steps directly instead:

| CODE | fail-on-breach | exit |
| --- | --- | --- |
| 0 | either | 0 |
| 1 | false | 0 + warning |
| 1 | true | 1 |
| 2 | either | 1 |

One thing I left alone: `Download the baseline report` is still `continue-on-error: true`, so a genuinely broken artifact download is indistinguishable from a first run. Same shape as the bug #56 fixed in the CLI, just in the action.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
