### PR TITLE
chore: fix workspace ranges, vite peer, and release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,34 +44,36 @@ jobs:
 
       - run: pnpm test:pack
 
+      - run: pnpm test:attw
+
       - name: Publish nuxt-cf-jobs
         if: startsWith(github.ref_name, 'nuxt-cf-jobs-v')
-        run: npm publish packages/nuxt-cf-jobs/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-cf-jobs/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-use-query
         if: startsWith(github.ref_name, 'nuxt-use-query-v')
-        run: npm publish packages/nuxt-use-query/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-use-query/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-domain-events
         if: startsWith(github.ref_name, 'nuxt-domain-events-v')
-        run: npm publish packages/nuxt-domain-events/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-domain-events/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-dx
         if: startsWith(github.ref_name, 'nuxt-dx-v')
-        run: npm publish packages/nuxt-dx/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-dx/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-github-sponsors
         if: startsWith(github.ref_name, 'nuxt-github-sponsors-v')
-        run: npm publish packages/nuxt-github-sponsors/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-github-sponsors/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-cloudflare
         if: startsWith(github.ref_name, 'nuxt-cloudflare-v')
-        run: npm publish packages/nuxt-cloudflare/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-cloudflare/.pack/*.tgz --access public --provenance
 
       - name: Publish nuxt-wide-events
         if: startsWith(github.ref_name, 'nuxt-wide-events-v')
-        run: npm publish packages/nuxt-wide-events/.pack/*.tgz --access public
+        run: npm publish packages/nuxt-wide-events/.pack/*.tgz --access public --provenance
 
       - name: Publish comark-content
         if: startsWith(github.ref_name, 'comark-content-v')
-        run: npm publish packages/comark-content/.pack/*.tgz --access public
+        run: npm publish packages/comark-content/.pack/*.tgz --access public --provenance

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -14,10 +14,12 @@ Canonical vocabulary for this project. Public APIs, docs, routes, and messages u
 | Diagnostic | `@harlan-zw/nuxt-dx` | published | developers and CI | "diagnostic" |
 | Wide Event | `@harlan-zw/nuxt-wide-events` | planned | Nuxt server code | "wide event" |
 | Field | `@harlan-zw/nuxt-wide-events/server` | planned | Nuxt server code | "field" |
+| Wrangler Diagnostic | `@harlan-zw/nuxt-cloudflare` | published | developers and CI | "warning" |
+| Collection | `@harlan-zw/comark-content/server` | published | Nuxt server code | "collection" |
 
 Collisions
 
-None recorded.
+`Diagnostic` belongs to `nuxt-dx`. `nuxt-cloudflare` always qualifies its findings as `Wrangler Diagnostic`.
 
 ## Terms
 
@@ -76,6 +78,20 @@ None recorded.
 **Use for:** reports, budgets, and developer messages.
 **Never:** issue, alert.
 **Casing:** `Diagnostic` in headings and `diagnostic` elsewhere.
+
+### Wrangler Diagnostic
+
+**Is:** one finding that `nuxt-cloudflare` raises against a generated Wrangler config.
+**Use for:** doctor output, build errors, and docs.
+**Never:** Diagnostic on its own, wrangler warning, lint error.
+**Casing:** `Wrangler Diagnostic` in headings and `Wrangler diagnostic` elsewhere.
+
+### Collection
+
+**Is:** a named set of markdown files that `comark-content` ingests, queries, and serves.
+**Use for:** `comark-content` APIs, configuration, and docs.
+**Never:** content source, corpus, folder.
+**Casing:** `Collection` in headings and `collection` elsewhere.
 
 ## Banned
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Experimental Nuxt modules developed in one repo, so they share tooling and a single verification pipeline.
 
-Every package here publishes under the `experimental` npm tag. Versions and release notes are per package, so one module moving fast never forces a version bump on the others.
+Every package here publishes to npm with provenance. Versions and release notes are per package, so one module moving fast never forces a version bump on the others.
 
 <p align="center">
 <table>
@@ -27,6 +27,8 @@ Every package here publishes under the `experimental` npm tag. Versions and rele
 | [`@harlan-zw/nuxt-dx`](./packages/nuxt-dx) | 🚨 Diagnostics: a client error overlay with agent handoff, and JavaScript budgets for Nuxt and Nitro runtime entries. |
 | [`@harlan-zw/nuxt-github-sponsors`](./packages/nuxt-github-sponsors) | 💖 Typed GitHub Sponsors data with tiers, profile overrides, a public route, and a composable. |
 | [`@harlan-zw/nuxt-wide-events`](./packages/nuxt-wide-events) | 📝 Minimal Wide Events with build-time Field enforcement and a small production runtime. |
+| [`@harlan-zw/nuxt-cloudflare`](./packages/nuxt-cloudflare) | 🌩️ Opinionated Cloudflare defaults, generated Wrangler config, and Wrangler diagnostics for Nuxt. |
+| [`@harlan-zw/comark-content`](./packages/comark-content) | 📄 Markdown-only Nuxt content powered by Comark, with Collection queries, navigation, and search sections. |
 
 ## Development
 

--- a/packages/comark-content/.attw.json
+++ b/packages/comark-content/.attw.json
@@ -1,0 +1,6 @@
+{
+  "ignoreRules": [
+    "cjs-resolves-to-esm",
+    "internal-resolution-error"
+  ]
+}

--- a/packages/comark-content/package.json
+++ b/packages/comark-content/package.json
@@ -36,11 +36,18 @@
   },
   "main": "./dist/module.mjs",
   "types": "./dist/module.d.mts",
+  "typesVersions": {
+    "*": {
+      "server": [
+        "dist/runtime/server/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],
   "engines": {
-    "node": ">=22.0.0 <27"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "bench": "node ./bench/run.mjs",
@@ -51,6 +58,7 @@
     "lint:fix": "eslint . --fix",
     "prepack": "pnpm run build",
     "test": "vitest run",
+    "test:attw": "attw --pack",
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz && node --input-type=module -e \"await import('./dist/runtime/core/navigation.js')\"",
     "typecheck": "tsc --noEmit"
   },
@@ -65,6 +73,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
+    "@arethetypeswrong/cli": "catalog:",
     "@nuxt/module-builder": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",

--- a/packages/nuxt-cf-jobs/package.json
+++ b/packages/nuxt-cf-jobs/package.json
@@ -137,7 +137,8 @@
   },
   "peerDependencies": {
     "@sentry/cloudflare": "catalog:",
-    "nuxt": ">=4.5.0 <5.0.0"
+    "nuxt": ">=4.5.0 <5.0.0",
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@sentry/cloudflare": {
@@ -145,12 +146,11 @@
     }
   },
   "dependencies": {
-    "@harlan-zw/nuxt-cloudflare": "workspace:*",
+    "@harlan-zw/nuxt-cloudflare": "workspace:^",
     "@nuxt/kit": "catalog:",
     "@nuxt/schema": "catalog:",
     "citty": "catalog:",
-    "drizzle-orm": "catalog:",
-    "vite": "catalog:"
+    "drizzle-orm": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -170,6 +170,7 @@
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:",
     "vue-tsc": "catalog:",

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -109,7 +109,7 @@
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
     "@cloudflare/workers-types": "catalog:",
-    "@harlan-zw/nuxt-wide-events": "workspace:*",
+    "@harlan-zw/nuxt-wide-events": "workspace:^",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",
     "@types/node": "catalog:",

--- a/packages/nuxt-domain-events/package.json
+++ b/packages/nuxt-domain-events/package.json
@@ -74,8 +74,9 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "@harlan-zw/nuxt-cf-jobs": "workspace:*",
-    "nuxt": ">=4.5.0 <5.0.0"
+    "@harlan-zw/nuxt-cf-jobs": "workspace:^",
+    "nuxt": ">=4.5.0 <5.0.0",
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@harlan-zw/nuxt-cf-jobs": {
@@ -83,19 +84,19 @@
     }
   },
   "dependencies": {
-    "@nuxt/kit": "catalog:",
-    "vite": "catalog:"
+    "@nuxt/kit": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
-    "@harlan-zw/nuxt-cf-jobs": "workspace:*",
+    "@harlan-zw/nuxt-cf-jobs": "workspace:^",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",
     "eslint": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vue-tsc": "catalog:"
   }

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -52,14 +52,14 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0"
+    "nuxt": ">=4.5.0 <5.0.0",
+    "vite": "^8.0.0"
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
     "@vueuse/core": "catalog:",
     "citty": "catalog:",
-    "consola": "catalog:",
-    "vite": "catalog:"
+    "consola": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -72,6 +72,7 @@
     "rollup": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:",
     "yaml": "catalog:"

--- a/packages/nuxt-use-query/package.json
+++ b/packages/nuxt-use-query/package.json
@@ -125,6 +125,7 @@
   },
   "peerDependencies": {
     "nuxt": ">=4.5.0 <5.0.0",
+    "vite": "^8.0.0",
     "zod": "^4.0.0"
   },
   "dependencies": {
@@ -132,8 +133,7 @@
     "@vueuse/core": "catalog:",
     "consola": "catalog:",
     "nitropack": "catalog:",
-    "pathe": "catalog:",
-    "vite": "catalog:"
+    "pathe": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -147,6 +147,7 @@
     "happy-dom": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:",
     "vue-router": "catalog:",

--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -67,12 +67,12 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0"
+    "nuxt": ">=4.5.0 <5.0.0",
+    "vite": "^8.0.0"
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
-    "pathe": "catalog:",
-    "vite": "catalog:"
+    "pathe": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -88,6 +88,7 @@
     "pino": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vue-tsc": "catalog:",
     "wrangler": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@antfu/eslint-config':
         specifier: 'catalog:'
         version: 9.3.0(@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3))(@typescript-eslint/utils@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.5
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
@@ -171,7 +174,7 @@ importers:
   packages/nuxt-cf-jobs:
     dependencies:
       '@harlan-zw/nuxt-cloudflare':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../nuxt-cloudflare
       '@nuxt/kit':
         specifier: 'catalog:'
@@ -185,9 +188,6 @@ importers:
       drizzle-orm:
         specifier: 'catalog:'
         version: 1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3)
-      vite:
-        specifier: 'catalog:'
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -240,6 +240,9 @@ importers:
       unbuild:
         specifier: 'catalog:'
         version: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -290,7 +293,7 @@ importers:
         specifier: 'catalog:'
         version: 5.20260811.1
       '@harlan-zw/nuxt-wide-events':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../nuxt-wide-events
       '@nuxt/module-builder':
         specifier: 'catalog:'
@@ -325,9 +328,6 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      vite:
-        specifier: 'catalog:'
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -336,7 +336,7 @@ importers:
         specifier: 'catalog:'
         version: 0.18.5
       '@harlan-zw/nuxt-cf-jobs':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../nuxt-cf-jobs
       '@nuxt/module-builder':
         specifier: 'catalog:'
@@ -356,6 +356,9 @@ importers:
       unbuild:
         specifier: 'catalog:'
         version: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -377,9 +380,6 @@ importers:
       consola:
         specifier: 'catalog:'
         version: 3.4.2
-      vite:
-        specifier: 'catalog:'
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -411,6 +411,9 @@ importers:
       unbuild:
         specifier: 'catalog:'
         version: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -484,9 +487,6 @@ importers:
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
-      vite:
-        specifier: 'catalog:'
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -521,6 +521,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -545,9 +548,6 @@ importers:
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
-      vite:
-        specifier: 'catalog:'
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -588,6 +588,9 @@ importers:
       unbuild:
         specifier: 'catalog:'
         version: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))


### PR DESCRIPTION
Repo-wide packaging and release hygiene. No `version` field changed. Nothing was published.

## What changed

1. **Workspace ranges.** `workspace:*` packs as an exact version pin. Four declarations now use `workspace:^`:
   - `nuxt-cf-jobs` dependencies on `@harlan-zw/nuxt-cloudflare`
   - `nuxt-domain-events` peerDependencies and devDependencies on `@harlan-zw/nuxt-cf-jobs`
   - `nuxt-cloudflare` devDependencies on `@harlan-zw/nuxt-wide-events`

   Verified with `pnpm pack` in `nuxt-cf-jobs`. The packed manifest now reads `"@harlan-zw/nuxt-cloudflare": "^0.0.18"` instead of `"0.0.18"`.

2. **`vite` is now a peer dependency.** `nuxt-cf-jobs`, `nuxt-domain-events`, `nuxt-dx`, `nuxt-use-query`, and `nuxt-wide-events` import only `parseSync` and `Visitor` from vite. Nuxt already supplies vite. The range is `^8.0.0`, because vite 7 does not export `parseSync` or `Visitor`. Each package keeps `vite: catalog:` in devDependencies, so the workspace still builds and tests.

3. **`comark-content` now runs attw.** It gained the `test:attw` script and the `@arethetypeswrong/cli` devDependency. The root `pnpm test:attw` uses `--if-present`, so the package was skipped in silence. Enabling it exposed two real defects:
   - `./server` had no `typesVersions` entry, so node10 resolution failed. Added, matching every other package.
   - `dist/runtime/server/index.d.ts` emits `import(".")` self references, which fail internal resolution. This needs explicit return type annotations in `src/runtime/server/index.ts`. That file is outside this PR's scope, so `.attw.json` ignores `internal-resolution-error` for now. Remove that ignore once the source is annotated.

   `pnpm test:attw` now passes for all 8 packages.

4. **Release workflow.** Added `pnpm test:attw` to the checks. Added `--provenance` to all 8 publish steps.

5. **`comark-content` engines.** Changed `>=22.0.0 <27` to `>=22.12.0`, matching the root and every other package.

6. **Docs.** Added `comark-content` and `nuxt-cloudflare` to the README package table and to `GLOSSARY.md`. `GLOSSARY.md` records `Collection` and `Wrangler Diagnostic`, plus the collision between `Wrangler Diagnostic` and the `nuxt-dx` term `Diagnostic`.

   The README claimed packages publish under the `experimental` npm tag. The workflow passes no `--tag`, so it publishes under `latest`. The README now states publication with provenance, which the workflow performs after this change.

## BREAKING

Two changes require a consumer to act. Both take effect only after the packages are republished.

1. **`vite` moved to peerDependencies with range `^8.0.0`.**
   Affects `@harlan-zw/nuxt-cf-jobs`, `@harlan-zw/nuxt-domain-events`, `@harlan-zw/nuxt-dx`, `@harlan-zw/nuxt-use-query`, `@harlan-zw/nuxt-wide-events`.
   Step for the consumer: install Nuxt 4.5 or later, which resolves vite 8. If the lockfile pins vite 7, run `pnpm up vite@^8` and reinstall. A vite 7 tree now reports an unmet peer dependency instead of silently installing a second vite copy.
   Consumer repos to check: nuxtseo.com, gscdump.com, request-indexing, harlanzw.com, unhead.unjs.io, unlighthouse.dev, mdream.dev, zhead.dev, scripts.nuxt.com.

2. **`@harlan-zw/comark-content` engines raised to `>=22.12.0`.**
   Step for the consumer: run Node 22.12 or later. Node 22.0 through 22.11 now fails the engines check. The change also removes the `<27` upper bound, so Node 27 is allowed.
   Consumer repos to check: harlanzw.com, unhead.unjs.io, unlighthouse.dev, mdream.dev, zhead.dev, scripts.nuxt.com, nuxtseo.com.

Nothing else breaks. The `workspace:^` change, the provenance flag, the attw check, the README, and the glossary are all safe for consumers.

## Packages that need a republish

| Package | Reason |
| --- | --- |
| `@harlan-zw/nuxt-cf-jobs` | `@harlan-zw/nuxt-cloudflare` range, `vite` peer |
| `@harlan-zw/nuxt-domain-events` | `@harlan-zw/nuxt-cf-jobs` peer range, `vite` peer |
| `@harlan-zw/nuxt-dx` | `vite` peer |
| `@harlan-zw/nuxt-use-query` | `vite` peer |
| `@harlan-zw/nuxt-wide-events` | `vite` peer |
| `@harlan-zw/comark-content` | engines, `typesVersions` for `./server` |

`@harlan-zw/nuxt-cloudflare` and `@harlan-zw/nuxt-github-sponsors` need no republish. Their published fields did not change.

## Known limit of `workspace:^`

`workspace:^` does not widen a range while a package sits on `0.0.x`. Semver treats `^0.0.18` as `>=0.0.18 <0.0.19`, so it still matches one exact version. Verified:

```
semver.satisfies('0.0.19', '^0.0.18')  // false
semver.satisfies('0.0.19', '~0.0.18')  // true
```

So this PR alone does not stop nuxtseo.com and gscdump.com installing two copies of `nuxt-cloudflare`. To fix that, pick one:

- Move the packages to `0.1.0` or later, where `^` widens as expected.
- Or switch these declarations to `workspace:~`, which widens today.

I kept `workspace:^` as specified. Please decide the follow up.

## Verification

- `pnpm install --lockfile-only`, then `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -r --if-present run lint` passes for all 8 packages
- `pnpm dev:prepare` passes
- `pnpm test:attw` passes for all 8 packages
- `pnpm pack` in `nuxt-cf-jobs` confirms the packed range and the vite peer

Not run: `pnpm typecheck` and `pnpm test`. This PR touches no source file, and other agents are editing `src/` in parallel.
