### PR TITLE
fix(comark-content)!: reuse remote checkouts and stabilize the content revision

### DIFF
--- a/packages/comark-content/LICENSE.md
+++ b/packages/comark-content/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harlan Wilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/comark-content/README.md
+++ b/packages/comark-content/README.md
@@ -1,0 +1,197 @@
+# @harlan-zw/comark-content
+
+Markdown-only Nuxt content powered by [Comark](https://github.com/harlan-zw/comark).
+
+The module parses Markdown at build time and writes compressed server assets. No database runs, and no Markdown is parsed at request time.
+
+## Boundary
+
+The module supports page collections of Markdown files only.
+
+| Supported | Not supported |
+| --- | --- |
+| Local Markdown, include and exclude globs, collection prefixes | Data collections, YAML, JSON, CSV sources |
+| Remote Git repositories with branch, tag, and token auth | Provider APIs and write access |
+| Standard Schema frontmatter parsing | Schema library re-exports |
+| Query, navigation, surroundings, search sections, sitemap entries | Raw SQL, count, skip, mutation |
+| Rangi code highlighting | Shiki, MDC nodes, `@nuxtjs/mdc`, runtime Markdown parsing |
+
+If you configure `database`, the build fails with an explicit error.
+
+## Setup
+
+```bash
+pnpm add @harlan-zw/comark-content
+```
+
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ['@harlan-zw/comark-content'],
+})
+```
+
+The module uses the `content` configuration key.
+
+## Collections
+
+Declare collections in `content.config.ts` at the root of any layer.
+
+```ts
+// content.config.ts
+import { defineCollection, defineContentConfig } from '@harlan-zw/comark-content'
+import { z } from 'zod'
+
+export default defineContentConfig({
+  collections: {
+    docs: defineCollection({
+      type: 'page',
+      source: { include: 'docs/**/*.md', prefix: '/docs' },
+      schema: z.object({
+        publishedAt: z.string().optional(),
+      }),
+    }),
+  },
+})
+```
+
+Every layer may declare collections. Each name must be unique across all layers. If two files declare one name, the build fails and names both files.
+
+Local sources resolve against the `content` directory of the layer that declares them. Set `cwd` to read from another directory.
+
+### Remote sources
+
+```ts
+defineCollection({
+  type: 'page',
+  source: {
+    include: 'docs/content/**/*.md',
+    prefix: '/modules/og-image',
+    repository: {
+      url: 'https://github.com/nuxt-modules/og-image',
+      tag: 'v5.1.14',
+      auth: { token: process.env.GITHUB_TOKEN },
+    },
+  },
+})
+```
+
+The checkout directory is keyed by repository URL and reference. A `tag` never moves, so its checkout is cloned once and then reused. A `branch`, or no reference, is cloned again on every full build. Local Markdown edits during development never trigger a clone.
+
+If a clone with a token fails, the module retries once without the token. If the retry fails, the build fails. Stale content is never served after a failed refresh.
+
+## Querying
+
+The same functions run in the browser and on the server.
+
+```vue
+<script setup lang="ts">
+const { data: page } = await useAsyncData('page', () => {
+  return queryCollection('docs').path('/docs/getting-started').first()
+})
+
+const { data: navigation } = await useAsyncData('navigation', () => {
+  return queryCollectionNavigation('docs')
+})
+</script>
+```
+
+Available functions:
+
+- `queryCollection(name)` with `path`, `where`, `select`, `order`, `limit`, `all`, and `first`
+- `queryCollectionNavigation(name, fields?)`
+- `queryCollectionItemSurroundings(name, path, options?)`
+- `queryCollectionSearchSections(name)`
+
+`where` supports the `=`, `LIKE`, `<>`, and `IS NULL` operators.
+
+Import the same functions from `@harlan-zw/comark-content/server` inside Nitro handlers. The server versions take the request event as their first argument.
+
+```ts
+// server/api/page.get.ts
+import { queryCollection } from '@harlan-zw/comark-content/server'
+
+export default defineEventHandler(async (event) => {
+  return queryCollection(event, 'docs').path('/docs').first()
+})
+```
+
+Only the metadata index is decompressed for a filtered query. Document bodies load one at a time, and only for matched documents.
+
+## Rendering
+
+```vue
+<template>
+  <ContentRenderer v-if="page" :value="page" />
+</template>
+```
+
+`ContentRenderer` renders Comark nodes as semantic HTML. It resolves an HTML tag to `ContentProseX`, then `ProseX`. It resolves a custom tag to `ContentX`, `ProseX`, then `X`. Components in `app/components/content` are also available under their unprefixed name. Only tags present in the parsed content are imported.
+
+Set `unwrap="p"` to render slot content without its paragraph wrapper.
+
+The `content:file:beforeParse` and `content:file:afterParse` Nuxt hooks run around each document.
+
+## Highlighting
+
+Code highlighting is on by default and uses [Rangi](https://github.com/harlan-zw/rangi). The bundled theme pair is GitHub Light and GitHub Dark, with an AA contrast comment color. The bundled extra languages are `dotenv`, `env`, `robots`, `robots-txt`, and `robots.txt`.
+
+```ts
+export default defineNuxtConfig({
+  content: {
+    highlight: {
+      theme: { light: myLightTheme, dark: myDarkTheme },
+      languages: { hcl: myHclGrammar },
+    },
+  },
+})
+```
+
+To turn highlighting off, set `highlight: false`. The Rangi stylesheet is then not added to your application.
+
+Import the bundled theme and languages to extend them:
+
+```ts
+import { contentRangiLanguages, contentRangiTheme } from '@harlan-zw/comark-content'
+```
+
+## AST helpers
+
+Two helpers read parsed Markdown nodes:
+
+```ts
+import { nodeToText, walkNodes } from '@harlan-zw/comark-content'
+
+const title = nodeToText(page.body.nodes[0])
+
+walkNodes(page.body.nodes, (node) => {
+  if (typeof node !== 'string' && node[0] === 'img')
+    images.push(node[1].src)
+})
+```
+
+## Sitemap
+
+If `@nuxtjs/sitemap` is installed, the module pushes one entry per document into `sitemap:input`. The Nuxt Content v3 sitemap source is excluded, so URLs are never listed twice.
+
+A page is skipped when its frontmatter sets `sitemap: false` or `robots: false`. Frontmatter `sitemap` object fields are merged into the entry. The entry `lastmod` comes from `updatedAt`, or from `publishedAt`.
+
+To keep a whole collection out of the sitemap, set `sitemap: false` on the collection:
+
+```ts
+snippets: defineCollection({
+  type: 'page',
+  source: 'snippets/**/*.md',
+  sitemap: false,
+})
+```
+
+## Deployment
+
+Parsed collections are written as gzip server assets. Navigation, surroundings, and search use content-addressed GET routes. The route key hashes the parsed content only. A redeploy that changes no content keeps the same routes, so clients running the previous build keep working.
+
+Cloudflare presets require `@harlan-zw/nuxt-cloudflare` with Workers Caching enabled. The build fails otherwise.
+
+## License
+
+[MIT](./LICENSE.md)

--- a/packages/comark-content/src/config.ts
+++ b/packages/comark-content/src/config.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'node:path'
+
 export interface StandardSchemaIssue {
   message: string
   path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>
@@ -31,19 +33,65 @@ export interface CollectionDefinition<TSchema extends StandardSchema | undefined
   source?: CollectionSource
   schema?: TSchema
   indexes?: Array<{ columns: string[] }>
+  /** Set `false` to keep the collection out of the sitemap. */
+  sitemap?: false
 }
 
 export interface ContentConfig<TCollections extends Record<string, CollectionDefinition> = Record<string, CollectionDefinition>> {
   collections: TCollections
 }
 
+/**
+ * Reads the file extensions a glob names.
+ * A glob with no extension returns an empty list.
+ */
+export function globExtensions(glob: string): string[] {
+  const segment = glob.split('/').pop() ?? ''
+  const braced = /\.\{([^}]*)\}$/.exec(segment)
+  if (braced)
+    return braced[1]!.split(',').map(value => value.trim().toLowerCase()).filter(Boolean)
+  const dot = segment.lastIndexOf('.')
+  return dot === -1 ? [] : [segment.slice(dot + 1).toLowerCase()]
+}
+
 export function defineCollection<const TSchema extends StandardSchema | undefined>(definition: CollectionDefinition<TSchema>): CollectionDefinition<TSchema> {
   if (definition.type !== 'page')
     throw new TypeError('Markdown page collections are the only supported collection type.')
   const source = typeof definition.source === 'string' ? definition.source : definition.source?.include
-  if (source && !source.includes('.md'))
+  const extensions = source ? globExtensions(source) : []
+  if (extensions.length > 0 && !extensions.includes('md'))
     throw new TypeError('Markdown files are the only supported collection source.')
   return definition
+}
+
+export interface DeclaredCollections {
+  configPath: string
+  collections: Record<string, CollectionDefinition>
+}
+
+export interface MergedCollection {
+  name: string
+  rootDir: string
+  configPath: string
+  definition: CollectionDefinition
+}
+
+/**
+ * Merges the collections of every content configuration file.
+ * If two files define one name, this throws.
+ */
+export function mergeCollectionSources(declared: ReadonlyArray<DeclaredCollections>): MergedCollection[] {
+  const merged = new Map<string, MergedCollection>()
+  for (const file of declared) {
+    const rootDir = dirname(file.configPath)
+    for (const [name, definition] of Object.entries(file.collections)) {
+      const existing = merged.get(name)
+      if (existing)
+        throw new TypeError(`${file.configPath}:1:1 Collection "${name}" is already defined in ${existing.configPath}. Rename one collection.`)
+      merged.set(name, { name, rootDir, configPath: file.configPath, definition })
+    }
+  }
+  return [...merged.values()]
 }
 
 export const defineContentConfig = <const TCollections extends Record<string, CollectionDefinition>>(config: ContentConfig<TCollections>) => config

--- a/packages/comark-content/src/core/asset.ts
+++ b/packages/comark-content/src/core/asset.ts
@@ -1,4 +1,4 @@
-import type { ContentSearchSection, IndexedContentDocument, NavigationCollectionItem, PageCollectionItemBase } from '../runtime/types'
+import type { ContentCollectionManifestEntry, ContentSearchSection, IndexedContentDocument, NavigationCollectionItem, PageCollectionItemBase } from '../runtime/types'
 import { createHash } from 'node:crypto'
 import { gzipSync } from 'node:zlib'
 import { createNavigationSource, createSearchSections } from '../runtime/core/navigation'
@@ -11,8 +11,14 @@ export interface GeneratedContentAsset {
 }
 
 export interface ContentAssetPlan {
-  collectionNames: string[]
+  manifest: ContentCollectionManifestEntry[]
   assets: GeneratedContentAsset[]
+}
+
+export interface ContentAssetPlanInput {
+  collections: Record<string, PageCollectionItemBase[]>
+  /** Names of the collections the sitemap includes. */
+  sitemapCollections: readonly string[]
 }
 
 const bodyAssetName = (id: string) => `${createHash('sha256').update(id).digest('hex').slice(0, 32)}.json.gz`
@@ -27,11 +33,13 @@ function canonicalContent(collections: Record<string, PageCollectionItemBase[]>)
   })
 }
 
-export function createContentRevision(buildId: string, collections: Record<string, PageCollectionItemBase[]>) {
+/**
+ * Hashes the parsed content only.
+ * The application build is excluded, so a redeploy keeps serving live clients.
+ */
+export function createContentRevision(collections: Record<string, PageCollectionItemBase[]>) {
   return createHash('sha256')
     .update('comark-content-assets-v1\0')
-    .update(buildId)
-    .update('\0')
     .update(canonicalContent(collections))
     .digest('hex')
 }
@@ -56,13 +64,14 @@ export function projectCollectionAssets(name: string, items: PageCollectionItemB
   ]
 }
 
-export function createContentAssetPlan(collections: Record<string, PageCollectionItemBase[]>): ContentAssetPlan {
-  const collectionNames = Object.keys(collections)
+export function createContentAssetPlan(input: ContentAssetPlanInput): ContentAssetPlan {
+  const sitemapCollections = new Set(input.sitemapCollections)
+  const manifest = Object.keys(input.collections).map(name => ({ name, sitemap: sitemapCollections.has(name) }))
   return {
-    collectionNames,
+    manifest,
     assets: [
-      { path: 'collections.json.gz', data: encodeCollectionAsset(collectionNames) },
-      ...Object.entries(collections).flatMap(([name, items]) => projectCollectionAssets(name, items)),
+      { path: 'collections.json.gz', data: encodeCollectionAsset(manifest) },
+      ...Object.entries(input.collections).flatMap(([name, items]) => projectCollectionAssets(name, items)),
     ],
   }
 }

--- a/packages/comark-content/src/core/ingest.ts
+++ b/packages/comark-content/src/core/ingest.ts
@@ -3,6 +3,7 @@ import type { CollectionDefinition, StandardSchemaIssue } from '../config'
 import type { ContentHighlight } from '../highlight'
 import type { ContentHook, ContentHookPage } from '../hooks'
 import type { PageCollectionItemBase, Result } from '../runtime/types'
+import type { RemoteCheckoutPolicy } from './remote'
 import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { createMarkdownParser } from 'comark'
@@ -27,6 +28,8 @@ export interface LoadedCollection {
 
 export interface IngestionResult {
   collections: Record<string, PageCollectionItemBase[]>
+  /** Names of the collections the sitemap includes. */
+  sitemapCollections: string[]
   parsedFiles: number
   cachedFiles: number
   componentTags: string[]
@@ -35,6 +38,7 @@ export interface IngestionResult {
 type IngestionOptions = ContentHook & {
   cacheFile: string
   remoteCacheDir?: string
+  remoteCheckout?: RemoteCheckoutPolicy
   parse?: (source: string) => Promise<MarkdownDocument>
   highlight?: ContentHighlight
 }
@@ -123,6 +127,7 @@ export async function ingestCollections(loadedCollections: LoadedCollection[], o
   const cache = await readCache(options.cacheFile)
   const nextCache = { version: CACHE_VERSION, entries: {} as typeof cache.entries }
   const collections: Record<string, PageCollectionItemBase[]> = {}
+  const sitemapCollections: string[] = []
   let parsedFiles = 0
   let cachedFiles = 0
   const componentTags = new Set<string>()
@@ -134,6 +139,7 @@ export async function ingestCollections(loadedCollections: LoadedCollection[], o
       const remote = await prepareRemoteSource(
         { ...declaredSource, repository: declaredSource.repository },
         options.remoteCacheDir ?? `${options.cacheFile}.remote`,
+        { policy: options.remoteCheckout },
       )
       if (remote._tag === 'Err')
         return remote
@@ -215,7 +221,9 @@ export async function ingestCollections(loadedCollections: LoadedCollection[], o
       items.push(afterParse.content)
     }
     collections[collection.name] = items
+    if (collection.definition.sitemap !== false)
+      sitemapCollections.push(collection.name)
   }
   await writeCache(options.cacheFile, nextCache)
-  return ok({ collections, parsedFiles, cachedFiles, componentTags: [...componentTags].sort() })
+  return ok({ collections, sitemapCollections, parsedFiles, cachedFiles, componentTags: [...componentTags].sort() })
 }

--- a/packages/comark-content/src/core/remote.ts
+++ b/packages/comark-content/src/core/remote.ts
@@ -2,6 +2,7 @@ import type { GitRepository } from '../config'
 import type { Result } from '../runtime/types'
 import { spawn } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { mkdir, rename, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
@@ -16,6 +17,24 @@ export interface RemoteSource {
 
 type Command = (command: string, args: string[], options: { env: NodeJS.ProcessEnv }) => Promise<void>
 
+/**
+ * Controls how an existing checkout is treated.
+ * `Refresh` clones a mutable reference again. `ReuseExisting` keeps any checkout.
+ */
+export type RemoteCheckoutPolicy
+  = | { _tag: 'Refresh' }
+    | { _tag: 'ReuseExisting' }
+
+export interface RemoteSourceOptions {
+  policy?: RemoteCheckoutPolicy
+  command?: Command
+}
+
+type RepositoryReference
+  = | { _tag: 'Immutable', name: string }
+    | { _tag: 'Mutable', name: string }
+    | { _tag: 'Default' }
+
 const runCommand: Command = (command, args, options) => new Promise((resolve, reject) => {
   const child = spawn(command, args, { env: options.env, stdio: ['ignore', 'ignore', 'pipe'] })
   let error = ''
@@ -24,22 +43,37 @@ const runCommand: Command = (command, args, options) => new Promise((resolve, re
   child.on('close', code => code === 0 ? resolve() : reject(new Error(error.trim() || `${command} exited with ${code}.`)))
 })
 
-function repositoryDetails(repository: GitRepository) {
-  return typeof repository === 'string'
-    ? { url: repository, reference: undefined, token: undefined }
-    : { url: repository.url, reference: repository.tag ?? repository.branch, token: repository.auth?.token }
+function repositoryReference(repository: Exclude<GitRepository, string>): RepositoryReference {
+  if (repository.tag)
+    return { _tag: 'Immutable', name: repository.tag }
+  if (repository.branch)
+    return { _tag: 'Mutable', name: repository.branch }
+  return { _tag: 'Default' }
 }
 
-export async function prepareRemoteSource(source: RemoteSource, cacheRoot: string, command: Command = runCommand): Promise<Result<string>> {
+function repositoryDetails(repository: GitRepository) {
+  return typeof repository === 'string'
+    ? { url: repository, reference: { _tag: 'Default' } as RepositoryReference, token: undefined }
+    : { url: repository.url, reference: repositoryReference(repository), token: repository.auth?.token }
+}
+
+export async function prepareRemoteSource(source: RemoteSource, cacheRoot: string, options: RemoteSourceOptions = {}): Promise<Result<string>> {
+  const command = options.command ?? runCommand
+  const policy = options.policy ?? { _tag: 'Refresh' }
   const repository = repositoryDetails(source.repository)
-  const key = createHash('sha256').update(repository.url).update('\0').update(repository.reference ?? 'HEAD').digest('hex').slice(0, 20)
+  const reference = repository.reference._tag === 'Default' ? undefined : repository.reference.name
+  const key = createHash('sha256').update(repository.url).update('\0').update(reference ?? 'HEAD').digest('hex').slice(0, 20)
   const target = join(cacheRoot, key)
+  // A tag never moves, so its checkout stays valid. A rebuild reuses every checkout.
+  const reusable = repository.reference._tag === 'Immutable' || policy._tag === 'ReuseExisting'
+  if (reusable && existsSync(target))
+    return ok(target)
   const temporary = join(cacheRoot, `${key}.${randomUUID()}.next`)
   const previous = join(cacheRoot, `${key}.${randomUUID()}.previous`)
   await mkdir(dirname(temporary), { recursive: true })
   const args = ['clone', '--depth', '1', '--single-branch']
-  if (repository.reference)
-    args.push('--branch', repository.reference)
+  if (reference)
+    args.push('--branch', reference)
   args.push(repository.url, temporary)
   const env = repository.token
     ? {

--- a/packages/comark-content/src/core/source.ts
+++ b/packages/comark-content/src/core/source.ts
@@ -102,3 +102,13 @@ export async function scanSource(source: ResolvedSource) {
   await visit(source.cwd)
   return files.sort((left, right) => left.key.localeCompare(right.key))
 }
+
+const markdownWatchEvents = new Set(['add', 'change', 'unlink'])
+
+/**
+ * Reports whether a watcher event changed a Markdown file.
+ * Added and deleted files count, so a rebuild needs no restart.
+ */
+export function isMarkdownWatchEvent(event: string, path: string): boolean {
+  return markdownWatchEvents.has(event) && path.endsWith('.md')
+}

--- a/packages/comark-content/src/module.ts
+++ b/packages/comark-content/src/module.ts
@@ -21,14 +21,18 @@ import {
   useLogger,
 } from '@nuxt/kit'
 import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtUiProseComponents, renderComponentManifest } from './components'
-import { assertCloudflareCacheModule, assertSupportedOptions } from './config'
+import { assertCloudflareCacheModule, assertSupportedOptions, mergeCollectionSources } from './config'
 import { createContentAssetPlan, createContentRevision } from './core/asset'
 import { ingestCollections } from './core/ingest'
+import { isMarkdownWatchEvent } from './core/source'
 import { excludeNuxtContentSitemapSource } from './sitemap'
 
 export * from './config'
+export { contentRangiLanguages, contentRangiTheme } from './core/rangi'
 export type * from './highlight'
 export type * from './hooks'
+export { nodeToText, walkNodes } from './runtime/core/ast'
+export type { NodeVisitor } from './runtime/core/ast'
 export type * from './runtime/types'
 
 export interface ModuleOptions {
@@ -54,7 +58,7 @@ function layerRoot(layer: Record<string, unknown>) {
 }
 
 async function loadCollections(layers: ReadonlyArray<Record<string, unknown>>): Promise<LoadedCollection[]> {
-  const collections = new Map<string, LoadedCollection>()
+  const declared = []
   for (const layer of [...layers].reverse()) {
     const rootDir = layerRoot(layer)
     if (!rootDir)
@@ -63,11 +67,9 @@ async function loadCollections(layers: ReadonlyArray<Record<string, unknown>>): 
     if (!configPath)
       continue
     const config = await importModule<ContentConfig>(configPath, { interopDefault: true })
-    for (const [name, definition] of Object.entries(config.collections)) {
-      collections.set(name, { name, definition, rootDir: dirname(configPath) })
-    }
+    declared.push({ configPath, collections: config.collections })
   }
-  return [...collections.values()]
+  return mergeCollectionSources(declared).map(({ name, definition, rootDir }) => ({ name, definition, rootDir }))
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -92,13 +94,14 @@ export default defineNuxtModule<ModuleOptions>({
       optional: true,
     },
   },
-  defaults: {},
+  defaults: { highlight: true },
   async setup(options, nuxt) {
     assertSupportedOptions(options as Record<string, unknown>, join(nuxt.options.rootDir, 'nuxt.config.ts'))
     const nuxtOptions = nuxt.options as typeof nuxt.options & { sitemap?: Parameters<typeof excludeNuxtContentSitemapSource>[0] }
     nuxtOptions.sitemap = excludeNuxtContentSitemapSource(nuxtOptions.sitemap)
     const resolver = createResolver(import.meta.url)
-    nuxt.options.css.push(resolver.resolve('./runtime/rangi.css'))
+    if (options.highlight)
+      nuxt.options.css.push(resolver.resolve('./runtime/rangi.css'))
     const outputDir = join(nuxt.options.rootDir, 'node_modules/.cache/comark-content/generated')
     const cacheFile = join(nuxt.options.rootDir, '.data/comark-content/cache.json')
     const remoteCacheDir = join(nuxt.options.rootDir, 'node_modules/.cache/comark-content/git')
@@ -152,12 +155,13 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options._prepare)
       return
 
-    const buildCollections = async () => {
+    const buildCollections = async (remoteCheckout: Parameters<typeof ingestCollections>[1]['remoteCheckout']) => {
       const loaded = await loadCollections(nuxt.options._layers as unknown as ReadonlyArray<Record<string, unknown>>)
       const startedAt = performance.now()
       const result = await ingestCollections(loaded, {
         cacheFile,
         remoteCacheDir,
+        remoteCheckout,
         highlight: options.highlight,
         beforeParse: context => nuxt.callHook('content:file:beforeParse', context),
         afterParse: context => nuxt.callHook('content:file:afterParse', context),
@@ -172,7 +176,10 @@ export default defineNuxtModule<ModuleOptions>({
       initializedCollections = true
       await rm(outputDir, { recursive: true, force: true })
       await mkdir(outputDir, { recursive: true })
-      const assetPlan = createContentAssetPlan(result.value.collections)
+      const assetPlan = createContentAssetPlan({
+        collections: result.value.collections,
+        sitemapCollections: result.value.sitemapCollections,
+      })
       await Promise.all(assetPlan.assets.map(async (asset) => {
         const path = join(outputDir, asset.path)
         await mkdir(dirname(path), { recursive: true })
@@ -180,11 +187,11 @@ export default defineNuxtModule<ModuleOptions>({
       }))
       const files = Object.values(result.value.collections).reduce((sum, items) => sum + items.length, 0)
       logger.success(`Processed ${loaded.length} collections and ${files} files in ${(performance.now() - startedAt).toFixed(2)}ms (${result.value.cachedFiles} cached, ${result.value.parsedFiles} parsed)`)
-      return nuxt.options.dev ? 'dev' : createContentRevision(nuxt.options.buildId, result.value.collections)
+      return nuxt.options.dev ? 'dev' : createContentRevision(result.value.collections)
     }
 
     nuxt.hook('modules:done', async () => {
-      const contentRevision = await buildCollections()
+      const contentRevision = await buildCollections({ _tag: 'Refresh' })
       nuxt.options.runtimeConfig.public.comarkContentRevision = contentRevision
       const contentRouteBase = `/__comark_content/${encodeURIComponent(contentRevision)}`
       addServerHandler({ route: `${contentRouteBase}/navigation/:collection`, method: 'get', handler: resolver.resolve('./runtime/server/api/navigation.get') })
@@ -193,10 +200,11 @@ export default defineNuxtModule<ModuleOptions>({
     })
     let rebuild = Promise.resolve()
     nuxt.hook('builder:watch', (event, path) => {
-      if (event !== 'change' || !path.endsWith('.md'))
+      if (!isMarkdownWatchEvent(event, path))
         return
       rebuild = rebuild.then(async () => {
-        await buildCollections()
+        // A local edit never changes a remote checkout, so no repository is cloned again.
+        await buildCollections({ _tag: 'ReuseExisting' })
       })
       return rebuild
     })

--- a/packages/comark-content/src/runtime/core/ast.ts
+++ b/packages/comark-content/src/runtime/core/ast.ts
@@ -1,0 +1,22 @@
+import type { Node } from 'comark'
+
+export type NodeVisitor = (node: Node) => void
+
+/**
+ * Calls `visit` for every node in document order.
+ * The visitor sees each parent before its children.
+ */
+export function walkNodes(nodes: readonly Node[], visit: NodeVisitor): void {
+  for (const node of nodes) {
+    visit(node)
+    if (typeof node !== 'string')
+      walkNodes(node.slice(2) as Node[], visit)
+  }
+}
+
+/** Joins the text of a node and every descendant. */
+export function nodeToText(node: Node): string {
+  return typeof node === 'string'
+    ? node
+    : node.slice(2).map(child => nodeToText(child as Node)).join('')
+}

--- a/packages/comark-content/src/runtime/core/navigation.ts
+++ b/packages/comark-content/src/runtime/core/navigation.ts
@@ -1,12 +1,6 @@
-import type { Node } from 'comark'
 import type { ContentNavigationItem, ContentSearchSection, NavigationCollectionItem, PageCollectionItemBase } from '../types'
+import { nodeToText } from './ast'
 import { generatedTitle } from './path'
-
-function text(node: Node): string {
-  return typeof node === 'string'
-    ? node
-    : node.slice(2).map(child => text(child as Node)).join('')
-}
 
 function navigationItem(page: NavigationCollectionItem, fields: string[]): ContentNavigationItem {
   const navigation = page.navigation
@@ -101,7 +95,7 @@ export function createSearchSections(pages: PageCollectionItemBase[]): ContentSe
     for (const node of page.body.nodes) {
       if (typeof node !== 'string' && typeof node[0] === 'string' && /^h[1-6]$/.test(node[0])) {
         const level = Number(node[0].slice(1))
-        const title = text(node)
+        const title = nodeToText(node)
         titles.splice(level - 1)
         current = {
           id: `${page.path}#${String(node[1].id ?? '')}`,
