### PR TITLE
fix(nuxt-dx)!: chain overlay handlers, catch dead overrides, repair the budget action

### DIFF
--- a/.github/actions/nuxt-dx-budget/action.yml
+++ b/.github/actions/nuxt-dx-budget/action.yml
@@ -11,9 +11,11 @@ inputs:
     required: false
     default: '10'
   artifact-name:
+    # Kept in step with `SNAPSHOT_ARTIFACT_NAME`, so a report format bump starts a clean
+    # artifact rather than pairing a new report with a baseline `compare` refuses to read.
     description: Artifact this uploads the report to, and reads the baseline back from.
     required: false
-    default: nuxt-dx-size-budget-v2
+    default: nuxt-dx-size-budget-v3
   base-branch:
     description: Branch whose last successful run of this workflow holds the baseline. Defaults to the pull request base, then the repository default branch.
     required: false
@@ -38,8 +40,13 @@ inputs:
 runs:
   using: composite
   steps:
-    # The baseline is the report the last green run on the base branch left behind, so
-    # nothing is rebuilt here and no baseline file is committed to the repository.
+    # The baseline is the report an earlier run on the base branch left behind, so nothing is
+    # rebuilt here and no baseline file is committed to the repository.
+    #
+    # The newest run holding the artifact wins, not the newest green run. This action drops
+    # into a job beside jobs it knows nothing about, so a green workflow would mean every job
+    # in it passed. One red lint job on the base branch would then leave every later pull
+    # request with no baseline, for as long as that job stays red.
     - name: Find the baseline run
       id: baseline
       shell: bash
@@ -49,17 +56,53 @@ runs:
         WORKFLOW: ${{ github.workflow }}
         BASE_BRANCH: ${{ inputs.base-branch || github.event.pull_request.base.ref || github.event.repository.default_branch }}
         REPORT_PATH: ${{ inputs.report-path }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
       run: |
-        set -euo pipefail
+        set -uo pipefail
         echo "report-file=$(basename "$REPORT_PATH")" >> "$GITHUB_OUTPUT"
-        run_id=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch "$BASE_BRANCH" \
-          --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' || true)
+        run_ids=$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch "$BASE_BRANCH" \
+          --status completed --limit 20 --json databaseId --jq '.[].databaseId' || true)
+        run_id=""
+        for candidate in $run_ids; do
+          # `$ENV.ARTIFACT_NAME` keeps the name out of the jq program text, where a quote in
+          # it would need escaping through two layers.
+          held=$(gh api "repos/$REPO/actions/runs/$candidate/artifacts?per_page=100" \
+            --jq '[.artifacts[] | select(.name == $ENV.ARTIFACT_NAME and .expired == false)] | length' 2>/dev/null || true)
+          if [ -n "$held" ] && [ "$held" != "0" ]; then
+            run_id="$candidate"
+            break
+          fi
+        done
         echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
         if [ -z "$run_id" ]; then
-          echo "No successful run of \"$WORKFLOW\" on $BASE_BRANCH yet, so this build has no baseline."
+          echo "No run of \"$WORKFLOW\" on $BASE_BRANCH still holds a \"$ARTIFACT_NAME\" artifact, so this build has no baseline."
         else
           echo "Taking the baseline from run $run_id on $BASE_BRANCH."
         fi
+
+    # `npx --no-install` exits 1 when the bin is absent, which is the code a breached budget
+    # also uses. Resolving the bin here keeps a missing install from reading as growth, and
+    # from passing the job green with an empty summary.
+    - name: Find the size budget CLI
+      id: cli
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -uo pipefail
+        dir="$PWD"
+        while [ "$dir" != "/" ]; do
+          if [ -x "$dir/node_modules/.bin/nuxt-dx" ]; then
+            echo "path=$dir/node_modules/.bin/nuxt-dx" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          dir="$(dirname "$dir")"
+        done
+        if command -v nuxt-dx > /dev/null 2>&1; then
+          echo "path=$(command -v nuxt-dx)" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        # Reported by the verdict step, so this build still uploads its own report.
+        echo "path=" >> "$GITHUB_OUTPUT"
 
     # Missing or expired artifacts are normal on a first run, so a failed download is
     # reported as no baseline rather than as a broken pull request.
@@ -78,27 +121,35 @@ runs:
     # leaves a summary, a comment, and a new baseline behind.
     - name: Compare against the baseline
       id: compare
+      if: steps.cli.outputs.path != ''
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
+        CLI: ${{ steps.cli.outputs.path }}
         BASE_REPORT: ${{ runner.temp }}/nuxt-dx-baseline/${{ steps.baseline.outputs.report-file }}
         HEAD_REPORT: ${{ inputs.report-path }}
         THRESHOLD_KB: ${{ inputs.threshold-kb }}
         SUMMARY_FILE: ${{ runner.temp }}/nuxt-dx-summary.md
       run: |
         set -uo pipefail
-        npx --no-install nuxt-dx compare "$BASE_REPORT" "$HEAD_REPORT" \
+        "$CLI" compare "$BASE_REPORT" "$HEAD_REPORT" \
           --threshold-kb "$THRESHOLD_KB" --allow-missing-base > "$SUMMARY_FILE"
         code="$?"
         cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
         cat "$SUMMARY_FILE"
-        echo "exit-code=$code" >> "$GITHUB_OUTPUT"
+        # Named, so the verdict step never has to read an exit code as growth.
+        case "$code" in
+          0) status=ok ;;
+          2) status=broken ;;
+          *) status=breach ;;
+        esac
+        echo "status=$status" >> "$GITHUB_OUTPUT"
         echo "summary-file=$SUMMARY_FILE" >> "$GITHUB_OUTPUT"
 
     # One comment per app, replaced in place, so a ten-push pull request carries the
     # current numbers rather than ten stale copies of them.
     - name: Comment the summary on the pull request
