### PR TITLE
fix(comark-content): answer the stale Nuxt Content sitemap source

### DIFF
--- a/packages/comark-content/src/module.ts
+++ b/packages/comark-content/src/module.ts
@@ -24,7 +24,7 @@ import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtU
 import { assertCloudflareCacheModule, assertSupportedOptions } from './config'
 import { createContentAssetPlan, createContentRevision } from './core/asset'
 import { ingestCollections } from './core/ingest'
-import { excludeNuxtContentSitemapSource } from './sitemap'
+import { excludeNuxtContentSitemapSource, NUXT_CONTENT_SITEMAP_ROUTE } from './sitemap'
 
 export * from './config'
 export type * from './highlight'
@@ -137,6 +137,9 @@ export default defineNuxtModule<ModuleOptions>({
     ])
     addServerHandler({ route: '/__comark_content/query', method: 'post', handler: resolver.resolve('./runtime/server/api/query.post') })
     addServerPlugin(resolver.resolve('./runtime/server/plugins/sitemap'))
+    // Answers the @nuxt/content sitemap source that @nuxtjs/sitemap keeps whenever it
+    // resolved its options before this module ran. See NUXT_CONTENT_SITEMAP_ROUTE.
+    addServerHandler({ route: NUXT_CONTENT_SITEMAP_ROUTE, method: 'get', handler: resolver.resolve('./runtime/server/api/nuxt-content-urls.get') })
 
     nuxt.hook('nitro:config', (config: NitroConfig) => {
       config.serverAssets ||= []

--- a/packages/comark-content/src/runtime/server/api/nuxt-content-urls.get.ts
+++ b/packages/comark-content/src/runtime/server/api/nuxt-content-urls.get.ts
@@ -1,0 +1,10 @@
+import { defineEventHandler } from '#imports'
+
+/**
+ * Stands in for the sitemap source @nuxt/content used to serve.
+ *
+ * Comark contributes its URLs through the `sitemap:input` nitro hook, so this
+ * source has nothing to add. It exists so a surviving `@nuxt/content@v3:urls`
+ * source resolves to an empty list instead of 404ing the whole sitemap route.
+ */
+export default defineEventHandler(() => [])

--- a/packages/comark-content/src/sitemap.ts
+++ b/packages/comark-content/src/sitemap.ts
@@ -5,6 +5,16 @@ interface SitemapOptions {
 
 const NUXT_CONTENT_SOURCE = '@nuxt/content@v3:urls'
 
+/**
+ * The route @nuxt/content's sitemap integration serves.
+ *
+ * @nuxtjs/sitemap registers this source against its own resolved config during its
+ * setup. A module that runs later, as this one does whenever @nuxtjs/sitemap is
+ * listed first, cannot exclude it any more, and the source outlives @nuxt/content
+ * in a restored build cache either way. Comark answers the route instead.
+ */
+export const NUXT_CONTENT_SITEMAP_ROUTE = '/__sitemap__/nuxt-content-urls.json'
+
 export function excludeNuxtContentSitemapSource(options: SitemapOptions | undefined): SitemapOptions {
   if (options?.excludeAppSources === true)
     return options

--- a/packages/comark-content/test/sitemap.test.ts
+++ b/packages/comark-content/test/sitemap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { excludeNuxtContentSitemapSource, NUXT_CONTENT_SITEMAP_ROUTE } from '../src/sitemap'
+
+describe('sitemap source exclusion', () => {
+  it('adds the nuxt content source to an empty exclude list', () => {
+    expect(excludeNuxtContentSitemapSource(undefined)).toEqual({ excludeAppSources: ['@nuxt/content@v3:urls'] })
+  })
+
+  it('keeps a blanket exclusion untouched', () => {
+    expect(excludeNuxtContentSitemapSource({ excludeAppSources: true })).toEqual({ excludeAppSources: true })
+  })
+
+  it('preserves existing exclusions and other options', () => {
+    expect(excludeNuxtContentSitemapSource({ excludeAppSources: ['nuxt:pages'], zeroRuntime: true })).toEqual({
+      excludeAppSources: ['nuxt:pages', '@nuxt/content@v3:urls'],
+      zeroRuntime: true,
+    })
+  })
+
+  it('does not add the source twice', () => {
+    expect(excludeNuxtContentSitemapSource({ excludeAppSources: ['@nuxt/content@v3:urls'] })).toEqual({
+      excludeAppSources: ['@nuxt/content@v3:urls'],
+    })
+  })
+
+  // The exclusion above is lost whenever @nuxtjs/sitemap resolves its options first,
+  // so the source has to stay answerable rather than 404 the sitemap route.
+  it('names the route the surviving source fetches', () => {
+    expect(NUXT_CONTENT_SITEMAP_ROUTE).toBe('/__sitemap__/nuxt-content-urls.json')
+  })
+})


### PR DESCRIPTION
Lands the only part of `chore/vite-8-release` that is not already on main.

## What this is

`chore/vite-8-release` carried 16 commits and a large uncommitted work in progress. Comparing it against main, almost all of it had already landed through PRs #37, #43, #44 and #55. What remained unique was this one fix.

`@nuxtjs/sitemap` registers the `@nuxt/content@v3:urls` source against its own resolved config during its setup. When it is listed before this module, the source can no longer be excluded, and it also outlives `@nuxt/content` in a restored build cache. The surviving source then 404s and takes the whole sitemap route with it.

Comark now answers that route with an empty list. Its own URLs still go through the `sitemap:input` nitro hook, so nothing is duplicated.

## What was deliberately dropped

Replaying the branch wholesale would have reverted newer work on main. These parts of the branch were superseded and are NOT included:

- content revision keying (`createContentRevision`, revision-keyed routes). Main's revision approach from #44 is newer, and the `buildId` weakness in it is being fixed separately.
- the immutable cache policy in `protocol.ts`, `cache.ts`, `config.ts` and `asset.ts`.
- the package's pre-eslint state, its older `package.json`, and the bench harness changes.

`.node-version` from that branch is also not included here. It stays on `chore/vite-8-release`.

## BREAKING

None. The change adds one server route and one exported constant.

## Verification

`pnpm --filter @harlan-zw/comark-content test`: 68 passed, 8 files. Lint clean.