@@ -117,9 +111,9 @@ export function createSearchSections(pages: PageCollectionItemBase[]): ContentSe
         continue
       }
       if (current)
-        appendText(current, text(node))
+        appendText(current, nodeToText(node))
       else
-        preface = `${preface} ${text(node)}`.trim()
+        preface = `${preface} ${nodeToText(node)}`.trim()
     }
     return sections
   })

--- a/packages/comark-content/src/runtime/server/plugins/sitemap.ts
+++ b/packages/comark-content/src/runtime/server/plugins/sitemap.ts
@@ -1,14 +1,15 @@
 import { defineNitroPlugin } from 'nitropack/runtime'
 import { createSitemapEntries } from '../../core/sitemap'
-import { loadCollectionIndex, loadCollectionNames } from '../storage'
+import { loadCollectionIndex, loadCollectionManifest } from '../storage'
 
 export default defineNitroPlugin((nitroApp) => {
   const hooks = nitroApp.hooks as typeof nitroApp.hooks & {
     hook: (name: string, callback: (context: { urls: unknown[] }) => Promise<void>) => void
   }
   hooks.hook('sitemap:input', async (context) => {
-    const names = await loadCollectionNames()
-    const collections = await Promise.all(names.map(loadCollectionIndex))
+    const manifest = await loadCollectionManifest()
+    const included = manifest.filter(entry => entry.sitemap).map(entry => entry.name)
+    const collections = await Promise.all(included.map(loadCollectionIndex))
     context.urls.push(...createSitemapEntries(collections.flatMap(collection => collection.map(item => item.metadata))))
   })
 })