-      if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' && steps.compare.outputs.exit-code != '2' }}
+      if: ${{ inputs.comment == 'true' && github.event_name == 'pull_request' && (steps.compare.outputs.status == 'ok' || steps.compare.outputs.status == 'breach') }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -138,23 +189,29 @@ runs:
         retention-days: 30
 
     # Last, so a failure here never costs the summary, the comment, or the baseline.
-    # Exit code 2 means nothing was compared, which is a broken step rather than a breach
-    # and fails regardless of what this action was asked to do about growth.
+    # A missing CLI and a broken comparison both mean nothing was measured. Neither is growth,
+    # so both fail regardless of what this action was asked to do about growth.
     - name: Apply the verdict
       shell: bash
       env:
-        CODE: ${{ steps.compare.outputs.exit-code }}
+        CLI: ${{ steps.cli.outputs.path }}
+        STATUS: ${{ steps.compare.outputs.status }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
         FAIL_ON_BREACH: ${{ inputs.fail-on-breach }}
       run: |
         set -uo pipefail
-        if [ "$CODE" = "2" ]; then
+        if [ -z "$CLI" ]; then
+          echo "::error::The nuxt-dx CLI is not installed in \"$WORKING_DIRECTORY\" or any directory above it. Add \`@harlan-zw/nuxt-dx\` to the app and install it before this step."
+          exit 1
+        fi
+        if [ "$STATUS" = "broken" ]; then
           echo "::error::nuxt-dx compare could not compare the two reports. See the log above."
           exit 1
         fi
-        if [ "$CODE" != "0" ] && [ "$FAIL_ON_BREACH" = "true" ]; then
+        if [ "$STATUS" = "breach" ] && [ "$FAIL_ON_BREACH" = "true" ]; then
           echo "::error::A target grew past the threshold. See the size budget summary."
           exit 1
         fi
-        if [ "$CODE" != "0" ]; then
+        if [ "$STATUS" = "breach" ]; then
           echo "::warning::A target grew past the threshold. Reporting only, since \`fail-on-breach\` is off."
         fi

--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -144,7 +144,7 @@ export default defineNuxtConfig({
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "entries": [
     {
       "scope": "client",
@@ -286,7 +286,7 @@ export default defineNuxtConfig({
       nitroPluginsKb: 75,
       // kB budget per Nitro middleware in the server bundle
       nitroMiddlewareKb: 20,
-      // keyed by plugin name or any fragment of an entry path
+      // keyed by plugin name, Nuxt module name, or any fragment of an entry path
       overridesKb: {
         'analytics': 60,
         'server/plugins/queue': 120,
@@ -302,6 +302,15 @@ export default defineNuxtConfig({
 ```
 
 Set `sizeBudget: false` to turn the check off entirely.
+
+A key in `overridesKb` must match a plugin name, a Nuxt module name, or a fragment of an entry path. A key that matches nothing changes no budget, so the build lists every key that matched no runtime entry:
+
+```
+[nuxt-dx]  WARN  1 `sizeBudget.overridesKb` key matched no runtime entry: `server/plugins/sentry.ts`.
+                 Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.
+```
+
+Some modules ship a runtime entry that no app can make smaller. Those carry their own budget, so you do not write the same override in every app that installs them. `@sentry/nuxt` gets 400 kB for its Nitro plugin. A known budget only raises the budget for the scope, so a lower `nitroPluginsKb`, or an override you write yourself, still wins.
 
 Budgets are measured whenever a bundle is produced. Nitro entries report during development and builds. Client entries only report during builds.
 

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -11,6 +11,7 @@ import { isAbsolute, resolve } from 'node:path'
 import { addPlugin, addTypeTemplate, createResolver, defineNuxtModule, resolveModule, useLogger } from '@nuxt/kit'
 import { budgetFor, smallestBudget } from './size-budget/budget'
 import { moduleOwnerOf, moduleRoot } from './size-budget/module-owner'
+import { createOverrideUsage } from './size-budget/override-usage'
 import { extractPluginName } from './size-budget/plugin-name'
 import { formatBudgetReport } from './size-budget/report'
 import { sizeBudgetRollupPlugin } from './size-budget/rollup'
@@ -32,6 +33,7 @@ export interface SizeBudgetOptions {
   middlewareKb?: number | false
   /**
    * Kilobyte budget for each Nitro plugin in the server bundle. `false` disables the check.
+   * Modules with a known heavy Nitro plugin, such as `@sentry/nuxt`, carry their own budget.
    * @default 75
    */
   nitroPluginsKb?: number | false
@@ -40,7 +42,10 @@ export interface SizeBudgetOptions {
    * @default 20
    */
   nitroMiddlewareKb?: number | false
-  /** Per-target kilobyte budgets, keyed by plugin name or any fragment of the path. */
+  /**
+   * Per-target kilobyte budgets, keyed by plugin name, Nuxt module name, or any fragment of
+   * the path. A key that matches no measured entry is reported at the end of the build.
+   */
   overridesKb?: Record<string, number>
   /**
    * Fail the build instead of warning.
@@ -156,7 +161,7 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
     const verdicts: BudgetVerdict[] = await Promise.all(candidates.map(async (target) => {
       const { path, owner, measurement } = target
       const name = target.name ?? (named ? await readPluginName(path, nuxt) : undefined)
-      return { path, name, owner, budgetBytes: budgetFor(path, name, defaultBytes, budgets.overrides), measurement }
+      return { path, name, owner, budgetBytes: budgetFor(scope, { path, name, owner }, defaultBytes, budgets.overrides), measurement }
     }))
 
     const over = verdicts
@@ -223,6 +228,38 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
   const writeSnapshot = reportPath === undefined
     ? undefined
     : createSnapshotWriter(resolve(nuxt.options.rootDir, reportPath), reportBaseDir(nuxt))
+
+  const clientScopes = enabledScopes.filter(scope => scope === 'client' || scope === 'client-middleware')
+  const nitroScopes = enabledScopes.filter(scope => scope === 'nitro' || scope === 'nitro-middleware')
+
+  const overrideUsage = createOverrideUsage(budgets.overrides)
+  /**
+   * The client bundle and the Nitro bundle are measured in separate passes, so an override
+   * keyed to a Nitro plugin has matched nothing while the client pass runs. The verdict waits
+   * for the last pass. A bundle with no runtime entries at all never reports, and then nothing
+   * is claimed either way.
+   */
+  let pendingPasses = (clientScopes.length ? 1 : 0) + (nitroScopes.length ? 1 : 0)
+  const trackOverrides = async (measured: readonly MeasuredTarget[]) => {
+    overrideUsage.use(measured)
+    if (overrideUsage.unused().length) {
+      // A fragment can name a plugin whose size never put it at risk, and those names are
+      // never read. Read them now, so a working override is not reported as a dead one.
+      const named = await Promise.all(measured
+        .filter(target => target.scope === 'client' && target.name === undefined)
+        .map(async target => ({ ...target, name: await readPluginName(target.path, nuxt) })))
+      overrideUsage.use(named)
+    }
+    pendingPasses -= 1
+    if (pendingPasses !== 0)
+      return
+    const unused = overrideUsage.unused()
+    if (!unused.length)
+      return
+    const keys = unused.map(fragment => `\`${fragment}\``).join(', ')
+    logger.warn(`${unused.length} \`sizeBudget.overridesKb\` key${unused.length === 1 ? '' : 's'} matched no runtime entry: ${keys}. Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.`)
+  }
+
   /**
    * Every measurement is recorded, then judged. The report covers the whole build so
    * a later run can diff it, and it is written before the verdict so a failing budget
@@ -239,10 +276,10 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
         await writeSnapshot?.(scope, entries)
         await reports.get(scope)!(entries)
       }
+      await trackOverrides(measured)
     }
   }
 
-  const clientScopes = enabledScopes.filter(scope => scope === 'client' || scope === 'client-middleware')
   // `app:resolve` holds app and module registrations before the client build starts.
   let resolvedApp: NuxtApp | undefined
   if (clientScopes.length) {
@@ -276,7 +313,6 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
     })
   }
 
-  const nitroScopes = enabledScopes.filter(scope => scope === 'nitro' || scope === 'nitro-middleware')
   if (nitroScopes.length) {
     nuxt.hook('nitro:init', (nitro) => {
       nitro.hooks.hook('rollup:before', (_nitro, config) => {

--- a/packages/nuxt-dx/src/runtime/app/handler-chain.ts
+++ b/packages/nuxt-dx/src/runtime/app/handler-chain.ts
@@ -1,0 +1,53 @@
+/**
+ * A Vue app config slot such as `warnHandler` holds exactly one function. Every plugin that
+ * wants to see warnings assigns to it, and the last assignment wins, so every plugin that
+ * assigned earlier goes silent without a word. A chain keeps the handler it displaced and
+ * calls it, and can take the slot back from a handler installed after it.
+ */
+
+type AnyHandler = (...args: never[]) => void
+
+export interface HandlerSlot<Fn extends AnyHandler> {
+  read: () => Fn | undefined
+  write: (handler: Fn | undefined) => void
+}
+
+export interface HandlerChain<Fn extends AnyHandler> {
+  /** The handler this one delegates to, or nothing when it is last in the chain. */
+  next: () => Fn | undefined
+  /** Replaces the handler this one delegates to. */
+  setNext: (handler: Fn | undefined) => void
+  /** Takes the slot back from a handler installed later, and delegates to that handler. */
+  reinstall: () => void
+  /** Gives the slot back. Does nothing when a handler installed later owns it. */
+  restore: () => void
+}
+
+export function chainHandler<Fn extends AnyHandler>(
+  slot: HandlerSlot<Fn>,
+  handle: (next: Fn | undefined, ...args: Parameters<Fn>) => void,
+): HandlerChain<Fn> {
+  let next = slot.read()
+  const handler = ((...args: Parameters<Fn>) => {
+    handle(next, ...args)
+  }) as unknown as Fn
+  slot.write(handler)
+  return {
+    next: () => next,
+    setNext: (replacement) => {
+      next = replacement
+    },
+    reinstall: () => {
+      const current = slot.read()
+      // Reinstalling while this chain still owns the slot would make it delegate to itself.
+      if (current === handler)
+        return
+      next = current
+      slot.write(handler)
+    },
+    restore: () => {
+      if (slot.read() === handler)
+        slot.write(next)
+    },
+  }
+}

--- a/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
+++ b/packages/nuxt-dx/src/runtime/app/plugins/error-overlay.client.ts
@@ -3,8 +3,17 @@ import type { DiagnosticIssue } from '../report'
 import { useEventListener, useStorage } from '@vueuse/core'
 import { effectScope } from 'vue'
 import { defineNuxtPlugin, useRoute, useRuntimeConfig } from '#app'
+import { chainHandler } from '../handler-chain'
 import { HYDRATION_SUMMARY_ERROR, parseComponentTrace, parseHydrationWarning } from '../hydration'
 import { formatDiagnosticReport, formatIssueLine, issueSignature, relativeSourcePath } from '../report'
+
+type VueWarnHandler = (message: string, instance: ComponentPublicInstance | null, trace: string) => void
+type VueErrorHandler = (error: unknown, instance: ComponentPublicInstance | null, info: string) => void
+
+/** Nuxt marks the `errorHandler` it installs before plugins run, so it can drop it again. */
+interface NuxtDefaultErrorHandler extends VueErrorHandler {
+  __nuxt_default?: boolean
+}
 
 interface DebugComponent extends ComponentPublicInstance {
   $: ComponentPublicInstance['$'] & {
@@ -583,30 +592,68 @@ export default defineNuxtPlugin({
     }
 
     const originalConsoleError = console.error
-    const previousWarnHandler = nuxtApp.vueApp.config.warnHandler
-    const previousErrorHandler = nuxtApp.vueApp.config.errorHandler
+    const vueConfig = nuxtApp.vueApp.config
 
-    const warnHandler: typeof previousWarnHandler = (message, instance, trace) => {
-      const mismatch = parseHydrationWarning(message.trim())
-      if (mismatch) {
-        const chain = parseComponentTrace(trace)
-        const issue: DiagnosticIssue = { kind: 'hydration', mismatch, component: chain[0], componentFile: sourceFile(instance), trace: chain }
-        addIssue(issue)
-        console.warn(`[nuxt-dx] ${formatIssueLine(issue)}`)
-        return
-      }
-      const formatted = `${message.trim()}${sourceDetails(instance)}`
-      addIssue({ kind: 'warning', message: formatted })
-      console.warn(`[Vue warn]: ${formatted}`)
-    }
-    const errorHandler: typeof previousErrorHandler = (error, instance, info) => {
-      const message = error instanceof Error ? error.stack ?? error.message : String(error)
-      const formatted = `${info}: ${message}${sourceDetails(instance)}`
-      addIssue({ kind: 'error', message: formatted })
-      originalConsoleError(`[Vue error]: ${formatted}`)
-    }
-    nuxtApp.vueApp.config.warnHandler = warnHandler
-    nuxtApp.vueApp.config.errorHandler = errorHandler
+    /**
+     * Both handlers record the issue and then hand it on. Whoever held the slot decides what
+     * reaches the console, and Vue logs the warning itself when nobody does, so this logs only
+     * when there is nothing behind it. An app that suppresses a warning keeps a quiet console
+     * and still sees the issue in the overlay.
+     */
+    const warnChain = chainHandler<VueWarnHandler>(
+      { read: () => vueConfig.warnHandler, write: (handler) => { vueConfig.warnHandler = handler } },
+      (next, message, instance, trace) => {
+        const mismatch = parseHydrationWarning(message.trim())
+        if (mismatch) {
+          const chain = parseComponentTrace(trace)
+          const issue: DiagnosticIssue = { kind: 'hydration', mismatch, component: chain[0], componentFile: sourceFile(instance), trace: chain }
+          addIssue(issue)
+          if (next)
+            next(message, instance, trace)
+          else
+            console.warn(`[nuxt-dx] ${formatIssueLine(issue)}`)
+          return
+        }
+        const formatted = `${message.trim()}${sourceDetails(instance)}`
+        addIssue({ kind: 'warning', message: formatted })
+        if (next)
+          next(message, instance, trace)
+        else
+          console.warn(`[Vue warn]: ${formatted}`)
+      },
+    )
+    const errorChain = chainHandler<VueErrorHandler>(
+      { read: () => vueConfig.errorHandler, write: (handler) => { vueConfig.errorHandler = handler } },
+      (next, error, instance, info) => {
+        const message = error instanceof Error ? error.stack ?? error.message : String(error)
+        const formatted = `${info}: ${message}${sourceDetails(instance)}`
+        addIssue({ kind: 'error', message: formatted })
+        if (next)
+          next(error, instance, info)
+        else
+          originalConsoleError(`[Vue error]: ${formatted}`)
+      },
+    )
+
+    /**
+     * This plugin runs first, so every plugin after it can take the slot and leave the overlay
+     * blind. `app:created` fires once every plugin has run, which is the first moment where
+     * taking the slot back cannot be undone by another plugin.
+     */
+    const removeCreatedHook = nuxtApp.hook('app:created', () => {
+      warnChain.reinstall()
+      errorChain.reinstall()
+    })
+    /**
+     * Nuxt installs its own `errorHandler` before any plugin, and drops it once the app has
+     * resolved, but only while it still holds the slot. This chain holds the slot instead, so
+     * it drops that handler on Nuxt's behalf. Without this, every error after hydration would
+     * reach Nuxt's startup handler and turn into the error page.
+     */
+    const removeSuspenseHook = nuxtApp.hook('app:suspense:resolve', () => {
+      if ((errorChain.next() as NuxtDefaultErrorHandler | undefined)?.__nuxt_default)
+        errorChain.setNext(undefined)
+    })
 
     const patchedConsoleError = (...args: unknown[]) => {
       const message = args.map(value => value instanceof Error ? value.stack ?? value.message : String(value)).join(' ').trim()
@@ -724,10 +771,10 @@ export default defineNuxtPlugin({
         clearTimeout(copyResetTimer)
       if (console.error === patchedConsoleError)
         console.error = originalConsoleError
-      if (nuxtApp.vueApp.config.warnHandler === warnHandler)
-        nuxtApp.vueApp.config.warnHandler = previousWarnHandler
-      if (nuxtApp.vueApp.config.errorHandler === errorHandler)
-        nuxtApp.vueApp.config.errorHandler = previousErrorHandler
+      removeCreatedHook()
+      removeSuspenseHook()
+      warnChain.restore()
+      errorChain.restore()
       host.remove()
     }
     import.meta.hot?.dispose(cleanup)

--- a/packages/nuxt-dx/src/size-budget/budget.ts
+++ b/packages/nuxt-dx/src/size-budget/budget.ts
@@ -1,4 +1,6 @@
 import type { CostMeasurement } from './graph'
+import type { BudgetScope } from './scope'
+import { knownBudgetBytes } from './known-budgets'
 
 export interface BudgetVerdict {
   path: string
@@ -11,9 +13,27 @@ export interface BudgetVerdict {
 }
 
 export interface BudgetOverride {
-  /** A plugin name or any fragment of a runtime entry path. */
+  /** A plugin name, a Nuxt module name, or any fragment of a runtime entry path. */
   fragment: string
   bytes: number
+}
+
+/** What an override fragment is matched against. */
+export interface BudgetSubject {
+  path: string
+  name?: string
+  owner?: string
+}
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+/** True when the fragment names the entry, names the module that registered it, or sits in its path. */
+export function overrideMatches(fragment: string, subject: BudgetSubject): boolean {
+  return fragment === subject.name
+    || fragment === subject.owner
+    || normalize(subject.path).includes(fragment)
 }
 
 /**
@@ -24,10 +44,12 @@ export function smallestBudget(defaultBytes: number, overrides: readonly BudgetO
   return overrides.reduce((smallest, override) => Math.min(smallest, override.bytes), defaultBytes)
 }
 
-export function budgetFor(path: string, name: string | undefined, defaultBytes: number, overrides: readonly BudgetOverride[]): number {
-  const normalized = path.replace(/\\/g, '/')
-  // An override keyed by name wins over one keyed by a path fragment.
-  const override = overrides.find(candidate => candidate.fragment === name)
-    ?? overrides.find(candidate => normalized.includes(candidate.fragment))
-  return override?.bytes ?? defaultBytes
+export function budgetFor(scope: BudgetScope, subject: BudgetSubject, defaultBytes: number, overrides: readonly BudgetOverride[]): number {
+  // An override keyed by name beats one keyed by module, which beats one keyed by a path fragment.
+  const override = overrides.find(candidate => candidate.fragment === subject.name)
+    ?? overrides.find(candidate => candidate.fragment === subject.owner)
+    ?? overrides.find(candidate => normalize(subject.path).includes(candidate.fragment))
+  if (override)
+    return override.bytes
+  return Math.max(defaultBytes, knownBudgetBytes(scope, subject) ?? 0)
 }

--- a/packages/nuxt-dx/src/size-budget/known-budgets.ts
+++ b/packages/nuxt-dx/src/size-budget/known-budgets.ts
@@ -1,0 +1,42 @@
+import type { BudgetScope } from './scope'
+import { kilobytesToBytes } from './size'
+
+export interface KnownBudget {
+  scope: BudgetScope
+  /** Nuxt module that registers the entry. Matched against the owner and the path. */
+  module: string
+  kilobytes: number
+  /** Why this entry costs more than the scope budget allows. */
+  reason: string
+}
+
+/**
+ * Budgets for runtime entries that are known to be heavy, and that the app installing them
+ * cannot make smaller. Without these, every app copies the same override into its config,
+ * and a real regression inside the module then hides behind that copy.
+ *
+ * A known budget only raises the scope budget. An app that sets a higher budget, or writes
+ * its own override, still wins.
+ */
+export const KNOWN_BUDGETS = [
+  {
+    scope: 'nitro',
+    module: '@sentry/nuxt',
+    // Measured at 326 kB across the apps that carried the copied override. 400 kB leaves
+    // room for a patch release of the SDK and still catches the plugin doubling in size.
+    kilobytes: 400,
+    reason: 'The Sentry Nitro plugin bundles the Node SDK and its OpenTelemetry instrumentation.',
+  },
+] as const satisfies readonly KnownBudget[]
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+/** The known budget for a runtime entry, in bytes, or nothing when no known module owns it. */
+export function knownBudgetBytes(scope: BudgetScope, subject: { path: string, owner?: string }): number | undefined {
+  const path = normalize(subject.path)
+  const known = KNOWN_BUDGETS.find(candidate => candidate.scope === scope
+    && (candidate.module === subject.owner || path.includes(`/${candidate.module}/`)))
+  return known === undefined ? undefined : kilobytesToBytes(known.kilobytes)
+}

--- a/packages/nuxt-dx/src/size-budget/override-usage.ts
+++ b/packages/nuxt-dx/src/size-budget/override-usage.ts
@@ -1,0 +1,27 @@
+import type { BudgetOverride, BudgetSubject } from './budget'
+import { overrideMatches } from './budget'
+
+export interface OverrideUsage {
+  /** Marks every fragment these entries match as used. */
+  use: (subjects: readonly BudgetSubject[]) => void
+  /** Fragments no measured entry matched. Each one changes no budget. */
+  unused: () => string[]
+}
+
+/**
+ * An override keyed to something the build never measured silences nothing. The warning it
+ * was written for keeps firing, and nothing says the key is dead. Tracking what each fragment
+ * matched turns a typo, a renamed plugin, or a deleted file into one warning.
+ */
+export function createOverrideUsage(overrides: readonly BudgetOverride[]): OverrideUsage {
+  const unused = new Set(overrides.map(override => override.fragment))
+  return {
+    use: (subjects) => {
+      for (const fragment of unused) {
+        if (subjects.some(subject => overrideMatches(fragment, subject)))
+          unused.delete(fragment)
+      }
+    },
+    unused: () => [...unused],
+  }
+}

--- a/packages/nuxt-dx/src/size-budget/snapshot.ts
+++ b/packages/nuxt-dx/src/size-budget/snapshot.ts
@@ -13,6 +13,13 @@ import { isBudgetScope } from './scope'
 export const SNAPSHOT_VERSION = 3
 
 /**
+ * Artifact the CI action stores the report in, and reads the baseline back from. Keyed by
+ * format, so a format bump starts a clean artifact instead of pairing a new report with a
+ * baseline that `compare` refuses to read.
+ */
+export const SNAPSHOT_ARTIFACT_NAME = `nuxt-dx-size-budget-v${SNAPSHOT_VERSION}`
+
+/**
  * Where the report lands, relative to the app root. Not `nuxt.options.buildDir`: that
  * moved into `node_modules/.cache` in Nuxt 4.5, which is no place to point a CI step at.
  */

--- a/packages/nuxt-dx/tests/action.test.ts
+++ b/packages/nuxt-dx/tests/action.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
+import { SNAPSHOT_ARTIFACT_NAME } from '../src/size-budget/snapshot'
 
 /**
  * The composite action consumers paste into their own workflow. It cannot be executed
@@ -55,10 +56,33 @@ describe('nuxt-dx-budget action', () => {
       expect(source).toMatch(new RegExp(`${uses.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} # v\\d+\\.\\d+\\.\\d+`))
   })
 
-  it('reads the baseline from the last green run on the base branch', () => {
-    expect(step('Find the baseline run').run).toContain('gh run list')
-    expect(step('Find the baseline run').run).toContain('--status success')
+  it('reads the baseline from the newest run on the base branch that still holds the artifact', () => {
+    const find = step('Find the baseline run').run!
+    expect(find).toContain('gh run list')
+    // A green workflow is the wrong test: the action drops into a job beside jobs it knows
+    // nothing about, so one red lint job on the base branch would leave every later pull
+    // request with no baseline. What matters is that the run left the artifact behind.
+    expect(find).not.toContain('--status success')
+    expect(find).toContain('actions/runs/')
+    expect(find).toContain('artifacts')
+    expect(find).toContain('ARTIFACT_NAME')
     expect(step('Download the baseline report').uses).toContain('actions/download-artifact')
+  })
+
+  it('names the baseline artifact after the report format, so a format bump starts clean', () => {
+    // A report the CLI refuses to read is a stuck branch: every run fails on the baseline
+    // that broke it, and never replaces it.
+    expect(action.inputs['artifact-name']!.default).toBe(SNAPSHOT_ARTIFACT_NAME)
+  })
+
+  it('fails loudly when the size budget CLI is not installed', () => {
+    // `npx --no-install` exits 1 for a missing bin, the same code a breach uses, so the
+    // job would otherwise pass green with an empty summary.
+    const find = step('Find the size budget CLI').run!
+    expect(find).toContain('node_modules/.bin/nuxt-dx')
+    expect(step('Compare against the baseline').if).toContain('steps.cli.outputs.path')
+    const verdict = step('Apply the verdict').run!
+    expect(verdict).toMatch(/-z "\$CLI"[\s\S]*?::error::[\s\S]*?exit 1/)
   })
 
   it('treats a missing or expired baseline as a pass', () => {
@@ -81,8 +105,9 @@ describe('nuxt-dx-budget action', () => {
   })
 
   it('still fails when the two reports could not be compared at all', () => {
-    // Exit code 2 is a broken step, not growth, so no input makes it passable.
-    expect(step('Apply the verdict').run).toMatch(/CODE" = "2"[\s\S]*?exit 1/)
+    // A broken comparison is not growth, so no input makes it passable.
+    expect(step('Compare against the baseline').run).toContain('status=broken')
+    expect(step('Apply the verdict').run).toMatch(/STATUS" = "broken"[\s\S]*?exit 1/)
   })
 
   it('decides the verdict after the baseline is uploaded, so a failure keeps it', () => {

--- a/packages/nuxt-dx/tests/budget.test.ts
+++ b/packages/nuxt-dx/tests/budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { budgetFor, smallestBudget } from '../src/size-budget/budget'
+import { kilobytesToBytes } from '../src/size-budget/size'
 
 const OVERRIDES = [
   { fragment: 'analytics', bytes: 60_000 },
@@ -22,23 +23,60 @@ describe('smallestBudget', () => {
 
 describe('budgetFor', () => {
   it('falls back to the default', () => {
-    expect(budgetFor('/app/plugins/other.ts', undefined, 20_000, OVERRIDES)).toBe(20_000)
+    expect(budgetFor('client', { path: '/app/plugins/other.ts' }, 20_000, OVERRIDES)).toBe(20_000)
   })
 
   it('matches an override by plugin name', () => {
-    expect(budgetFor('/app/plugins/heavy.ts', 'analytics', 20_000, OVERRIDES)).toBe(60_000)
+    expect(budgetFor('client', { path: '/app/plugins/heavy.ts', name: 'analytics' }, 20_000, OVERRIDES)).toBe(60_000)
   })
 
   it('matches an override by path fragment', () => {
-    expect(budgetFor('/app/server/plugins/queue.ts', undefined, 20_000, OVERRIDES)).toBe(5000)
+    expect(budgetFor('nitro', { path: '/app/server/plugins/queue.ts' }, 20_000, OVERRIDES)).toBe(5000)
+  })
+
+  it('matches an override by the Nuxt module that registered the entry', () => {
+    const overrides = [{ fragment: 'fixture-auth-module', bytes: 90_000 }]
+    expect(budgetFor('client', { path: '/app/.nuxt/auth.mjs', owner: 'fixture-auth-module' }, 20_000, overrides)).toBe(90_000)
   })
 
   it('prefers a name match over a path match', () => {
     const overrides = [{ fragment: 'plugins/heavy', bytes: 1000 }, { fragment: 'analytics', bytes: 60_000 }]
-    expect(budgetFor('/app/plugins/heavy.ts', 'analytics', 20_000, overrides)).toBe(60_000)
+    expect(budgetFor('client', { path: '/app/plugins/heavy.ts', name: 'analytics' }, 20_000, overrides)).toBe(60_000)
   })
 
   it('matches path fragments written with windows separators', () => {
-    expect(budgetFor('C:\\app\\server\\plugins\\queue.ts', undefined, 20_000, OVERRIDES)).toBe(5000)
+    expect(budgetFor('nitro', { path: 'C:\\app\\server\\plugins\\queue.ts' }, 20_000, OVERRIDES)).toBe(5000)
+  })
+})
+
+// Every app that installs one of these modules used to copy the same override into its
+// config, which also hid a real regression inside that module behind the copy.
+describe('budgetFor with a known heavy module', () => {
+  const sentryBudget = kilobytesToBytes(400)
+
+  it('raises the Nitro plugin budget for the Sentry Nitro plugin, by owner', () => {
+    expect(budgetFor('nitro', { path: '/app/.nuxt/sentry-nitro.mjs', owner: '@sentry/nuxt' }, kilobytesToBytes(75), []))
+      .toBe(sentryBudget)
+  })
+
+  it('raises it by path when the module reports no name', () => {
+    expect(budgetFor('nitro', { path: '/app/node_modules/@sentry/nuxt/build/module/plugins/sentry.js' }, kilobytesToBytes(75), []))
+      .toBe(sentryBudget)
+  })
+
+  it('leaves the client plugin budget alone, since only the Nitro plugin is heavy', () => {
+    expect(budgetFor('client', { path: '/app/.nuxt/sentry-client.mjs', owner: '@sentry/nuxt' }, kilobytesToBytes(30), []))
+      .toBe(kilobytesToBytes(30))
+  })
+
+  it('never lowers a budget the app set higher', () => {
+    expect(budgetFor('nitro', { path: '/app/.nuxt/sentry-nitro.mjs', owner: '@sentry/nuxt' }, kilobytesToBytes(600), []))
+      .toBe(kilobytesToBytes(600))
+  })
+
+  it('loses to an override the app wrote', () => {
+    const overrides = [{ fragment: '@sentry/nuxt', bytes: 10_000 }]
+    expect(budgetFor('nitro', { path: '/app/.nuxt/sentry-nitro.mjs', owner: '@sentry/nuxt' }, kilobytesToBytes(75), overrides))
+      .toBe(10_000)
   })
 })

--- a/packages/nuxt-dx/tests/handler-chain.test.ts
+++ b/packages/nuxt-dx/tests/handler-chain.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { chainHandler } from '../src/runtime/app/handler-chain'
+
+type Warn = (message: string) => void
+
+/** Stands in for `vueApp.config.warnHandler`: one slot, last writer wins. */
+function warnSlot(initial?: Warn) {
+  let handler = initial
+  return {
+    current: () => handler,
+    slot: {
+      read: () => handler,
+      write: (next: Warn | undefined) => {
+        handler = next
+      },
+    },
+  }
+}
+
+describe('chainHandler', () => {
+  it('calls the handler that already held the slot', () => {
+    const seen: string[] = []
+    const previous: Warn = message => seen.push(`previous:${message}`)
+    const { slot, current } = warnSlot(previous)
+
+    chainHandler<Warn>(slot, (next, message) => {
+      seen.push(`chain:${message}`)
+      next?.(message)
+    })
+    current()!('boom')
+
+    expect(seen).toEqual(['chain:boom', 'previous:boom'])
+  })
+
+  it('reports nothing to delegate when the slot was empty', () => {
+    const seen: (Warn | undefined)[] = []
+    const { slot, current } = warnSlot()
+
+    chainHandler<Warn>(slot, (next) => {
+      seen.push(next)
+    })
+    current()!('boom')
+
+    expect(seen).toEqual([undefined])
+  })
+
+  it('takes the slot back from a handler installed later, and keeps that handler', () => {
+    const seen: string[] = []
+    const { slot, current } = warnSlot(message => seen.push(`first:${message}`))
+    const chain = chainHandler<Warn>(slot, (next, message) => {
+      seen.push(`chain:${message}`)
+      next?.(message)
+    })
+
+    // A plugin that runs after this one assigns the slot, so the chain stops being called.
+    slot.write(message => seen.push(`later:${message}`))
+    current()!('one')
+    chain.reinstall()
+    current()!('two')
+
+    expect(seen).toEqual(['later:one', 'chain:two', 'later:two'])
+  })
+
+  it('reinstalls without adding itself to its own chain', () => {
+    const seen: string[] = []
+    const { slot, current } = warnSlot()
+    const chain = chainHandler<Warn>(slot, (next, message) => {
+      seen.push(`chain:${message}`)
+      next?.(message)
+    })
+
+    chain.reinstall()
+    chain.reinstall()
+    current()!('boom')
+
+    expect(seen).toEqual(['chain:boom'])
+  })
+
+  it('gives the slot back to the handler it delegates to', () => {
+    const seen: string[] = []
+    const previous: Warn = message => seen.push(`previous:${message}`)
+    const { slot, current } = warnSlot(previous)
+    const chain = chainHandler<Warn>(slot, (next, message) => {
+      seen.push(`chain:${message}`)
+      next?.(message)
+    })
+
+    chain.restore()
+
+    expect(current()).toBe(previous)
+  })
+
+  it('leaves a handler installed later alone when it gives the slot back', () => {
+    const { slot, current } = warnSlot()
+    const chain = chainHandler<Warn>(slot, () => {})
+    const later: Warn = () => {}
+
+    slot.write(later)
+    chain.restore()
+
+    expect(current()).toBe(later)
+  })
+
+  it('stops delegating once the handler it delegates to is dropped', () => {
+    const seen: string[] = []
+    const previous: Warn = message => seen.push(`previous:${message}`)
+    const { slot, current } = warnSlot(previous)
+    const chain = chainHandler<Warn>(slot, (next, message) => {
+      seen.push(`chain:${message}`)
+      next?.(message)
+    })
+
+    expect(chain.next()).toBe(previous)
+    chain.setNext(undefined)
+    current()!('boom')
+
+    expect(seen).toEqual(['chain:boom'])
+  })
+})

--- a/packages/nuxt-dx/tests/override-usage.test.ts
+++ b/packages/nuxt-dx/tests/override-usage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { createOverrideUsage } from '../src/size-budget/override-usage'
+
+const override = (fragment: string) => ({ fragment, bytes: 1024 })
+
+describe('createOverrideUsage', () => {
+  it('reports every fragment as unused before anything is measured', () => {
+    const usage = createOverrideUsage([override('analytics'), override('server/plugins/sentry.ts')])
+
+    expect(usage.unused()).toEqual(['analytics', 'server/plugins/sentry.ts'])
+  })
+
+  it('clears a fragment that a measured path contains', () => {
+    const usage = createOverrideUsage([override('server/plugins/sentry.ts')])
+
+    usage.use([{ path: '/app/server/plugins/sentry.ts' }])
+
+    expect(usage.unused()).toEqual([])
+  })
+
+  it('clears a fragment that names a measured entry', () => {
+    const usage = createOverrideUsage([override('analytics')])
+
+    usage.use([{ path: '/app/app/plugins/tracking.ts', name: 'analytics' }])
+
+    expect(usage.unused()).toEqual([])
+  })
+
+  it('clears a fragment that names the Nuxt module that registered an entry', () => {
+    const usage = createOverrideUsage([override('@sentry/nuxt')])
+
+    usage.use([{ path: '/app/.nuxt/sentry.mjs', owner: '@sentry/nuxt' }])
+
+    expect(usage.unused()).toEqual([])
+  })
+
+  it('keeps a fragment that no measured entry matches', () => {
+    const usage = createOverrideUsage([override('server/plugins/sentry.ts'), override('analytics')])
+
+    usage.use([{ path: '/app/server/plugins/audit.ts' }])
+    usage.use([{ path: '/app/app/plugins/analytics.client.ts', name: 'analytics' }])
+
+    expect(usage.unused()).toEqual(['server/plugins/sentry.ts'])
+  })
+
+  it('matches a Windows path against a fragment written with forward slashes', () => {
+    const usage = createOverrideUsage([override('server/plugins/sentry.ts')])
+
+    usage.use([{ path: 'C:\\app\\server\\plugins\\sentry.ts' }])
+
+    expect(usage.unused()).toEqual([])
+  })
+})


### PR DESCRIPTION
Six findings in `nuxt-dx` and its budget action, most important first. Each one is a silent failure: the tool reported nothing while doing nothing.

## 1. The dev overlay lost the Vue handler slots

`error-overlay.client.ts` replaced `vueApp.config.warnHandler` and `errorHandler`. It saved the previous handler, but restored it only on HMR dispose. The plugin is `enforce: 'pre'`, so it always assigned first and any plugin after it always won.

Real casualty: `unhead.unjs.io` has `app/plugins/suppress-mdc-warn.client.ts`, which assigns `warnHandler`. Every warning and every hydration mismatch was dead in the overlay there.

Fix: a new `chainHandler` keeps the handler it displaced and calls it. Both slots are taken back at `app:created`, once every plugin has run, so a later plugin cannot silently win. Whoever owned the slot still decides what reaches the console, so a suppressed warning stays out of the console and still shows in the overlay.

Nuxt installs its own `errorHandler` before plugins and drops it at `app:suspense:resolve`, but only while it still holds the slot. Chaining would have kept that handler alive forever, and turned every post hydration error into the error page. The chain drops it on Nuxt's behalf at the same hook.

## 2. A dead `overridesKb` key was accepted in silence

`scripts.nuxt.com` carries `overridesKb: { 'server/plugins/sentry.ts': 326 }` and has no such file. The override was inert and the warning it was meant to silence kept firing.

Fix: every key is matched against what the build measured. Unmatched keys are listed in one warning after the last bundle reports. A key that names a plugin whose size never put it at risk still counts, because the plugin names are read once when a key is still unmatched.

A key now also matches the Nuxt module that registered an entry, which is the natural key for a module that ships a heavy plugin.

## 3. `nitroPluginsKb: 75` is wrong for `@sentry/nuxt`

The identical Sentry override sits in 10 of 12 consumer apps. That copy also hides a real regression inside the module, since the override is written to the current size.

I picked **recognise the module** over **raise the default**. Raising the default to clear Sentry would mean roughly 400 kB for every Nitro plugin, which makes the check useless for the plugins the app actually controls. Recognising the module keeps the tight default and puts the cost where it belongs.

`KNOWN_BUDGETS` in `src/size-budget/known-budgets.ts` gives `@sentry/nuxt` 400 kB for the `nitro` scope only, matched by owner or by path. Measured at 326 kB, so 400 kB leaves room for an SDK patch release and still catches the plugin doubling. A known budget only raises the scope budget, so a lower `nitroPluginsKb` and any override you write still win.

**Consumer action:** the 10 apps carrying `overridesKb: { 'server/plugins/sentry.ts': N }` or the equivalent can delete that line. Nothing breaks if they keep it.

## 4. The action failed open when the CLI was missing

`npx --no-install nuxt-dx compare` exits 1 when the bin is absent. The verdict step read exit 1 as a breach, and `fail-on-breach` defaults to false, so the job passed green with an empty summary.

Fix: a `Find the size budget CLI` step resolves `node_modules/.bin/nuxt-dx` up the tree, then `PATH`. A missing bin skips the comparison and fails the job with an error naming the directory it searched. The report still uploads, so the next run has a baseline.

The compare step now reports a named status (`ok`, `breach`, `broken`) instead of a bare exit code, so no step has to read an exit code as growth again.

## 5. The baseline needed the whole workflow green

`gh run list --status success` means every job in the workflow passed. The README tells consumers to add the step to their existing CI job. `gscdump.com` did exactly that in a five job workflow, so one red lint job on `main` meant every later pull request reported "no baseline" forever.

Fix: walk the newest 20 completed runs on the base branch and take the first that still holds the artifact, expired ones excluded.

## 6. The artifact name was a format behind

`SNAPSHOT_VERSION` is 3, the action default was `nuxt-dx-size-budget-v2`. `gscdump` hand bumped its artifact name to `-v3` to escape a stale baseline.

Fix: the default is `nuxt-dx-size-budget-v3`, and `SNAPSHOT_ARTIFACT_NAME` in `snapshot.ts` derives that string from `SNAPSHOT_VERSION`. A test fails the next time the format moves and the action does not. The README report sample now shows `"version": 3`.

## BREAKING

**The action default `artifact-name` moves from `nuxt-dx-size-budget-v2` to `nuxt-dx-size-budget-v3`.**

- Every consumer that does not pin `artifact-name`: the first run after this reports "no baseline" and passes, then repopulates from that run. No action needed.
- `gscdump.com`: remove the hand written `artifact-name: nuxt-dx-size-budget-v3`, since it is the default now.
- Any app that pinned `artifact-name: nuxt-dx-size-budget-v2`: drop the pin, or a v2 named artifact will keep holding v3 reports.

## Left for PR #58

PR #58 rewrites the README "GitHub Actions" section, so I did not touch it. Two lines in it are now stale and should be fixed there:

- the `artifact-name` row still reads `nuxt-dx-size-budget-v2`
- "the report left behind by the last successful run" and "a workflow that has never been green on the base branch" now describe finding 5's old behaviour

## Tests

`pnpm --filter @harlan-zw/nuxt-dx test`: 19 files, 178 tests, all pass. Up from 17 files and 157 tests.

New: `tests/handler-chain.test.ts` (7), `tests/override-usage.test.ts` (6), plus known budget cases in `tests/budget.test.ts` and CLI, baseline, and artifact name cases in `tests/action.test.ts`. Each finding got its failing test first.

`pnpm --filter @harlan-zw/nuxt-dx lint` passes. `tsc --noEmit` passes.

Not covered by a test: the action's shell runs only in CI. The CLI finder script was exercised locally for both the found and the missing case, and every `run` block passes `bash -n`.
