### PR TITLE
fix(nuxt-wide-events)!: level API, configured standalone, honest records

### DIFF
--- a/packages/nuxt-wide-events/README.md
+++ b/packages/nuxt-wide-events/README.md
@@ -49,6 +49,24 @@ export default defineEventHandler((event) => {
 
 Each value must be a string, number, boolean, or `null`. Nested objects cannot hide unapproved data.
 
+## Set the Level
+
+`setWideEventLevel` marks a request Wide Event as `debug`, `info`, `warn`, or `error`.
+
+```ts
+export default defineEventHandler(async (event) => {
+  try {
+    return await chargeCard()
+  }
+  catch {
+    setWideEventLevel(event, 'error')
+    return { charged: false }
+  }
+})
+```
+
+A record keeps the highest level it receives. If the request handler recovers from an error, the record stays an error. A drain and a sampling rate both see the real level.
+
 This code stops the build because `user.email` is not configured:
 
 ```ts
@@ -71,8 +89,10 @@ This constraint keeps the Field boundary visible to reviewers and coding agents.
 Default production performs no stack formatting, deep redaction, regular expression matching, or pretty printing.
 
 ```json
-{ "timestamp": "2026-08-13T04:12:00.000Z", "level": "info", "service": "shop", "method": "GET", "path": "/api/cart", "status": 200, "durationMs": 1.4, "requestId": "req_123", "cart.itemCount": 2, "user.id": "user_123" }
+{ "timestamp": "2026-08-13T04:12:00.000Z", "level": "info", "kind": "request", "service": "shop", "method": "GET", "path": "/api/cart", "status": 200, "durationMs": 1.4, "requestId": "req_123", "cart.itemCount": 2, "user.id": "user_123" }
 ```
+
+`kind` is `request` for a request record and `background` for a background record.
 
 Production errors include status only. All error strings remain absent because they can contain unapproved data.
 
@@ -86,17 +106,21 @@ Development records include error messages and stacks. Development uses compact 
 export default defineTask({
   async run() {
     const wideEvent = createWideEvent({ 'job.id': 'job_123' })
-    wideEvent.setLevel('info')
+    wideEvent.setLevel('warn')
     return await wideEvent.emit()
   },
 })
 ```
 
-The Nuxt auto-import selects JSON output in production and object output in development. It uses the configured `service`, `console`, and `drain` options. With `drain: true`, `emit()` returns a Promise and waits for background drain adapters. Without a drain, `emit()` remains synchronous.
+A background record carries `kind: "background"`. It has no `method`, `path`, or `status`, because a background operation has none.
 
-Use `@harlan-zw/nuxt-wide-events/standalone` when Nuxt auto-imports are unavailable. This package export always uses production JSON output without module configuration.
+The Nuxt auto-import selects JSON output in production and object output in development. It uses the configured `service`, `console`, `sampling`, and `drain` options. With `drain: true`, `emit()` returns a Promise and waits for background drain adapters. Without a drain, `emit()` remains synchronous.
 
-Set `request: false` to disable request collection. Field enforcement and `createWideEvent` remain available.
+Use `@harlan-zw/nuxt-wide-events/standalone` when Nuxt auto-imports are unavailable. Inside Nitro this export resolves to the same configured variant as the auto-import, so a deep import never loses `service`, `console`, `sampling`, or `drain`. Outside Nitro it writes production JSON without module configuration.
+
+Set `request: false` to disable request collection. Field enforcement, `createWideEvent`, and `setWideEventLevel` remain available.
+
+Set `enabled: false` to stop all output. Every server import still resolves, so application code needs no change.
 
 ## Migrate from evlog
 
@@ -109,6 +133,8 @@ addWideEventFields(event, { 'section.value': value })
 ```
 
 For background operations, replace `createLogger(fields)` with `createWideEvent(fields)`. Replace each `.set(fields)` call with `addWideEventFields(wideEvent, fields)`. Keep `.setLevel()`. If `drain` is enabled, await or return `.emit()`.
+
+For requests, replace `log.setLevel(level)` with `setWideEventLevel(event, level)`.
 
 Set `request: false` for background-only sites. Convert spreads, computed keys, arrays, and nested objects into configured primitive Fields. Keep browser logging and custom error transports in the application.
 
@@ -128,9 +154,11 @@ export default defineNuxtConfig({
 })
 ```
 
-Rates are percentages. Keep conditions use `>=` and OR logic. Request Wide Events use `info` and `error` rates. Standalone Wide Events also use `debug` and `warn` rates.
+Rates are percentages. A record is kept when it matches one whole keep condition. Every part of one condition must match, and the conditions are tried in order. So `{ duration: 1000, status: 500 }` keeps a slow server error, while `[{ duration: 1000 }, { status: 500 }]` keeps either one.
 
-The module compiles route patterns during the build. Default production uses a separate plugin without filtering code.
+Every level rate applies to every Wide Event. A background record has no status, so a status condition never keeps one.
+
+The module compiles route patterns during the build. A pattern that ends with `/**` also matches the bare prefix, which is how Nitro matches routes. Default production uses a separate plugin without filtering code.
 
 ## Drain Records
 
@@ -144,20 +172,20 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-Set `drain: true` to enable this hook. Set `console: false` when the hook owns output.
+Set `drain: true` to enable this hook. `console` then defaults to `false`, because the hook owns the record. Set `console: true` to keep stdout output as well.
 Request drains use `event.waitUntil()`. Background `emit()` waits for every hook adapter and surfaces adapter failures.
 
 ## Options
 
 | Option | Default | Purpose |
 | --- | --- | --- |
-| `enabled` | `true` | Register request collection and output. |
+| `enabled` | `true` | Emit Wide Events. `false` keeps Field enforcement and server imports. |
 | `request` | `true` | Collect one Wide Event for each request. |
 | `fields` | `[]` | Allow application Fields. |
 | `service` | none | Add a service name. |
 | `exclude` | `[]` | Exclude routes that match a glob pattern. |
 | `sampling` | none | Set rates and keep conditions for production. |
-| `console` | `true` | Write records to stdout. |
+| `console` | `true`, or `false` with a drain | Write records to stdout. |
 | `drain` | `false` | Call the `wide-events:emit` hook for request and background records. |
 
 ## Benchmarks

--- a/packages/nuxt-wide-events/bench/ci/perf.mjs
+++ b/packages/nuxt-wide-events/bench/ci/perf.mjs
@@ -243,8 +243,19 @@ async function main() {
   })}\n`)
 }
 
+/**
+ * Fields this branch adds to every record on purpose.
+ *
+ * The parity guard checks that both runtimes do the same work, not that they emit the
+ * same schema. A deliberate new field is dropped from both sides so the guard still
+ * catches an accidental workload change. Remove an entry once the base runtime emits it.
+ */
+const INTENTIONAL_NEW_FIELDS = ['kind']
+
 function normalizedOutput(scenario, output) {
   const record = JSON.parse(output)
+  for (const field of INTENTIONAL_NEW_FIELDS)
+    delete record[field]
   if (scenario.id !== 'runtime')
     return record
   ok(typeof record.durationMs === 'number')

--- a/packages/nuxt-wide-events/bench/production-policy.bench.ts
+++ b/packages/nuxt-wide-events/bench/production-policy.bench.ts
@@ -3,9 +3,10 @@ import { afterAll, bench, describe } from 'vitest'
 import { shouldEmitWideEvent } from '../src/runtime/server/production-policy'
 
 const exclude = /^(?:\/api\/_nuxt_icon\/.*|\/api\/_content\/.*|\/api\/_mdc\/.*)$/
-const sampling = { duration: 1000, info: 10, status: 400 }
+const sampling = { info: 10, keep: [{ duration: 1000 }, { status: 400 }] }
 const request: WideEventRecord = {
   durationMs: 10,
+  kind: 'request',
   level: 'info',
   method: 'GET',
   path: '/api/checkout',

--- a/packages/nuxt-wide-events/bench/production.bench.ts
+++ b/packages/nuxt-wide-events/bench/production.bench.ts
@@ -160,6 +160,7 @@ function buildRuntimeEvlogEvent() {
 function buildRawEvent(fields: BenchFields) {
   return {
     ...metadata,
+    kind: 'request',
     level: 'info',
     ...fields,
   }
@@ -171,6 +172,7 @@ function buildRuntimeRawEvent() {
   const endedAt = performance.now()
   return {
     timestamp: new Date().toISOString(),
+    kind: 'request',
     level: 'info',
     service: metadata.service,
     method: metadata.method,
@@ -185,6 +187,7 @@ function buildRuntimeRawEvent() {
 function writePinoEvent(fields: BenchFields): void {
   pinoLogger.info({
     ...metadata,
+    kind: 'request',
     ...fields,
   })
 }
@@ -195,6 +198,7 @@ function writeRuntimePinoEvent(): void {
   const endedAt = performance.now()
   pinoLogger.info({
     timestamp: new Date().toISOString(),
+    kind: 'request',
     service: metadata.service,
     method: metadata.method,
     path: metadata.path,
@@ -227,6 +231,7 @@ function buildEvlogErrorEvent() {
 function buildRawErrorEvent() {
   return {
     ...metadata,
+    kind: 'request',
     level: 'error',
     status: ERROR.statusCode,
     ...fields5,
@@ -236,6 +241,7 @@ function buildRawErrorEvent() {
 function writePinoErrorEvent(): void {
   pinoLogger.error({
     ...metadata,
+    kind: 'request',
     status: ERROR.statusCode,
     ...fields5,
   })

--- a/packages/nuxt-wide-events/src/build/runtime-config.ts
+++ b/packages/nuxt-wide-events/src/build/runtime-config.ts
@@ -11,9 +11,11 @@ type RuntimeOptions = Pick<ModuleOptions, 'console' | 'drain' | 'exclude' | 'sam
 export function resolveWideEventsRuntimeConfig(options: RuntimeOptions): WideEventsRuntimeConfig {
   const exclude = compileRoutePatterns(options.exclude)
   const sampling = resolveSampling(options.sampling?.rates, options.sampling?.keep)
+  const drain = options.drain ?? false
   return {
-    console: options.console ?? true,
-    drain: options.drain ?? false,
+    // A drain owns the record, so console output would duplicate it.
+    console: options.console ?? !drain,
+    drain,
     ...(options.service === undefined ? {} : { service: options.service }),
     ...(exclude === undefined ? {} : { exclude }),
     ...(sampling === undefined ? {} : { sampling }),
@@ -34,13 +36,19 @@ function compileRoutePatterns(patterns: string[] | undefined): RegExp | undefine
   return new RegExp(`^(?:${patterns.map(globSource).join('|')})$`)
 }
 
+const TRAILING_GLOBSTAR = '\u0001'
+const GLOBSTAR = '\u0002'
+
 function globSource(pattern: string): string {
+  // A trailing `/**` also matches the bare prefix, which is how Nitro matches routes.
   return pattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replaceAll('**', '\0')
+    .replace(/\/\*\*$/, TRAILING_GLOBSTAR)
+    .replaceAll('**', GLOBSTAR)
     .replaceAll('*', '[^/]*')
-    .replaceAll('\0', '.*')
     .replaceAll('?', '[^/]')
+    .replaceAll(GLOBSTAR, '.*')
+    .replaceAll(TRAILING_GLOBSTAR, '(?:/.*)?')
 }
 
 function resolveSampling(
@@ -49,27 +57,19 @@ function resolveSampling(
 ): WideEventsRuntimeSampling | undefined {
   for (const [level, rate] of Object.entries(rates ?? {}))
     parseRate(level, rate)
-  for (const [index, condition] of (keep ?? []).entries()) {
-    if (condition.duration !== undefined && (!Number.isFinite(condition.duration) || condition.duration < 0))
-      throw new TypeError(`wideEvents.sampling.keep[${index}].duration must be a finite nonnegative number.`)
-    if (condition.status !== undefined && (!Number.isInteger(condition.status) || condition.status < 0))
-      throw new TypeError(`wideEvents.sampling.keep[${index}].status must be a nonnegative integer.`)
-  }
+  const conditions = (keep ?? []).map(parseCondition)
 
-  const duration = minimum(keep?.map(condition => condition.duration))
-  const status = minimum(keep?.map(condition => condition.status))
   const info = rates?.info
   const error = rates?.error
   const debug = rates?.debug
   const warn = rates?.warn
-  if (duration === undefined && status === undefined && info === undefined && error === undefined && debug === undefined && warn === undefined)
+  if (conditions.length === 0 && info === undefined && error === undefined && debug === undefined && warn === undefined)
     return undefined
   return {
     ...(debug === undefined ? {} : { debug }),
-    ...(duration === undefined ? {} : { duration }),
     ...(error === undefined ? {} : { error }),
     ...(info === undefined ? {} : { info }),
-    ...(status === undefined ? {} : { status }),
+    ...(conditions.length === 0 ? {} : { keep: conditions }),
     ...(warn === undefined ? {} : { warn }),
   }
 }
@@ -79,11 +79,15 @@ function parseRate(level: string, rate: number): void {
     throw new TypeError(`wideEvents.sampling.rates.${level} must be a finite number from 0 to 100.`)
 }
 
-function minimum(values: (number | undefined)[] | undefined): number | undefined {
-  let result: number | undefined
-  for (const value of values ?? []) {
-    if (value !== undefined && (result === undefined || value < result))
-      result = value
+function parseCondition(condition: WideEventTailSamplingCondition, index: number): WideEventTailSamplingCondition {
+  if (condition.duration !== undefined && (!Number.isFinite(condition.duration) || condition.duration < 0))
+    throw new TypeError(`wideEvents.sampling.keep[${index}].duration must be a finite nonnegative number.`)
+  if (condition.status !== undefined && (!Number.isInteger(condition.status) || condition.status < 0))
+    throw new TypeError(`wideEvents.sampling.keep[${index}].status must be a nonnegative integer.`)
+  if (condition.duration === undefined && condition.status === undefined)
+    throw new TypeError(`wideEvents.sampling.keep[${index}] must set duration, status, or both.`)
+  return {
+    ...(condition.duration === undefined ? {} : { duration: condition.duration }),
+    ...(condition.status === undefined ? {} : { status: condition.status }),
   }
-  return result
 }

--- a/packages/nuxt-wide-events/src/module.ts
+++ b/packages/nuxt-wide-events/src/module.ts
@@ -22,10 +22,19 @@ declare module '@nuxt/schema' {
   }
 }
 
+const STANDALONE_EXPORT = '@harlan-zw/nuxt-wide-events/standalone'
+
 interface NitroConfigLike {
   alias?: Record<string, string>
   rollupConfig?: {
     plugins?: ReturnType<typeof createWideEventValidationPlugin>[]
+  }
+  typescript?: {
+    tsConfig?: {
+      compilerOptions?: {
+        paths?: Record<string, string[]>
+      }
+    }
   }
 }
 
@@ -41,12 +50,12 @@ export default defineNuxtModule<ModuleOptions>({
     enabled: true,
     request: true,
     fields: [],
-    console: true,
     drain: false,
   },
   setup(options, nuxt) {
-    if (!options.enabled)
-      return
+    // A disabled module keeps every server import, so `addWideEventFields` and
+    // `createWideEvent` still resolve. It stops output instead.
+    const enabled = options.enabled ?? true
 
     // Resolved at `modules:done`, not here, so a module contributing fields
     // through `addWideEventFields` is treated the same whether it sets up
@@ -68,7 +77,9 @@ export default defineNuxtModule<ModuleOptions>({
         fields.add(field)
       addWideEventTypes(resolvedFields.fields)
     })
-    const runtimeConfig = resolveWideEventsRuntimeConfig(options)
+    const runtimeConfig = resolveWideEventsRuntimeConfig(enabled
+      ? options
+      : { ...options, console: false, drain: false })
     const configTemplate = addTemplate({
       filename: 'wide-events/config.mjs',
       write: true,
@@ -82,25 +93,30 @@ export default defineNuxtModule<ModuleOptions>({
     nitro.rollupConfig.plugins ||= []
     nitro.rollupConfig.plugins.push(createWideEventValidationPlugin(nuxt.options.rootDir, fields))
 
-    if (options.request ?? true) {
+    if (enabled && (options.request ?? true)) {
       addServerPlugin(resolver.resolve(nuxt.options.dev
         ? './runtime/server/development-plugin'
         : runtimeConfig.exclude || runtimeConfig.sampling
           ? './runtime/server/production-policy-plugin'
           : './runtime/server/production-plugin'))
     }
-    addServerImports({
-      name: 'addWideEventFields',
-      from: resolver.resolve('./runtime/server/index'),
-    })
-    addServerImports({
-      name: 'createWideEvent',
-      from: resolver.resolve(runtimeConfig.drain
-        ? './runtime/server/standalone-drain'
-        : nuxt.options.dev
-          ? './runtime/server/standalone-development'
-          : './runtime/server/standalone-production'),
-    })
+    addServerImports([
+      { name: 'addWideEventFields', from: resolver.resolve('./runtime/server/index') },
+      { name: 'setWideEventLevel', from: resolver.resolve('./runtime/server/index') },
+    ])
+
+    // One implementation inside Nitro. A deep import of `/standalone` would
+    // otherwise drop `service`, `console`, `sampling`, and `drain`.
+    const standalone = resolver.resolve(runtimeConfig.drain
+      ? './runtime/server/standalone-drain'
+      : nuxt.options.dev
+        ? './runtime/server/standalone-development'
+        : './runtime/server/standalone-production')
+    addServerImports({ name: 'createWideEvent', from: standalone })
+    nitro.alias[STANDALONE_EXPORT] = standalone
+    const tsConfig = (nitro.typescript ??= {}).tsConfig ??= {}
+    const compilerOptions = tsConfig.compilerOptions ??= {}
+    ;(compilerOptions.paths ??= {})[STANDALONE_EXPORT] = [standalone]
   },
 })
 
@@ -122,12 +138,11 @@ export {}
   addTypeTemplate({
     filename: 'wide-events/hooks.d.ts',
     getContents: () => `
-import type { WideEventRecord } from '@harlan-zw/nuxt-wide-events/server'
-import type { StandaloneWideEventRecord } from '@harlan-zw/nuxt-wide-events/standalone'
+import type { BackgroundWideEventRecord, WideEventRecord } from '@harlan-zw/nuxt-wide-events/server'
 
 declare module 'nitropack/types' {
   interface NitroRuntimeHooks {
-    'wide-events:emit': (record: StandaloneWideEventRecord | WideEventRecord) => void | Promise<void>
+    'wide-events:emit': (record: BackgroundWideEventRecord | WideEventRecord) => void | Promise<void>
   }
 }
 

--- a/packages/nuxt-wide-events/src/runtime/server/config.d.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/config.d.ts
@@ -5,10 +5,9 @@ declare module '#wide-events/config' {
     exclude?: RegExp
     sampling?: {
       debug?: number
-      duration?: number
       error?: number
       info?: number
-      status?: number
+      keep?: { duration?: number, status?: number }[]
       warn?: number
     }
     service?: string

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -1,15 +1,15 @@
-import type { WideEventRecord } from './index'
-import type { StandaloneWideEventLevel } from './standalone-core'
+import type { WideEventKind, WideEventLevel, WideEventRecord } from './index'
 
 export interface DevelopmentWideEventRecord extends Record<string, string | number | boolean | null | undefined> {
   durationMs: number
-  level: StandaloneWideEventLevel
-  method: string
+  kind: WideEventKind
+  level: WideEventLevel
   requestId: string
-  status: number
   timestamp: string
+  method?: string
   path?: string
   service?: string
+  status?: number
 }
 
 interface DevelopmentWideEventFormatOptions {
@@ -52,7 +52,7 @@ export function formatDevelopmentWideEvent(
   const scope = typeof record.scope === 'string' ? record.scope : undefined
   const tag = safeTerminalText(record.service ?? scope ?? 'Wide Event')
   const level = record.level.toUpperCase()
-  const request = record.path !== undefined
+  const request = record.kind === 'request'
   const header = [
     paint(formatTimestamp(record.timestamp), ANSI.dim, colors),
     paint(level, levelColor(record.level), colors),
@@ -60,8 +60,8 @@ export function formatDevelopmentWideEvent(
   ]
 
   if (request) {
-    header.push(`${safeTerminalText(record.method)} ${safeTerminalText(record.path ?? '')}`)
-    header.push(paint(String(record.status), record.status >= 400 ? ANSI.red : ANSI.green, colors))
+    header.push(`${safeTerminalText(record.method ?? '')} ${safeTerminalText(record.path ?? '')}`)
+    header.push(paint(String(record.status), (record.status ?? 0) >= 400 ? ANSI.red : ANSI.green, colors))
     header.push(paint(`in ${formatDuration(record.durationMs)}`, ANSI.dim, colors))
   }
   if (messageLines?.[0])
@@ -129,6 +129,7 @@ function indentMessageLines(lines: string[]): string[] {
 function isHeaderField(field: string): boolean {
   switch (field) {
     case 'durationMs':
+    case 'kind':
     case 'level':
     case 'method':
     case 'path':
@@ -141,7 +142,7 @@ function isHeaderField(field: string): boolean {
   }
 }
 
-function levelColor(level: StandaloneWideEventLevel): string {
+function levelColor(level: WideEventLevel): string {
   switch (level) {
     case 'debug':
       return ANSI.gray

--- a/packages/nuxt-wide-events/src/runtime/server/drain.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/drain.ts
@@ -1,8 +1,7 @@
 import type { NitroApp } from 'nitropack/types'
-import type { WideEventRecord } from './index'
-import type { StandaloneWideEventRecord } from './standalone-core'
+import type { BackgroundWideEventRecord, WideEventRecord } from './index'
 
-type DrainedWideEventRecord = StandaloneWideEventRecord | WideEventRecord
+type DrainedWideEventRecord = BackgroundWideEventRecord | WideEventRecord
 
 declare module 'nitropack/types' {
   interface NitroRuntimeHooks {
@@ -23,7 +22,8 @@ export function scheduleWideEventDrain(
   context: WideEventDrainContext,
   record: WideEventRecord,
 ): void {
-  context.waitUntil(drainWideEvent(app, record).catch(() => {
-    console.error('[nuxt-wide-events] Wide Event drain failed.')
+  context.waitUntil(drainWideEvent(app, record).catch((error: unknown) => {
+    // The drain owns the only durable copy of this record, so report why it was lost.
+    console.error('[nuxt-wide-events] Wide Event drain failed.', error)
   }))
 }

--- a/packages/nuxt-wide-events/src/runtime/server/index.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/index.ts
@@ -9,15 +9,32 @@ export type WideEventFields = [ConfiguredWideEventField] extends [never]
   ? Record<string, never>
   : Partial<Record<ConfiguredWideEventField, WideEventValue>>
 
-export interface WideEventRecord extends Record<string, WideEventValue | undefined> {
+/** Severity of one Wide Event, from lowest to highest. */
+export type WideEventLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/** Source of one Wide Event. */
+export type WideEventKind = 'background' | 'request'
+
+interface WideEventRecordBase extends Record<string, WideEventValue | undefined> {
   durationMs: number
-  level: 'error' | 'info'
-  method: string
+  kind: WideEventKind
+  level: WideEventLevel
   requestId: string
-  status: number
   timestamp: string
-  path?: string
   service?: string
+}
+
+/** One Wide Event for one request. */
+export interface WideEventRecord extends WideEventRecordBase {
+  kind: 'request'
+  method: string
+  status: number
+  path?: string
+}
+
+/** One Wide Event for one background operation, which has no method, path, or status. */
+export interface BackgroundWideEventRecord extends WideEventRecordBase {
+  kind: 'background'
 }
 
 export interface WideEventLike {
@@ -29,13 +46,15 @@ export interface WideEventLike {
 const STATE_KEY = Symbol.for('@harlan-zw/nuxt-wide-events/state')
 const STARTED_AT_KEY = Symbol('startedAt')
 const REQUEST_ID_KEY = Symbol('requestId')
-const ERROR_KEY = Symbol('error')
+const LEVEL_KEY = Symbol('level')
 const COLLECTING = Symbol('collecting')
 const EMITTED = Symbol('emitted')
 
 type CollectingWideEvent = Record<string, WideEventValue | undefined>
 
 type WideEventState = CollectingWideEvent | typeof COLLECTING | typeof EMITTED
+
+const LEVEL_RANK = { debug: 0, info: 1, warn: 2, error: 3 } as const
 
 export function startWideEvent(event: WideEventLike, requestId?: string, startedAt?: number): void {
   const context = stateContext(event)
@@ -96,17 +115,27 @@ export function addWideEventFields(event: WideEventLike, fields: WideEventFields
   }
 }
 
+/**
+ * Raise the level of one Wide Event without ending Field collection.
+ *
+ * The record keeps the highest level it receives. A recovered error stays an
+ * error, so a later `info` cannot hide it from a drain or a sampling rate.
+ */
+export function setWideEventLevel(event: WideEventLike, level: WideEventLevel): void {
+  if (!Object.hasOwn(LEVEL_RANK, level))
+    throw new TypeError('Wide Event level must be debug, error, info, or warn.')
+  const context = stateContext(event)
+  if (context[STATE_KEY] === EMITTED)
+    throw new Error('The Wide Event was already emitted.')
+  raiseLevel(context, level)
+}
+
 /** Record an error without ending Field collection. */
 export function captureWideEventError(event: WideEventLike, _error: unknown): void {
   const context = stateContext(event)
-  const current = context[STATE_KEY] as WideEventState | undefined
-  if (current === EMITTED)
+  if (context[STATE_KEY] === EMITTED)
     return
-  if (current === undefined) {
-    initializeMetadata(context)
-    context[STATE_KEY] = COLLECTING
-  }
-  context[ERROR_KEY] = true
+  raiseLevel(context, 'error')
 }
 
 export function emitWideEvent(
@@ -118,6 +147,41 @@ export function emitWideEvent(
   timestamp = new Date().toISOString(),
 ): WideEventRecord | null {
   const context = stateContext(event)
+  const record = finalizeWideEvent(context, service, timestamp) as WideEventRecord | null
+  if (!record)
+    return null
+  record.kind = 'request'
+  record.method = safeMethod(event.method)
+  if (path !== undefined)
+    record.path = path
+  record.status = status
+  record.durationMs = Math.max(0, endedAt - (context[STARTED_AT_KEY] as number))
+  record.requestId = context[REQUEST_ID_KEY] as string
+  return record
+}
+
+/** Emit one Wide Event for a background operation, which has no method, path, or status. */
+export function emitBackgroundWideEvent(
+  event: WideEventLike,
+  service?: string,
+  endedAt = performance.now(),
+  timestamp = new Date().toISOString(),
+): BackgroundWideEventRecord | null {
+  const context = stateContext(event)
+  const record = finalizeWideEvent(context, service, timestamp) as BackgroundWideEventRecord | null
+  if (!record)
+    return null
+  record.kind = 'background'
+  record.durationMs = Math.max(0, endedAt - (context[STARTED_AT_KEY] as number))
+  record.requestId = context[REQUEST_ID_KEY] as string
+  return record
+}
+
+function finalizeWideEvent(
+  context: Record<PropertyKey, unknown>,
+  service: string | undefined,
+  timestamp: string,
+): WideEventRecordBase | null {
   const current = context[STATE_KEY] as WideEventState | undefined
   if (current === EMITTED)
     return null
@@ -125,19 +189,23 @@ export function emitWideEvent(
   if (current === undefined)
     initializeMetadata(context)
   const state = current === undefined || current === COLLECTING ? {} : current
-  const record = state as WideEventRecord
+  const record = state as WideEventRecordBase
   record.timestamp = timestamp
-  record.level = context[ERROR_KEY] === true ? 'error' : 'info'
+  record.level = (context[LEVEL_KEY] as WideEventLevel | undefined) ?? 'info'
   if (service !== undefined)
     record.service = service
-  record.method = safeMethod(event.method)
-  if (path !== undefined)
-    record.path = path
-  record.status = status
-  record.durationMs = Math.max(0, endedAt - (context[STARTED_AT_KEY] as number))
-  record.requestId = context[REQUEST_ID_KEY] as string
   context[STATE_KEY] = EMITTED
   return record
+}
+
+function raiseLevel(context: Record<PropertyKey, unknown>, level: WideEventLevel): void {
+  if (context[STATE_KEY] === undefined) {
+    initializeMetadata(context)
+    context[STATE_KEY] = COLLECTING
+  }
+  const current = context[LEVEL_KEY] as WideEventLevel | undefined
+  if (current === undefined || LEVEL_RANK[level] > LEVEL_RANK[current])
+    context[LEVEL_KEY] = level
 }
 
 function stateContext(event: WideEventLike): Record<PropertyKey, unknown> {

--- a/packages/nuxt-wide-events/src/runtime/server/production-policy.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/production-policy.ts
@@ -6,11 +6,14 @@ export function shouldEmitWideEvent(
   sampling: WideEventsRuntimeSampling,
   random: () => number = Math.random,
 ): boolean {
-  if (sampling.duration !== undefined && record.durationMs >= sampling.duration)
+  for (const condition of sampling.keep ?? []) {
+    if (condition.duration !== undefined && record.durationMs < condition.duration)
+      continue
+    if (condition.status !== undefined && record.status < condition.status)
+      continue
     return true
-  if (sampling.status !== undefined && record.status >= sampling.status)
-    return true
-  const rate = record.level === 'error' ? sampling.error ?? 100 : sampling.info ?? 100
+  }
+  const rate = sampling[record.level] ?? 100
   if (rate <= 0)
     return false
   return rate >= 100 || random() * 100 < rate

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-core.ts
@@ -1,89 +1,63 @@
-import type { WideEventFields, WideEventLike, WideEventValue } from './index'
-import { addWideEventFields, emitWideEvent, startWideEvent } from './index'
+import type { BackgroundWideEventRecord, WideEventFields, WideEventLevel, WideEventLike } from './index'
+import { addWideEventFields, emitBackgroundWideEvent, setWideEventLevel, startWideEvent } from './index'
 
-export type StandaloneWideEventLevel = 'debug' | 'error' | 'info' | 'warn'
+export interface BackgroundWideEvent extends WideEventLike {
+  emit: () => BackgroundWideEventRecord | null
+  setLevel: (level: WideEventLevel) => void
+}
 
-export interface StandaloneWideEventRecord extends Record<string, WideEventValue | undefined> {
-  durationMs: number
-  level: StandaloneWideEventLevel
-  method: string
-  requestId: string
-  status: number
-  timestamp: string
-  path?: string
+export interface DrainedBackgroundWideEvent extends WideEventLike {
+  emit: () => Promise<BackgroundWideEventRecord | null>
+  setLevel: (level: WideEventLevel) => void
+}
+
+interface BackgroundWideEventOptions {
+  output?: (record: BackgroundWideEventRecord) => void
+  sampling?: BackgroundWideEventSampling
   service?: string
 }
 
-export interface StandaloneWideEvent extends WideEventLike {
-  emit: () => StandaloneWideEventRecord | null
-  setLevel: (level: StandaloneWideEventLevel) => void
+interface DrainedBackgroundWideEventOptions extends BackgroundWideEventOptions {
+  output: (record: BackgroundWideEventRecord) => Promise<void>
 }
 
-export interface DrainedStandaloneWideEvent extends WideEventLike {
-  emit: () => Promise<StandaloneWideEventRecord | null>
-  setLevel: (level: StandaloneWideEventLevel) => void
-}
-
-interface StandaloneWideEventOptions {
-  output?: (record: StandaloneWideEventRecord) => void
-  sampling?: StandaloneWideEventSampling
-  service?: string
-}
-
-interface DrainedStandaloneWideEventOptions extends StandaloneWideEventOptions {
-  output: (record: StandaloneWideEventRecord) => Promise<void>
-}
-
-interface StandaloneWideEventSampling {
+interface BackgroundWideEventSampling {
   debug?: number
-  duration?: number
   error?: number
   info?: number
-  status?: number
+  keep?: { duration?: number, status?: number }[]
   warn?: number
 }
 
-export function createStandaloneWideEvent(
+export function createBackgroundWideEvent(
   initialFields: WideEventFields | undefined,
-  options: StandaloneWideEventOptions,
-): StandaloneWideEvent {
-  const event = {
-    context: {},
-    method: 'UNKNOWN',
-  } as StandaloneWideEvent
-  let emitted = false
-  let level: StandaloneWideEventLevel = 'info'
+  options: BackgroundWideEventOptions,
+): BackgroundWideEvent {
+  const event = { context: {} } as BackgroundWideEvent
 
   startWideEvent(event)
   if (initialFields)
     addWideEventFields(event, initialFields)
 
-  event.setLevel = (nextLevel) => {
-    if (emitted)
-      throw new Error('The Wide Event was already emitted.')
-    level = parseLevel(nextLevel)
-  }
+  event.setLevel = level => setWideEventLevel(event, level)
   event.emit = () => {
-    const record = emitWideEvent(event, 200, options.service)
+    const record = emitBackgroundWideEvent(event, options.service)
     if (!record)
       return null
-    emitted = true
-    const output = record as StandaloneWideEventRecord
-    output.level = level
-    if (options.sampling && !shouldEmitStandaloneWideEvent(output, options.sampling))
+    if (options.sampling && !shouldEmitBackgroundWideEvent(record, options.sampling))
       return null
-    options.output?.(output)
-    return output
+    options.output?.(record)
+    return record
   }
 
   return event
 }
 
-export function createDrainedStandaloneWideEvent(
+export function createDrainedBackgroundWideEvent(
   initialFields: WideEventFields | undefined,
-  options: DrainedStandaloneWideEventOptions,
-): DrainedStandaloneWideEvent {
-  const event = createStandaloneWideEvent(initialFields, {
+  options: DrainedBackgroundWideEventOptions,
+): DrainedBackgroundWideEvent {
+  const event = createBackgroundWideEvent(initialFields, {
     sampling: options.sampling,
     service: options.service,
   })
@@ -94,29 +68,20 @@ export function createDrainedStandaloneWideEvent(
       return Promise.resolve(null)
     return options.output(record).then(() => record)
   }) as never
-  return event as unknown as DrainedStandaloneWideEvent
+  return event as unknown as DrainedBackgroundWideEvent
 }
 
-function shouldEmitStandaloneWideEvent(
-  record: StandaloneWideEventRecord,
-  sampling: StandaloneWideEventSampling,
+function shouldEmitBackgroundWideEvent(
+  record: BackgroundWideEventRecord,
+  sampling: BackgroundWideEventSampling,
 ): boolean {
-  if (sampling.duration !== undefined && Number(record.durationMs) >= sampling.duration)
-    return true
-  if (sampling.status !== undefined && Number(record.status) >= sampling.status)
-    return true
+  // A background Wide Event has no status, so a status condition can never keep it.
+  for (const condition of sampling.keep ?? []) {
+    if (condition.status !== undefined)
+      continue
+    if (condition.duration === undefined || record.durationMs >= condition.duration)
+      return true
+  }
   const rate = sampling[record.level] ?? 100
   return rate > 0 && (rate >= 100 || Math.random() * 100 < rate)
-}
-
-function parseLevel(input: StandaloneWideEventLevel): StandaloneWideEventLevel {
-  switch (input) {
-    case 'debug':
-    case 'error':
-    case 'info':
-    case 'warn':
-      return input
-    default:
-      throw new TypeError('Wide Event level must be debug, error, info, or warn.')
-  }
 }

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-development.ts
@@ -1,12 +1,12 @@
 import type { WideEventFields } from './index'
-import type { StandaloneWideEvent } from './standalone-core'
+import type { BackgroundWideEvent } from './standalone-core'
 import config from '#wide-events/config'
 import { writeDevelopmentWideEvent } from './development'
-import { createStandaloneWideEvent } from './standalone-core'
+import { createBackgroundWideEvent } from './standalone-core'
 
 /** Create one development Wide Event for a background operation. */
-export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
-  return createStandaloneWideEvent(initialFields, {
+export function createWideEvent(initialFields?: WideEventFields): BackgroundWideEvent {
+  return createBackgroundWideEvent(initialFields, {
     ...(config.console ? { output: writeDevelopmentWideEvent } : {}),
     service: config.service,
   })

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-drain.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-drain.ts
@@ -1,17 +1,17 @@
 import type { WideEventsRuntimeConfig } from '../../types'
 import type { WideEventFields } from './index'
-import type { DrainedStandaloneWideEvent } from './standalone-core'
+import type { DrainedBackgroundWideEvent } from './standalone-core'
 import { useNitroApp } from 'nitropack/runtime'
 import config from '#wide-events/config'
 import { writeDevelopmentWideEvent } from './development'
 import { drainWideEvent } from './drain'
-import { createDrainedStandaloneWideEvent } from './standalone-core'
+import { createDrainedBackgroundWideEvent } from './standalone-core'
 
 const runtimeConfig = config as WideEventsRuntimeConfig
 
 /** Create one drained Wide Event for a background operation. */
-export function createWideEvent(initialFields?: WideEventFields): DrainedStandaloneWideEvent {
-  return createDrainedStandaloneWideEvent(initialFields, {
+export function createWideEvent(initialFields?: WideEventFields): DrainedBackgroundWideEvent {
+  return createDrainedBackgroundWideEvent(initialFields, {
     output: async (record) => {
       if (runtimeConfig.console) {
         if (import.meta.dev)

--- a/packages/nuxt-wide-events/src/runtime/server/standalone-production.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone-production.ts
@@ -1,14 +1,14 @@
 import type { WideEventsRuntimeConfig } from '../../types'
 import type { WideEventFields } from './index'
-import type { StandaloneWideEvent } from './standalone-core'
+import type { BackgroundWideEvent } from './standalone-core'
 import config from '#wide-events/config'
-import { createStandaloneWideEvent } from './standalone-core'
+import { createBackgroundWideEvent } from './standalone-core'
 
 const runtimeConfig = config as WideEventsRuntimeConfig
 
 /** Create one production Wide Event for a background operation. */
-export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
-  return createStandaloneWideEvent(initialFields, {
+export function createWideEvent(initialFields?: WideEventFields): BackgroundWideEvent {
+  return createBackgroundWideEvent(initialFields, {
     ...(runtimeConfig.console ? { output: (record: unknown) => console.log(JSON.stringify(record)) } : {}),
     sampling: runtimeConfig.sampling,
     service: runtimeConfig.service,

--- a/packages/nuxt-wide-events/src/runtime/server/standalone.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/standalone.ts
@@ -1,16 +1,18 @@
 import type { WideEventFields } from './index'
-import type { StandaloneWideEvent } from './standalone-core'
-import { createStandaloneWideEvent } from './standalone-core'
+import type { BackgroundWideEvent } from './standalone-core'
+import { createBackgroundWideEvent } from './standalone-core'
 
-export type {
-  StandaloneWideEvent,
-  StandaloneWideEventLevel,
-  StandaloneWideEventRecord,
-} from './standalone-core'
+export type { BackgroundWideEventRecord, WideEventLevel } from './index'
+export type { BackgroundWideEvent, DrainedBackgroundWideEvent } from './standalone-core'
 
-/** Create one production Wide Event for a background operation. */
-export function createWideEvent(initialFields?: WideEventFields): StandaloneWideEvent {
-  return createStandaloneWideEvent(initialFields, {
+/**
+ * Create one Wide Event for a background operation, outside Nuxt.
+ *
+ * Inside Nitro this entry point resolves to the configured variant, so the
+ * record keeps the `service`, `console`, `sampling`, and `drain` options.
+ */
+export function createWideEvent(initialFields?: WideEventFields): BackgroundWideEvent {
+  return createBackgroundWideEvent(initialFields, {
     output: record => console.log(JSON.stringify(record)),
   })
 }

--- a/packages/nuxt-wide-events/src/types.ts
+++ b/packages/nuxt-wide-events/src/types.ts
@@ -1,5 +1,5 @@
 export interface ModuleOptions {
-  /** Emit Wide Events. */
+  /** Emit Wide Events. Set `false` to keep Field enforcement and stop all output. */
   enabled?: boolean
   /** Collect one Wide Event for each request. */
   request?: boolean
@@ -11,7 +11,7 @@ export interface ModuleOptions {
   exclude?: string[]
   /** Reduce production Wide Event volume after the request completes. */
   sampling?: WideEventSamplingConfig
-  /** Write each Wide Event as one JSON line to stdout. */
+  /** Write each Wide Event as one JSON line to stdout. Defaults to `false` when `drain` is set. */
   console?: boolean
   /** Call the wide-events:emit hook for each request and background Wide Event. */
   drain?: boolean
@@ -34,17 +34,12 @@ export interface WideEventTailSamplingCondition {
 export interface WideEventSamplingConfig {
   /** Percentage of each level to keep, from 0 to 100. */
   rates?: WideEventSamplingRates
-  /** Conditions that bypass percentage sampling. */
+  /** Conditions that bypass percentage sampling. Every part of one condition must match. */
   keep?: WideEventTailSamplingCondition[]
 }
 
-export interface WideEventsRuntimeSampling {
-  debug?: number
-  duration?: number
-  error?: number
-  info?: number
-  status?: number
-  warn?: number
+export interface WideEventsRuntimeSampling extends WideEventSamplingRates {
+  keep?: WideEventTailSamplingCondition[]
 }
 
 export interface WideEventsRuntimeConfig {

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -5,6 +5,7 @@ describe('enrichDevelopmentWideEvent', () => {
   it('adds error details only to a development record', () => {
     const record = {
       'timestamp': 'now',
+      'kind': 'request' as const,
       'level': 'error' as const,
       'method': 'GET',
       'path': '/',
@@ -33,6 +34,7 @@ describe('formatDevelopmentWideEvent', () => {
       try {
         return formatDevelopmentWideEvent({
           timestamp: '2026-08-14T08:28:15.225Z',
+          kind: 'request',
           level: 'info',
           method: 'GET',
           path: '/api/cart',
@@ -59,14 +61,13 @@ describe('formatDevelopmentWideEvent', () => {
     ].join('\n'))
   })
 
-  it('renders developer messages as compact terminal blocks', () => {
+  it('renders a background developer message as a compact terminal block', () => {
     expect(formatDevelopmentWideEvent({
       scope: 'ssr',
       devMessage: 'server fetch completed\n  fetch   : GET /api/_auth/session\n  duration: 16ms\n  request : GET /',
       timestamp: '2026-08-14T08:28:15.225Z',
+      kind: 'background',
       level: 'debug',
-      method: 'UNKNOWN',
-      status: 200,
       durationMs: 0.155,
       requestId: 'req_1',
     }, { colors: false })).toBe([
@@ -81,6 +82,7 @@ describe('formatDevelopmentWideEvent', () => {
   it('renders request metadata and Fields without object inspection noise', () => {
     expect(formatDevelopmentWideEvent({
       'timestamp': '2026-08-14T08:28:15.225Z',
+      'kind': 'request',
       'level': 'warn',
       'service': 'shop',
       'method': 'GET',
@@ -99,6 +101,7 @@ describe('formatDevelopmentWideEvent', () => {
   it('keeps request metadata for unsupported HTTP methods', () => {
     expect(formatDevelopmentWideEvent({
       timestamp: '2026-08-14T08:28:15.225Z',
+      kind: 'request',
       level: 'info',
       method: 'UNKNOWN',
       path: '/webdav/files',

--- a/packages/nuxt-wide-events/tests/drain.test.ts
+++ b/packages/nuxt-wide-events/tests/drain.test.ts
@@ -1,0 +1,61 @@
+import type { NitroApp } from 'nitropack/types'
+import type { WideEventRecord } from '../src/runtime/server/index'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { scheduleWideEventDrain } from '../src/runtime/server/drain'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const record: WideEventRecord = {
+  durationMs: 10,
+  kind: 'request',
+  level: 'error',
+  method: 'GET',
+  requestId: 'req_1',
+  status: 500,
+  timestamp: '2026-08-13T00:00:00.000Z',
+}
+
+function nitroApp(hook: () => Promise<void>): NitroApp {
+  return {
+    hooks: {
+      callHookParallel: () => hook(),
+    },
+  } as unknown as NitroApp
+}
+
+describe('scheduleWideEventDrain', () => {
+  it('reports the failure that stopped the drain', async () => {
+    const error = new Error('D1 unavailable')
+    const reported = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const pending: Promise<unknown>[] = []
+
+    scheduleWideEventDrain(
+      nitroApp(() => Promise.reject(error)),
+      { waitUntil: promise => pending.push(promise) },
+      record,
+    )
+    await Promise.all(pending)
+
+    expect(reported).toHaveBeenCalledWith('[nuxt-wide-events] Wide Event drain failed.', error)
+  })
+
+  it('waits for the drain before the request ends', async () => {
+    let drained = false
+    const pending: Promise<unknown>[] = []
+
+    scheduleWideEventDrain(
+      nitroApp(async () => {
+        await Promise.resolve()
+        drained = true
+      }),
+      { waitUntil: promise => pending.push(promise) },
+      record,
+    )
+
+    expect(drained).toBe(false)
+    await Promise.all(pending)
+    expect(drained).toBe(true)
+  })
+})

--- a/packages/nuxt-wide-events/tests/fixtures/basic/nuxt.config.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/nuxt.config.ts
@@ -4,6 +4,7 @@ const measureSize = process.env.NUXT_WIDE_EVENTS_MEASURE === 'true'
 const testPolicy = process.env.NUXT_WIDE_EVENTS_POLICY === 'true'
 const testDrain = process.env.NUXT_WIDE_EVENTS_DRAIN === 'true'
 const standaloneOnly = process.env.NUXT_WIDE_EVENTS_STANDALONE === 'true'
+const disabled = process.env.NUXT_WIDE_EVENTS_DISABLED === 'true'
 
 export default defineNuxtConfig({
   compatibilityDate: '2026-08-13',
@@ -16,6 +17,7 @@ export default defineNuxtConfig({
   ],
   wideEvents: {
     console: !testDrain,
+    enabled: !disabled,
     drain: testDrain,
     fields: ['cache.hit', 'user.id'],
     request: !standaloneOnly,

--- a/packages/nuxt-wide-events/tests/fixtures/basic/server/api/deep-standalone.get.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/basic/server/api/deep-standalone.get.ts
@@ -1,0 +1,7 @@
+import { createWideEvent } from '@harlan-zw/nuxt-wide-events/standalone'
+
+export default defineEventHandler(async () => {
+  const wideEvent = createWideEvent({ 'user.id': 'deep_1' })
+  wideEvent.setLevel('warn')
+  return await wideEvent.emit()
+})

--- a/packages/nuxt-wide-events/tests/fixtures/workers/nuxt.config.ts
+++ b/packages/nuxt-wide-events/tests/fixtures/workers/nuxt.config.ts
@@ -5,6 +5,7 @@ export default defineNuxtConfig({
     preset: 'cloudflare_module',
   },
   wideEvents: {
+    console: true,
     drain: true,
     fields: ['worker.ok'],
     service: 'workers-fixture',

--- a/packages/nuxt-wide-events/tests/integration/module.test.ts
+++ b/packages/nuxt-wide-events/tests/integration/module.test.ts
@@ -30,6 +30,7 @@ describe('nuxt module integration', () => {
     expect(record.response).toEqual({ recorded: true })
     expect(record.logs).toEqual([
       expect.objectContaining({
+        'kind': 'request',
         'level': 'info',
         'method': 'GET',
         'path': '/api/record',
@@ -80,17 +81,32 @@ describe('nuxt module integration', () => {
     ])
   }, 60_000)
 
-  it('keeps standalone collection and removes request collection when disabled', async () => {
+  it('keeps background collection and removes request collection when request is off', async () => {
     await runNuxt(['build', 'tests/fixtures/basic'], { NUXT_WIDE_EVENTS_STANDALONE: 'true' })
 
-    expect(await requestStandaloneFixture()).toEqual([
+    const records = await requestStandaloneFixture()
+
+    expect(records).toEqual([
       expect.objectContaining({
+        'kind': 'background',
         'level': 'warn',
-        'method': 'UNKNOWN',
         'service': 'integration-fixture',
         'user.id': 'standalone_1',
       }),
+      expect.objectContaining({
+        'kind': 'background',
+        'level': 'warn',
+        'service': 'integration-fixture',
+        'user.id': 'deep_1',
+      }),
     ])
+    expect(records.every(record => record.method === undefined && record.status === undefined)).toBe(true)
+  }, 60_000)
+
+  it('keeps every server import and stops output when the module is disabled', async () => {
+    await runNuxt(['build', 'tests/fixtures/basic'], { NUXT_WIDE_EVENTS_DISABLED: 'true' })
+
+    expect(await requestDisabledFixture()).toEqual({ logs: [], response: { recorded: true } })
   }, 60_000)
 
   it('drains request and background Wide Events through one hook', async () => {
@@ -100,9 +116,9 @@ describe('nuxt module integration', () => {
 
     expect(result.standaloneStatus).toBe(500)
     expect(result.d1).toEqual([
-      expect.objectContaining({ 'path': '/api/record', 'user.id': 'user_1' }),
-      expect.objectContaining({ 'method': 'UNKNOWN', 'user.id': 'standalone_1' }),
-      expect.objectContaining({ level: 'error', path: '/api/standalone', status: 500 }),
+      expect.objectContaining({ 'kind': 'request', 'path': '/api/record', 'user.id': 'user_1' }),
+      expect.objectContaining({ 'kind': 'background', 'user.id': 'standalone_1' }),
+      expect.objectContaining({ kind: 'request', level: 'error', path: '/api/standalone', status: 500 }),
     ])
     expect(result.sentry).toEqual(result.d1)
   }, 60_000)
@@ -232,8 +248,38 @@ async function requestStandaloneFixture(): Promise<Record<string, unknown>[]> {
     await waitForServer(child, port, () => output)
     output = ''
     await fetch(`http://127.0.0.1:${port}/api/standalone`)
-    await waitFor(() => eventLogs(output).length === 1, child, () => output)
+    await fetch(`http://127.0.0.1:${port}/api/deep-standalone`)
+    await waitFor(() => eventLogs(output).length === 2, child, () => output)
     return eventLogs(output)
+  }
+  finally {
+    child.kill('SIGTERM')
+  }
+}
+
+async function requestDisabledFixture(): Promise<{ logs: Record<string, unknown>[], response: unknown }> {
+  const port = await availablePort()
+  const child = spawn(process.execPath, ['.output/server/index.mjs'], {
+    cwd: basicFixture,
+    env: {
+      ...process.env,
+      HOST: '127.0.0.1',
+      NO_COLOR: '1',
+      PORT: String(port),
+    },
+    stdio: 'pipe',
+  })
+  let output = ''
+  child.stdout.on('data', chunk => output += String(chunk))
+  child.stderr.on('data', chunk => output += String(chunk))
+
+  try {
+    await waitForServer(child, port, () => output)
+    output = ''
+    const response = await fetch(`http://127.0.0.1:${port}/api/record`).then(value => value.json())
+    await fetch(`http://127.0.0.1:${port}/api/standalone`)
+    await new Promise(resolve => setTimeout(resolve, 250))
+    return { logs: eventLogs(output), response }
   }
   finally {
     child.kill('SIGTERM')

--- a/packages/nuxt-wide-events/tests/integration/workers.test.ts
+++ b/packages/nuxt-wide-events/tests/integration/workers.test.ts
@@ -49,6 +49,7 @@ describe('cloudflare Workers integration', () => {
       expect(created.status).toBe(201)
       expect(eventLogs(output)).toEqual([
         expect.objectContaining({
+          'kind': 'request',
           'level': 'info',
           'method': 'GET',
           'path': '/api/record',

--- a/packages/nuxt-wide-events/tests/production-policy.test.ts
+++ b/packages/nuxt-wide-events/tests/production-policy.test.ts
@@ -4,6 +4,7 @@ import { shouldEmitWideEvent } from '../src/runtime/server/production-policy'
 
 const record: WideEventRecord = {
   durationMs: 10,
+  kind: 'request',
   level: 'info',
   method: 'GET',
   requestId: 'req_1',
@@ -21,12 +22,25 @@ describe('shouldEmitWideEvent', () => {
     expect(shouldEmitWideEvent(record, { info: 100 }, () => 1)).toBe(true)
   })
 
-  it('keeps matching duration or status before applying the rate', () => {
-    const sampling = { duration: 1000, error: 0, info: 0, status: 400 }
+  it('applies the rate that matches the record level', () => {
+    expect(shouldEmitWideEvent({ ...record, level: 'warn' }, { info: 100, warn: 0 }, () => 0)).toBe(false)
+    expect(shouldEmitWideEvent({ ...record, level: 'debug' }, { debug: 0, info: 100 }, () => 0)).toBe(false)
+    expect(shouldEmitWideEvent({ ...record, level: 'error' }, {}, () => 1)).toBe(true)
+  })
+
+  it('keeps a record that matches one whole condition', () => {
+    const sampling = { error: 0, info: 0, keep: [{ duration: 1000 }, { status: 400 }] }
 
     expect(shouldEmitWideEvent({ ...record, durationMs: 1000 }, sampling, () => 1)).toBe(true)
     expect(shouldEmitWideEvent({ ...record, status: 400 }, sampling, () => 1)).toBe(true)
     expect(shouldEmitWideEvent(record, sampling, () => 0)).toBe(false)
-    expect(shouldEmitWideEvent({ ...record, level: 'error' }, {}, () => 1)).toBe(true)
+  })
+
+  it('requires every part of one condition', () => {
+    const sampling = { info: 0, keep: [{ duration: 1000, status: 500 }] }
+
+    expect(shouldEmitWideEvent({ ...record, durationMs: 1000, status: 500 }, sampling, () => 0)).toBe(true)
+    expect(shouldEmitWideEvent({ ...record, durationMs: 1000 }, sampling, () => 0)).toBe(false)
+    expect(shouldEmitWideEvent({ ...record, status: 500 }, sampling, () => 0)).toBe(false)
   })
 })

--- a/packages/nuxt-wide-events/tests/runtime-config.test.ts
+++ b/packages/nuxt-wide-events/tests/runtime-config.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWideEventsRuntimeConfig } from '../src/build/runtime-config'
+import { resolveWideEventsRuntimeConfig, serializeWideEventsRuntimeConfig } from '../src/build/runtime-config'
 
 describe('resolveWideEventsRuntimeConfig', () => {
   it('omits route and sampling policy by default', () => {
-    expect(resolveWideEventsRuntimeConfig({ console: true, drain: false })).toEqual({
+    expect(resolveWideEventsRuntimeConfig({})).toEqual({
       console: true,
       drain: false,
+    })
+  })
+
+  it('stops console output when a drain owns the record', () => {
+    expect(resolveWideEventsRuntimeConfig({ drain: true })).toEqual({
+      console: false,
+      drain: true,
+    })
+    expect(resolveWideEventsRuntimeConfig({ console: true, drain: true })).toEqual({
+      console: true,
+      drain: true,
     })
   })
 
@@ -16,17 +27,30 @@ describe('resolveWideEventsRuntimeConfig', () => {
       exclude: ['/api/_nuxt_icon/**', '/health', '/users/?'],
       sampling: {
         rates: { debug: 0, error: 5, info: 10, warn: 50 },
-        keep: [{ duration: 1000 }, { duration: 2000 }, { status: 500 }, { status: 400 }],
+        keep: [{ duration: 1000 }, { status: 500 }],
       },
     })
 
     expect(config.exclude).toBeInstanceOf(RegExp)
     expect(config.exclude?.test('/api/_nuxt_icon/foo/bar')).toBe(true)
-    expect(config.exclude?.test('/api/_nuxt_icon')).toBe(false)
+    expect(config.exclude?.test('/api/_nuxt_icon')).toBe(true)
+    expect(config.exclude?.test('/api/_nuxt_iconography')).toBe(false)
     expect(config.exclude?.test('/health')).toBe(true)
     expect(config.exclude?.test('/users/a')).toBe(true)
     expect(config.exclude?.test('/users/ab')).toBe(false)
-    expect(config.sampling).toEqual({ debug: 0, duration: 1000, error: 5, info: 10, status: 400, warn: 50 })
+    expect(config.sampling).toEqual({
+      debug: 0,
+      error: 5,
+      info: 10,
+      keep: [{ duration: 1000 }, { status: 500 }],
+      warn: 50,
+    })
+  })
+
+  it('keeps each condition whole so both parts must match', () => {
+    expect(resolveWideEventsRuntimeConfig({
+      sampling: { keep: [{ duration: 1000, status: 500 }] },
+    }).sampling).toEqual({ keep: [{ duration: 1000, status: 500 }] })
   })
 
   it.each([
@@ -35,6 +59,7 @@ describe('resolveWideEventsRuntimeConfig', () => {
     ['a non-finite rate', { sampling: { rates: { warn: Infinity } } }, 'wideEvents.sampling.rates.warn'],
     ['a negative duration', { sampling: { keep: [{ duration: -1 }] } }, 'wideEvents.sampling.keep[0].duration'],
     ['a decimal status', { sampling: { keep: [{ status: 400.5 }] } }, 'wideEvents.sampling.keep[0].status'],
+    ['an empty condition', { sampling: { keep: [{}] } }, 'wideEvents.sampling.keep[0]'],
   ])('rejects %s', (_label, input, expected) => {
     expect(() => resolveWideEventsRuntimeConfig(input as never)).toThrow(expected)
   })
@@ -43,5 +68,21 @@ describe('resolveWideEventsRuntimeConfig', () => {
     expect(resolveWideEventsRuntimeConfig({
       sampling: { rates: { debug: 1, error: 2, info: 3, warn: 4 } },
     }).sampling).toEqual({ debug: 1, error: 2, info: 3, warn: 4 })
+  })
+
+  it('serializes the compiled route pattern for the runtime', () => {
+    const config = resolveWideEventsRuntimeConfig({
+      exclude: ['/api/_content/**'],
+      sampling: { keep: [{ duration: 1000, status: 500 }] },
+    })
+    // eslint-disable-next-line no-new-func
+    const runtime = new Function(serializeWideEventsRuntimeConfig(config).replace('export default', 'return'))() as {
+      exclude: RegExp
+      sampling: { keep: { duration?: number, status?: number }[] }
+    }
+
+    expect(runtime.exclude.test('/api/_content')).toBe(true)
+    expect(runtime.exclude.test('/api/_content/query')).toBe(true)
+    expect(runtime.sampling.keep).toEqual([{ duration: 1000, status: 500 }])
   })
 })

--- a/packages/nuxt-wide-events/tests/runtime.test.ts
+++ b/packages/nuxt-wide-events/tests/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { addWideEventFields, captureWideEventError, emitWideEvent, startWideEvent } from '../src/runtime/server/index'
+import { addWideEventFields, captureWideEventError, emitWideEvent, setWideEventLevel, startWideEvent } from '../src/runtime/server/index'
 
 function event() {
   return {
@@ -27,6 +27,7 @@ describe('wide Event runtime', () => {
     expect(emitWideEvent(request, 201, 'shop', '/api/cart', 12.5, '2026-08-13T00:00:00.000Z')).toEqual({
       'timestamp': '2026-08-13T00:00:00.000Z',
       'level': 'info',
+      'kind': 'request',
       'service': 'shop',
       'method': 'POST',
       'path': '/api/cart',
@@ -198,5 +199,61 @@ describe('wide Event runtime', () => {
     emitWideEvent(request, 200, undefined, undefined, 11, 'now')
 
     expect(() => addWideEventFields(request, { 'user.id': 'late' } as never)).toThrow(/already emitted/)
+  })
+
+  it('marks a request record with an explicit level', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    setWideEventLevel(request, 'error')
+
+    expect(emitWideEvent(request, 200, undefined, undefined, 11, 'now')).toEqual(expect.objectContaining({
+      kind: 'request',
+      level: 'error',
+      status: 200,
+    }))
+  })
+
+  it('keeps the highest level so a captured error survives a later level', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    captureWideEventError(request, new Error('recovered'))
+    setWideEventLevel(request, 'info')
+
+    expect(emitWideEvent(request, 200, undefined, undefined, 11, 'now')?.level).toBe('error')
+  })
+
+  it('raises the level from warn to error', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    setWideEventLevel(request, 'warn')
+    setWideEventLevel(request, 'error')
+
+    expect(emitWideEvent(request, 200, undefined, undefined, 11, 'now')?.level).toBe('error')
+  })
+
+  it('starts collection when the level arrives before any Field', () => {
+    const request = event()
+    setWideEventLevel(request, 'warn')
+    addWideEventFields(request, { 'user.id': 'user_1' } as never)
+
+    expect(emitWideEvent(request, 200, undefined, undefined, undefined, 'now')).toEqual(expect.objectContaining({
+      'level': 'warn',
+      'user.id': 'user_1',
+    }))
+  })
+
+  it('rejects an unknown level', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+
+    expect(() => setWideEventLevel(request, 'secret' as never)).toThrow(/level must be/)
+  })
+
+  it('rejects a level change after emission', () => {
+    const request = event()
+    startWideEvent(request, 'req_1', 10)
+    emitWideEvent(request, 200, undefined, undefined, 11, 'now')
+
+    expect(() => setWideEventLevel(request, 'error')).toThrow(/already emitted/)
   })
 })

--- a/packages/nuxt-wide-events/tests/standalone.test.ts
+++ b/packages/nuxt-wide-events/tests/standalone.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { addWideEventFields } from '../src/runtime/server/index'
 import { createWideEvent } from '../src/runtime/server/standalone'
-import { createDrainedStandaloneWideEvent, createStandaloneWideEvent } from '../src/runtime/server/standalone-core'
+import { createBackgroundWideEvent, createDrainedBackgroundWideEvent } from '../src/runtime/server/standalone-core'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -71,7 +71,7 @@ describe('standalone Wide Event', () => {
   it('applies standalone levels and emits an object to development output', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
     const output = vi.fn()
-    const sampled = createStandaloneWideEvent(undefined, {
+    const sampled = createBackgroundWideEvent(undefined, {
       output,
       sampling: { debug: 0, warn: 100 },
       service: 'worker',
@@ -81,7 +81,7 @@ describe('standalone Wide Event', () => {
     expect(sampled.emit()).toBeNull()
     expect(output).not.toHaveBeenCalled()
 
-    const kept = createStandaloneWideEvent(undefined, {
+    const kept = createBackgroundWideEvent(undefined, {
       output,
       sampling: { warn: 100 },
       service: 'worker',
@@ -94,7 +94,7 @@ describe('standalone Wide Event', () => {
 
   it('waits for asynchronous drain output before resolving', async () => {
     let finishDrain: (() => void) | undefined
-    const wideEvent = createDrainedStandaloneWideEvent(undefined, {
+    const wideEvent = createDrainedBackgroundWideEvent(undefined, {
       output: () => new Promise<void>((resolve) => {
         finishDrain = resolve
       }),
@@ -112,12 +112,40 @@ describe('standalone Wide Event', () => {
   })
 
   it('surfaces asynchronous drain failures', async () => {
-    const wideEvent = createDrainedStandaloneWideEvent(undefined, {
+    const wideEvent = createDrainedBackgroundWideEvent(undefined, {
       output: async () => {
         throw new Error('D1 unavailable')
       },
     })
 
     await expect(wideEvent.emit()).rejects.toThrow('D1 unavailable')
+  })
+
+  it('marks a background record and omits request only fields', () => {
+    const output = vi.fn()
+    const wideEvent = createBackgroundWideEvent({ 'job.id': 'job_1' } as never, { output })
+
+    const record = wideEvent.emit()!
+
+    expect(record.kind).toBe('background')
+    expect(Object.hasOwn(record, 'method')).toBe(false)
+    expect(Object.hasOwn(record, 'status')).toBe(false)
+  })
+
+  it('keeps a slow background record before applying the rate', () => {
+    const output = vi.fn()
+    const slow = createBackgroundWideEvent(undefined, {
+      output,
+      sampling: { info: 0, keep: [{ duration: 0 }] },
+    })
+
+    expect(slow.emit()).not.toBeNull()
+
+    const dropped = createBackgroundWideEvent(undefined, {
+      output,
+      sampling: { info: 0, keep: [{ status: 500 }] },
+    })
+
+    expect(dropped.emit()).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes seven findings in `@harlan-zw/nuxt-wide-events`. Each fix has a test.

## 1. Request Wide Events can be marked as errors

`setLevel` existed only on background events, so a failure marker inside a `catch` still emitted `level: 'info'`. A drain that filters `record.level !== 'error'` never saw it, and `rates: { info: 10 }` dropped 90% of them.

New auto-imported `setWideEventLevel(event, level)`:

```ts
export default defineEventHandler(async (event) => {
  try {
    return await track()
  }
  catch {
    setWideEventLevel(event, 'error')
    return { tracked: false }
  }
})
```

A record keeps the highest level it receives, so a recovered error stays an error. A later `info` cannot hide it.

## 2. `/standalone` inside Nitro keeps its configuration

Importing `@harlan-zw/nuxt-wide-events/standalone` inside Nitro dropped `service`, `console`, `sampling`, and `drain`. The module now aliases that specifier to the configured variant, for the Rollup bundle and for the generated Nitro tsconfig paths. An integration test proves a deep import emits `service` and `kind: 'background'`.

## 3. `enabled: false` disables the module

`setup` returned before `addServerImports`, so every `addWideEventFields` call site failed to resolve and the build broke. The imports now always register. A disabled module stops output and skips the request plugin. Field enforcement stays on.

## 4. The drain reports its failure

`scheduleWideEventDrain` logged a fixed string and discarded the error. It now logs the error.

## 5. `console` defaults to `false` with a drain

`drain: true` with the default console wrote every record twice. `console` now defaults to `!drain`. An explicit `console: true` still wins.

## 6. Records carry `kind`

Background records carried a fake `method: 'UNKNOWN'` and `status: 200`. Every record now carries `kind: 'request'` or `kind: 'background'`, and a background record has no `method`, `path`, or `status`.

## 7. Sampling and route globs

- One `keep` condition now needs every part to match. `{ duration: 1000, status: 500 }` keeps a slow server error. `[{ duration: 1000 }, { status: 500 }]` keeps either one. The runtime keeps the condition list instead of collapsing it to two minima.
- An empty `keep` condition now fails the build. It would otherwise keep every record.
- Every level rate applies to every record. `warn` and `debug` rates were ignored for requests.
- A pattern that ends with `/**` now also matches the bare prefix, the way Nitro matches routes. `/api/_content/**` excludes `/api/_content`.

## Verification

- `pnpm --filter @harlan-zw/nuxt-wide-events test`: 109 passed, 12 files. Includes Nuxt build, Node server, and workerd integration tests.
- `lint` and `typecheck` pass.
- `vitest bench` runs clean. The request path adds one string property per record.
- The Nitro plugin stays inside the 2 KB bundle budget.

## BREAKING

Per repository:

**All consumers**
- Every record gains `kind`. Widen any strict record schema or D1 column set.
- If you set `drain: true` and still want stdout, set `console: true`.

**unhead.unjs.io**
- Delete the second standalone Wide Event created only to reach `setLevel('error')`. Call `setWideEventLevel(event, 'error')` on the request event instead: `layers/tools/server/api/tools/track.post.ts`, `server/utils/upstream-cache.ts`, `server/cloudflare-pages-worker.ts`.
- The four `/standalone` imports now pick up `service: 'unhead.unjs.io'` and the configured output. No code change needed for that.
- Type imports: `StandaloneWideEventRecord` is now `BackgroundWideEventRecord`, `StandaloneWideEvent` is `BackgroundWideEvent`, `DrainedStandaloneWideEvent` is `DrainedBackgroundWideEvent`, `StandaloneWideEventLevel` is `WideEventLevel`. All are exported from `/server` and `/standalone`.

**nuxtseo.com (site and pro)**
- `layers/core/shared/logging/wide-event.ts:17` detects background records by `method === 'UNKNOWN' && status === 200`. Replace it with `record.kind === 'background'`.
- `layers/saas/server/plugins/wide-event-d1.ts`: `method` and `status` are absent on a background record. Store null.
- Both sites set `drain: true`, so console output stops by default. Set `console: true` to keep it.
- The D1 drain now reports its own failure through `console.error`.

**mdream.dev**
- `rates: { info: 10 }` no longer drops handled errors, because those records are now `level: 'error'`. Expect more error records.
- `exclude` patterns that end with `/**` now also exclude the bare prefix.

**gscdump.com**
- No action. `enabled: false` no longer breaks the 252 `addWideEventFields` call sites.

**request-indexing**
- `exclude` patterns that end with `/**` now also exclude the bare prefix.

## Not done

- `GLOSSARY.md` has no term for the two record kinds. The change uses `request` and `background`, matching the README's "Background Operations" heading. The glossary is outside this package, so it is unchanged. Worth one line if you agree with the words.
- Benchmark result documents are not regenerated. They record numbers from a specific machine, and this branch has no controlled baseline run.