--- a/packages/comark-content/src/runtime/server/storage-core.ts
+++ b/packages/comark-content/src/runtime/server/storage-core.ts
@@ -1,4 +1,4 @@
-import type { ContentSearchSection, IndexedContentDocument, NavigationCollectionItem, PageCollectionItemBase } from '../types'
+import type { ContentCollectionManifestEntry, ContentSearchSection, IndexedContentDocument, NavigationCollectionItem, PageCollectionItemBase } from '../types'
 import { decodeCollectionAsset } from './asset'
 
 export type ContentAssetReader = (path: string) => Promise<Uint8Array | null | undefined>
@@ -43,6 +43,6 @@ export function createContentStorage(readAsset: ContentAssetReader) {
       items.push({ ...item.metadata, body: await loadDocumentBody(name, item.bodyAsset) })
     return items
   }
-  const loadCollectionNames = () => loadAsset<string[]>('collections', '<request>:1:1 Missing generated collection metadata.')
-  return { loadCollection, loadCollectionIndex, loadCollectionNames, loadDocumentBody, loadNavigationCollection, loadSearchSections }
+  const loadCollectionManifest = () => loadAsset<ContentCollectionManifestEntry[]>('collections', '<request>:1:1 Missing generated collection metadata.')
+  return { loadCollection, loadCollectionIndex, loadCollectionManifest, loadDocumentBody, loadNavigationCollection, loadSearchSections }
 }

--- a/packages/comark-content/src/runtime/server/storage.ts
+++ b/packages/comark-content/src/runtime/server/storage.ts
@@ -5,7 +5,7 @@ const storage = createContentStorage(path => useStorage('assets:comark-content')
 
 export const loadCollection = storage.loadCollection
 export const loadCollectionIndex = storage.loadCollectionIndex
-export const loadCollectionNames = storage.loadCollectionNames
+export const loadCollectionManifest = storage.loadCollectionManifest
 export const loadDocumentBody = storage.loadDocumentBody
 export const loadNavigationCollection = storage.loadNavigationCollection
 export const loadSearchSections = storage.loadSearchSections

--- a/packages/comark-content/src/runtime/types.ts
+++ b/packages/comark-content/src/runtime/types.ts
@@ -15,16 +15,12 @@ export interface PageCollectionItemBase {
   layout?: string
   prose?: boolean
   breadcrumbs?: boolean
-  h1?: boolean
-  wide?: boolean
   icon?: string
   image?: string
-  status?: string
   publishedAt?: string
   updatedAt?: string
   keywords?: string[]
   relatedPages?: Array<{ path: string, title: string }>
-  newsletter?: boolean
   tags?: string[]
   new?: boolean
   deprecated?: boolean
@@ -34,6 +30,11 @@ export interface PageCollectionItemBase {
   seo?: Record<string, unknown>
   _source: string
   [key: string]: unknown
+}
+
+export interface ContentCollectionManifestEntry {
+  name: string
+  sitemap: boolean
 }
 
 export interface ContentDocumentMetadata {

--- a/packages/comark-content/test/ast.test.ts
+++ b/packages/comark-content/test/ast.test.ts
@@ -1,0 +1,22 @@
+import type { Node } from 'comark'
+import { describe, expect, it } from 'vitest'
+import { nodeToText, walkNodes } from '../src/runtime/core/ast'
+
+const document: Node[] = [
+  ['h1', { id: 'guide' }, 'The ', ['em', {}, 'short'], ' guide'],
+  ['p', {}, 'Read ', ['a', { href: '/next' }, 'the next page'], '.'],
+]
+
+describe('markdown AST helpers', () => {
+  it('joins the text of a node and its descendants', () => {
+    expect(nodeToText(document[0]!)).toBe('The short guide')
+    expect(nodeToText('plain')).toBe('plain')
+  })
+
+  it('visits every node in document order', () => {
+    const tags: string[] = []
+    walkNodes(document, node => tags.push(typeof node === 'string' ? `#${node}` : String(node[0])))
+
+    expect(tags).toEqual(['h1', '#The ', 'em', '#short', '# guide', 'p', '#Read ', 'a', '#the next page', '#.'])
+  })
+})

--- a/packages/comark-content/test/ingest.test.ts
+++ b/packages/comark-content/test/ingest.test.ts
@@ -184,7 +184,19 @@ describe('markdown ingestion', () => {
       { name: 'pages', rootDir: root, definition: defineCollection({ type: 'page', source: '**/*.md' }) },
     ], { cacheFile: join(root, 'cache.json') })
 
-    expect(result).toEqual({ _tag: 'Ok', value: { collections: { pages: [] }, parsedFiles: 0, cachedFiles: 0, componentTags: [] } })
+    expect(result).toEqual({ _tag: 'Ok', value: { collections: { pages: [] }, sitemapCollections: ['pages'], parsedFiles: 0, cachedFiles: 0, componentTags: [] } })
+  })
+
+  it('reports the collections that opted out of the sitemap', async () => {
+    const root = await temporaryRoot()
+    await writeFixture(root, 'content/page.md', '# Page')
+
+    const result = await ingestCollections([
+      { name: 'pages', rootDir: root, definition: defineCollection({ type: 'page', source: '**/*.md' }) },
+      { name: 'snippets', rootDir: root, definition: defineCollection({ type: 'page', source: '**/*.md', sitemap: false }) },
+    ], { cacheFile: join(root, 'cache.json') })
+
+    expect(result).toMatchObject({ _tag: 'Ok', value: { sitemapCollections: ['pages'] } })
   })
 
   it('parses frontmatter and exposes the direct Comark document', async () => {

--- a/packages/comark-content/test/options.test.ts
+++ b/packages/comark-content/test/options.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtUiProseComponents, selectContentComponents } from '../src/components'
-import { assertCloudflareCacheModule, assertSupportedOptions, defineCollection } from '../src/config'
+import { assertCloudflareCacheModule, assertSupportedOptions, defineCollection, mergeCollectionSources } from '../src/config'
+import { isMarkdownWatchEvent } from '../src/core/source'
 
 describe('configuration boundary', () => {
   it('finds unprefixed content component directories in layer priority order', () => {
@@ -65,6 +66,40 @@ describe('configuration boundary', () => {
 
   it('rejects non-Markdown data collections', () => {
     expect(() => defineCollection({ type: 'data' as 'page', source: '**/*.json' })).toThrow('Markdown page collections are the only supported collection type')
+  })
+
+  it('accepts a glob that lists Markdown among its extensions', () => {
+    expect(() => defineCollection({ type: 'page', source: '**/*.{md,yml}' })).not.toThrow()
+    expect(() => defineCollection({ type: 'page', source: { include: '3.docs/**/*.{md,yml}' } })).not.toThrow()
+    expect(() => defineCollection({ type: 'page', source: '**/*.md' })).not.toThrow()
+    expect(() => defineCollection({ type: 'page', source: '**/*' })).not.toThrow()
+    expect(() => defineCollection({ type: 'page', source: '**/*.{json,yml}' })).toThrow('Markdown files are the only supported collection source')
+    expect(() => defineCollection({ type: 'page', source: '**/*.json' })).toThrow('Markdown files are the only supported collection source')
+  })
+
+  it('reports a collection name that two content configurations define', () => {
+    expect(() => mergeCollectionSources([
+      { configPath: '/site/content.config.ts', collections: { docs: defineCollection({ type: 'page' }) } },
+      { configPath: '/layer/content.config.ts', collections: { docs: defineCollection({ type: 'page' }) } },
+    ])).toThrow('/layer/content.config.ts:1:1 Collection "docs" is already defined in /site/content.config.ts')
+  })
+
+  it('keeps every uniquely named collection with its configuration directory', () => {
+    expect(mergeCollectionSources([
+      { configPath: '/site/content.config.ts', collections: { docs: defineCollection({ type: 'page' }) } },
+      { configPath: '/layer/content.config.ts', collections: { blog: defineCollection({ type: 'page' }) } },
+    ]).map(collection => [collection.name, collection.rootDir])).toEqual([
+      ['docs', '/site'],
+      ['blog', '/layer'],
+    ])
+  })
+
+  it('rebuilds content when Markdown is added, changed, or deleted', () => {
+    expect(isMarkdownWatchEvent('add', '/site/content/new.md')).toBe(true)
+    expect(isMarkdownWatchEvent('change', '/site/content/new.md')).toBe(true)
+    expect(isMarkdownWatchEvent('unlink', '/site/content/new.md')).toBe(true)
+    expect(isMarkdownWatchEvent('addDir', '/site/content/guide')).toBe(false)
+    expect(isMarkdownWatchEvent('change', '/site/app/app.vue')).toBe(false)
   })
 
   it('reports database configuration as unsupported at its source', () => {

--- a/packages/comark-content/test/remote.test.ts
+++ b/packages/comark-content/test/remote.test.ts
@@ -34,7 +34,7 @@ describe('remote Markdown sources', () => {
     const result = await prepareRemoteSource({
       repository: { url: 'https://github.com/nuxt-modules/og-image', auth: { token: 'expired' } },
       include: 'docs/content/**/*.md',
-    }, join(root, 'cache'), command)
+    }, join(root, 'cache'), { command })
 
     expect(result._tag).toBe('Ok')
     expect(calls).toHaveLength(2)
@@ -61,5 +61,67 @@ describe('remote Markdown sources', () => {
       _tag: 'Err',
       error: { _tag: 'SourceError', source: repository, line: 1, column: 1 },
     })
+  })
+
+  it('clones an immutable tag once and reuses the checkout', async () => {
+    const root = await temporaryRoot()
+    const clones: string[] = []
+    const command = async (_command: string, args: string[]) => {
+      clones.push(args.at(-1)!)
+      await mkdir(args.at(-1)!, { recursive: true })
+    }
+    const source = { repository: { url: 'https://example.com/docs.git', tag: 'v1.2.3' }, include: '**/*.md' }
+
+    const first = await prepareRemoteSource(source, join(root, 'cache'), { command })
+    const second = await prepareRemoteSource(source, join(root, 'cache'), { command })
+
+    expect(first).toEqual(second)
+    expect(clones).toHaveLength(1)
+  })
+
+  it('reclones a mutable branch under the refresh policy', async () => {
+    const root = await temporaryRoot()
+    const clones: string[] = []
+    const command = async (_command: string, args: string[]) => {
+      clones.push(args.at(-1)!)
+      await mkdir(args.at(-1)!, { recursive: true })
+    }
+    const source = { repository: { url: 'https://example.com/docs.git', branch: 'main' }, include: '**/*.md' }
+
+    await prepareRemoteSource(source, join(root, 'cache'), { command })
+    await prepareRemoteSource(source, join(root, 'cache'), { command })
+
+    expect(clones).toHaveLength(2)
+  })
+
+  it('reuses any existing checkout under the reuse policy', async () => {
+    const root = await temporaryRoot()
+    const clones: string[] = []
+    const command = async (_command: string, args: string[]) => {
+      clones.push(args.at(-1)!)
+      await mkdir(args.at(-1)!, { recursive: true })
+    }
+    const source = { repository: { url: 'https://example.com/docs.git', branch: 'main' }, include: '**/*.md' }
+    const options = { command, policy: { _tag: 'ReuseExisting' } as const }
+
+    const first = await prepareRemoteSource(source, join(root, 'cache'), { command })
+    const second = await prepareRemoteSource(source, join(root, 'cache'), options)
+
+    expect(first).toEqual(second)
+    expect(clones).toHaveLength(1)
+  })
+
+  it('separates checkouts of the same repository by reference', async () => {
+    const root = await temporaryRoot()
+    const command = async (_command: string, args: string[]) => {
+      await mkdir(args.at(-1)!, { recursive: true })
+    }
+    const url = 'https://example.com/docs.git'
+
+    const stable = await prepareRemoteSource({ repository: { url, tag: 'v1' }, include: '**/*.md' }, join(root, 'cache'), { command })
+    const next = await prepareRemoteSource({ repository: { url, tag: 'v2' }, include: '**/*.md' }, join(root, 'cache'), { command })
+
+    expect(stable._tag).toBe('Ok')
+    expect(next).not.toEqual(stable)
   })
 })

--- a/packages/comark-content/test/storage.test.ts
+++ b/packages/comark-content/test/storage.test.ts
@@ -34,13 +34,13 @@ describe('generated collection storage', () => {
   })
 
   it('projects metadata, navigation, search, and one body asset per document', async () => {
-    const plan = createContentAssetPlan({ pages })
+    const plan = createContentAssetPlan({ collections: { pages }, sitemapCollections: ['pages'] })
     const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
     const index = await decodeCollectionAsset<Array<{ metadata: Record<string, unknown>, bodyAsset: string }>>(assets.get('pages/index.json.gz')!, 'pages/index')
     const navigation = await decodeCollectionAsset<Array<Record<string, unknown>>>(assets.get('pages/navigation.json.gz')!, 'pages/navigation')
     const search = await decodeCollectionAsset<Array<Record<string, unknown>>>(assets.get('pages/search.json.gz')!, 'pages/search')
 
-    expect(plan.collectionNames).toEqual(['pages'])
+    expect(plan.manifest).toEqual([{ name: 'pages', sitemap: true }])
     expect(index.map(item => item.metadata)).toEqual(pages.map(({ body: _body, ...metadata }) => metadata))
     expect(index.every(item => assets.has(`pages/body/${item.bodyAsset}`))).toBe(true)
     expect(navigation).toEqual([
@@ -53,7 +53,7 @@ describe('generated collection storage', () => {
     ])
   })
 
-  it('changes the content revision when either the application build or one document changes', () => {
+  it('changes the content revision only when a document changes', () => {
     const original = { pages }
     const changed = {
       pages: pages.map(page => page.path === '/draft'
@@ -61,16 +61,26 @@ describe('generated collection storage', () => {
         : page),
     }
 
-    expect(createContentRevision('app-build', original)).toMatch(/^[a-f0-9]{64}$/)
-    expect(createContentRevision('app-build', { pages })).toBe(createContentRevision('app-build', original))
-    expect(createContentRevision('app-build', { empty: [], pages })).toBe(createContentRevision('app-build', { pages, empty: [] }))
-    expect(createContentRevision('app-build', { pages: pages.map(page => ({ ...page, _source: `/other${page._source}` })) })).toBe(createContentRevision('app-build', original))
-    expect(createContentRevision('app-build', changed)).not.toBe(createContentRevision('app-build', original))
-    expect(createContentRevision('next-app-build', original)).not.toBe(createContentRevision('app-build', original))
+    expect(createContentRevision(original)).toMatch(/^[a-f0-9]{64}$/)
+    expect(createContentRevision({ pages })).toBe(createContentRevision(original))
+    expect(createContentRevision({ empty: [], pages })).toBe(createContentRevision({ pages, empty: [] }))
+    expect(createContentRevision({ pages: pages.map(page => ({ ...page, _source: `/other${page._source}` })) })).toBe(createContentRevision(original))
+    expect(createContentRevision(changed)).not.toBe(createContentRevision(original))
+  })
+
+  it('keeps an opted out collection out of the sitemap manifest', async () => {
+    const plan = createContentAssetPlan({ collections: { pages, snippets: [] }, sitemapCollections: ['pages'] })
+    const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
+    const storage = createContentStorage(async path => assets.get(path) ?? null)
+
+    await expect(storage.loadCollectionManifest()).resolves.toEqual([
+      { name: 'pages', sitemap: true },
+      { name: 'snippets', sitemap: false },
+    ])
   })
 
   it('filters metadata before loading only matched document bodies', async () => {
-    const plan = createContentAssetPlan({ pages })
+    const plan = createContentAssetPlan({ collections: { pages }, sitemapCollections: ['pages'] })
     const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
     const storage = createContentStorage(async path => assets.get(path) ?? null)
     const index = await storage.loadCollectionIndex('pages')
@@ -86,7 +96,7 @@ describe('generated collection storage', () => {
   })
 
   it('returns selected metadata without loading a document body', async () => {
-    const plan = createContentAssetPlan({ pages })
+    const plan = createContentAssetPlan({ collections: { pages }, sitemapCollections: ['pages'] })
     const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
     const storage = createContentStorage(async path => assets.get(path) ?? null)
     const index = await storage.loadCollectionIndex('pages')
@@ -101,7 +111,7 @@ describe('generated collection storage', () => {
   })
 
   it('decompresses matched document bodies one at a time', async () => {
-    const plan = createContentAssetPlan({ pages })
+    const plan = createContentAssetPlan({ collections: { pages }, sitemapCollections: ['pages'] })
     const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
     const storage = createContentStorage(async path => assets.get(path) ?? null)
     const index = await storage.loadCollectionIndex('pages')
@@ -121,7 +131,7 @@ describe('generated collection storage', () => {
   })
 
   it('loads compact navigation and precomputed search without document bodies', async () => {
-    const plan = createContentAssetPlan({ pages })
+    const plan = createContentAssetPlan({ collections: { pages }, sitemapCollections: ['pages'] })
     const assets = new Map(plan.assets.map(asset => [asset.path, asset.data]))
     const reads: string[] = []
     const storage = createContentStorage(async (path) => {


### PR DESCRIPTION
Ten findings in `packages/comark-content`, most costly first. Scope is the package only.

## Fixes

1. **Remote sources cloned again on every ingest.** `prepareRemoteSource` now keys the checkout by repository URL plus reference. A `tag` is immutable, so it is cloned once and reused. A development rebuild passes a `ReuseExisting` policy, so a local Markdown edit never clones a repository. nuxtseo.com has 12 remote collections, so each save cost 12 clones.
2. **Content revision hashed `buildId`.** Every deploy changed the navigation, search, and surroundings routes, so clients on the previous build got 404s. This was incident GSCDUMP-43. `createContentRevision` now hashes the parsed content only. A redeploy with unchanged content keeps the same routes.
3. **Watcher ignored added and deleted Markdown.** `isMarkdownWatchEvent` now accepts `add`, `change`, and `unlink`. A new file no longer needs a restart.
4. **Duplicate collection names were dropped silently.** `mergeCollectionSources` now throws and names both configuration files.
5. **`source.includes('.md')` rejected `**/*.{md,yml}`.** `globExtensions` parses the extensions the glob names. A glob with no extension is accepted, because the scan already filters to `.md`.
6. **`highlight` defaulted off** although all five consumers turn it on. It now defaults on. The Rangi stylesheet is added only when highlighting is on.
7. **Rangi theme and AST helpers were internal.** `contentRangiTheme`, `contentRangiLanguages`, `nodeToText`, and `walkNodes` are exported from the package root.
8. **Sitemap emitted every collection.** A collection can now set `sitemap: false`. The generated manifest carries the flag, and the Nitro plugin reads it.
9. **No README and no LICENSE.** Both added. The README covers setup, collections, remote sources, querying, rendering, highlighting, AST helpers, the sitemap integration, and deployment.
10. **Consumer frontmatter in the public type.** `newsletter`, `wide`, `h1`, and `status` removed from `PageCollectionItemBase`. The index signature still accepts them, and consumers should augment the type.

## BREAKING

Per repository action:

- **harlanzw.com**: `PageCollectionItemBase` no longer declares `newsletter`, `wide`, `h1`, `status`. Augment `PageCollectionItemBase` in a local `.d.ts` if you want them typed. Remove `highlight: true` from `nuxt.config.ts`; it is now the default.
- **unlighthouse.dev**: delete `shared/rangi.ts` and import `contentRangiTheme` and `contentRangiLanguages` from `@harlan-zw/comark-content`. Remove `highlight: true`.
- **nuxtseo.com**: delete the stale `layers/site/_root/content.config.ts`, or rename its 17 collections. The build now fails on the duplicate names. Delete `layers/design-system/shared/rangi.ts` and import the theme from the package. Replace `sitemap: z.literal(false).default(false)` on the snippets schema with `sitemap: false` on the collection. Remove `highlight: true`.
- **gscdump.com**: remove the GSCDUMP-43 workaround in `server/utils/sentry-event-policy.ts:20-34` after this ships. Remove `highlight: true`.
- **request-indexing**: remove `highlight: true`.
- **Any consumer of `@harlan-zw/comark-content/server`**: `loadCollectionNames` is now `loadCollectionManifest` and returns `Array<{ name, sitemap }>`.

Package-internal signature changes, listed for completeness: `createContentRevision(collections)`, `createContentAssetPlan({ collections, sitemapCollections })`, `prepareRemoteSource(source, cacheRoot, { policy, command })`.

## Verification

- `pnpm --filter @harlan-zw/comark-content test`: 8 files, 75 tests, all pass (baseline was 7 files, 63 tests).
- `pnpm --filter @harlan-zw/comark-content lint`: clean.
- `pnpm --filter @harlan-zw/comark-content typecheck`: clean.
- `pnpm --filter @harlan-zw/comark-content build`: clean, and the new root exports appear in `dist/module.mjs`.

New tests cover checkout reuse per reference kind, the reuse policy, content-only revision hashing, the watcher events, duplicate collection names, glob extension parsing, the sitemap manifest, and the AST helpers.

## Not done

- The `configKey` collision with `@nuxt/content` is untouched, as instructed.
- `package.json` version and dependency fields are untouched.
- No consumer repository was changed.
