### PR TITLE
fix(nuxt-cloudflare)!: let authored Wrangler config outrank module defaults

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -6,6 +6,8 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 
 ## Defaults
 
+Every default below yields to a value you wrote. The root `wrangler.jsonc`, `wrangler.json`, or `wrangler.toml` is authored config, and so is `nitro.cloudflare.wrangler`. A module default applies only where neither names the key. Workers Caching is the one exception: the module owns that policy because it also registers the caching plugin.
+
 - Cloudflare module preset, generated Wrangler config, and Node compatibility
 - Static assets remain asset first by default. Blanket `assets.run_worker_first: true` warns because valid authentication and transform use cases exist
 - Workers Logs sampled at 1%, traces at 1%, both overridable
@@ -15,7 +17,8 @@ The module extracts production patterns already proven in Nuxt SEO and gscdump. 
 - Smart Placement enabled unless the project chooses a placement
 - Workers Caching enabled with version isolation
 - Rendered HTML forced to `private, no-store`; explicit non-HTML cache policies remain intact
-- Source-map upload when the Nitro build emits maps; explicit `false` is preserved
+- Source-map upload when the Nitro build emits maps; an authored value is preserved
+- `nodejs_compat` added unless the config chooses `nodejs_compat_v2`, which Cloudflare rejects alongside it
 - Module-wide `secrets.required` names copied to each environment; source root secrets remain scoped to the root
 - Version metadata is skipped when `CF_VERSION_METADATA` already names another binding
 - Raw `cloudflare-kv-binding` on Nitro's `cache` mount upgraded to a 30-day physical expiry
@@ -184,7 +187,8 @@ D1 allows 100 bound parameters per statement, including each statement inside `d
 ### Bindings
 
 ```ts
-import { createCloudflareBindings, resolveCloudflareBindings, runtimeConfigSource } from '@harlan-zw/nuxt-cloudflare/bindings'
+import type { H3Event } from 'h3'
+import { createCloudflareBindings, useCloudflareRuntimeConfig } from '@harlan-zw/nuxt-cloudflare/bindings'
 
 const cloudflare = createCloudflareBindings()
 
@@ -192,13 +196,17 @@ function requireDatabase(source?: unknown) {
   return cloudflare.require('DB', source)
 }
 
-const env = resolveCloudflareBindings(event)
-const config = useRuntimeConfig(runtimeConfigSource(env ?? {}))
+// `event` on the request path, nothing in a queue, scheduled, email, or task handler.
+function apiToken(event?: H3Event) {
+  return useCloudflareRuntimeConfig(event).apiToken
+}
 ```
 
 `nuxt prepare` runs Wrangler and writes exact, compatibility-aware types to `.nuxt/types/cloudflare-bindings.d.ts`. It merges root JSON, JSONC, or TOML bindings with `nitro.cloudflare.wrangler`. Nuxt and Nitro typechecks both reference the declaration, while bindings remain server runtime values. Production builds compare it with the final generated Wrangler config and fail on drift. Set `bindingTypes: false` only when another tool owns the declaration.
 
 The source may be an H3 event, Nitro task input, or task context. Eventless access uses Nitro's `globalThis.__env__` Cloudflare entry shim. An explicit environment always wins and never mixes with the global environment. Binding names come from the generated `CloudflareBindings` interface. Missing required bindings throw. Pass a generic only to override generated types in a focused test.
+
+`useCloudflareRuntimeConfig` reads runtime config from both contexts. On Cloudflare, `NUXT_*` Worker vars and secrets bind onto runtime config only through an event, so a bare `useRuntimeConfig()` off the request path returns build-time defaults. Without an event this reads the Cloudflare entry environment and wraps it as the source Nitro requires. The module's Nitro plugin supplies the reader; use `runtimeConfigSource` directly only when you own the `useRuntimeConfig` call.
 
 ### Scoped secrets file
 

--- a/packages/nuxt-cloudflare/src/binding-types.ts
+++ b/packages/nuxt-cloudflare/src/binding-types.ts
@@ -2,8 +2,7 @@ import type { WranglerConfigInput } from './wrangler'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { resolve } from 'pathe'
 import { experimental_generateTypes } from 'wrangler'
-import { discoverWranglerSourceConfigs } from './diagnostics'
-import { readWranglerConfigFile } from './wrangler-file'
+import { readAuthoredWranglerConfig } from './wrangler-file'
 
 interface BindingTypeGenerationOptions {
   buildDir: string
@@ -100,16 +99,11 @@ function createBindingTypeSignature(environment: string, runtime: string): strin
   return `${canonicalizeBindingEnvironment(environment)}\0${runtime.replaceAll('\r\n', '\n')}`
 }
 
-async function readAuthoredConfig(rootDir: string): Promise<WranglerConfigInput> {
-  const [path] = discoverWranglerSourceConfigs(rootDir)
-  if (!path)
-    return {}
-  const loaded = readWranglerConfigFile(path)
-  if (loaded._tag === 'loaded')
-    return loaded.config
-  if (loaded._tag === 'missing')
-    return {}
-  throw new SyntaxError(`Invalid Wrangler config "${path}": ${loaded.reason}`)
+function readAuthoredConfig(rootDir: string): WranglerConfigInput {
+  const authored = readAuthoredWranglerConfig(rootDir)
+  if (authored._tag === 'invalid')
+    throw new SyntaxError(`Invalid Wrangler config "${authored.path}": ${authored.reason}`)
+  return authored._tag === 'authored' ? authored.config : {}
 }
 
 async function generateCloudflareBindingTypes(
@@ -140,7 +134,7 @@ async function generateCloudflareBindingTypes(
 export async function prepareCloudflareBindingTypes(
   options: PreparedBindingTypeGenerationOptions,
 ): Promise<CloudflareBindingTypeArtifact> {
-  const authored = await readAuthoredConfig(options.rootDir)
+  const authored = readAuthoredConfig(options.rootDir)
   const config = mergeDefaults(options.wrangler, authored) as WranglerConfigInput
   return generateCloudflareBindingTypes({ ...options, config })
 }

--- a/packages/nuxt-cloudflare/src/bindings.ts
+++ b/packages/nuxt-cloudflare/src/bindings.ts
@@ -1,3 +1,6 @@
+import type { H3Event } from 'h3'
+import type { NitroRuntimeConfig } from 'nitropack/types'
+
 type BindingName<Environment extends object> = Extract<keyof Environment, string>
 
 type CloudflareEntryHost = typeof globalThis & { __env__?: unknown }
@@ -63,14 +66,67 @@ export function mergeCloudflareBindings<Environment extends object = CloudflareB
   return merged
 }
 
-/** Creates the event-shaped source required by Nitro runtime config resolution. */
-export function runtimeConfigSource<Environment extends object>(env: Environment): CloudflareRuntimeConfigSource<Environment> {
-  return {
+/**
+ * Creates the event-shaped source Nitro runtime config resolution requires.
+ *
+ * `useRuntimeConfig` writes the resolved config onto `context.nitro`, so a
+ * source without that object throws for every read that reaches it. Two
+ * production incidents came from a source that omitted it.
+ *
+ * The return type includes `H3Event` because that is the parameter
+ * `useRuntimeConfig` declares, and this value carries every field it reads.
+ * It is a config source, never a request: no other H3 helper may receive it.
+ */
+export function runtimeConfigSource<Environment extends object>(
+  env: Environment,
+): CloudflareRuntimeConfigSource<Environment> & H3Event {
+  const source: CloudflareRuntimeConfigSource<Environment> = {
     context: {
       nitro: {},
       cloudflare: { env },
     },
   }
+  return source as CloudflareRuntimeConfigSource<Environment> & H3Event
+}
+
+/** Reads Nitro runtime config for one event, or the shared config without one. */
+export type NitroRuntimeConfigReader = (event?: H3Event) => NitroRuntimeConfig
+
+let nitroRuntimeConfigReader: NitroRuntimeConfigReader | undefined
+
+/**
+ * Provides Nitro's `useRuntimeConfig` to `useCloudflareRuntimeConfig`.
+ *
+ * The module's own Nitro plugin calls this. The reader is injected rather than
+ * imported because this file is also loaded outside a Nitro bundle, where a
+ * module-top `nitropack/runtime` import resolves virtual specifiers that only
+ * exist inside the Nitro build and crashes the development server at boot.
+ */
+export function provideCloudflareRuntimeConfig(read: NitroRuntimeConfigReader | undefined): void {
+  nitroRuntimeConfigReader = read
+}
+
+/**
+ * Reads Nitro runtime config from Cloudflare request and eventless contexts.
+ *
+ * Pass the request event on the request path. Off it, in queue consumers,
+ * scheduled handlers, email handlers, and Nitro tasks, there is no event and a
+ * bare `useRuntimeConfig()` returns build-time defaults: the deployment's
+ * `NUXT_*` Worker vars and secrets bind onto runtime config only through an
+ * event. The Cloudflare entry assigns the live environment to
+ * `globalThis.__env__` in every handler, so the eventless path reads that and
+ * wraps it as a runtime config source.
+ */
+export function useCloudflareRuntimeConfig(event?: H3Event): NitroRuntimeConfig {
+  if (!nitroRuntimeConfigReader) {
+    throw new Error(
+      '[nuxt-cloudflare] No Nitro runtime config reader is available. Keep the module enabled, or call provideCloudflareRuntimeConfig() at the host boundary.',
+    )
+  }
+  if (event)
+    return nitroRuntimeConfigReader(event)
+  const env = resolveCloudflareBindings<Record<string, unknown>>()
+  return nitroRuntimeConfigReader(env ? runtimeConfigSource(env) : undefined)
 }
 
 /**

--- a/packages/nuxt-cloudflare/src/cli/index.ts
+++ b/packages/nuxt-cloudflare/src/cli/index.ts
@@ -5,6 +5,7 @@ import { resolve } from 'pathe'
 import { evaluateWranglerDiagnostics, parseWranglerAllowedWarnings } from '../diagnostics'
 import { diagnoseWranglerProject } from '../doctor'
 import { formatWranglerDiagnostics } from '../wrangler'
+import { readCliVersion } from './meta'
 
 const doctor = defineCommand({
   meta: { name: 'doctor', description: 'Audit the effective Wrangler configuration' },
@@ -63,7 +64,7 @@ const doctor = defineCommand({
 const main = defineCommand({
   meta: {
     name: 'nuxt-cloudflare',
-    version: '0.0.13',
+    version: readCliVersion(),
     description: 'Cloudflare deployment defaults and diagnostics for Nuxt',
   },
   subCommands: { doctor },

--- a/packages/nuxt-cloudflare/src/cli/meta.ts
+++ b/packages/nuxt-cloudflare/src/cli/meta.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Reads the version this package publishes.
+ *
+ * The manifest sits two directories above this file in the source tree and in
+ * the built CLI, so one path serves both. A hardcoded version drifts from the
+ * published one and makes `nuxt-cloudflare --version` report a build that does
+ * not exist.
+ */
+export function readCliVersion(): string {
+  const path = fileURLToPath(new URL('../../package.json', import.meta.url))
+  const manifest: unknown = JSON.parse(readFileSync(path, 'utf8'))
+  const version = manifest !== null && typeof manifest === 'object'
+    ? (manifest as { version?: unknown }).version
+    : undefined
+  if (typeof version !== 'string')
+    throw new TypeError(`Package manifest "${path}" declares no version.`)
+  return version
+}

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -15,6 +15,7 @@ import {
   applyCloudflareDefaults,
   diagnoseWranglerConfig,
   formatWranglerDiagnostics,
+  readAuthoredWranglerConfig,
   readWranglerJsonFile,
 } from './wrangler'
 
@@ -66,6 +67,12 @@ const wideEventsPluginPath = resolve(
   import.meta.url.endsWith('.ts')
     ? 'runtime/server/plugins/wide-events.ts'
     : 'runtime/server/plugins/wide-events.js',
+)
+const runtimeConfigPluginPath = resolve(
+  import.meta.dirname,
+  import.meta.url.endsWith('.ts')
+    ? 'runtime/server/plugins/runtime-config.ts'
+    : 'runtime/server/plugins/runtime-config.js',
 )
 
 /**
@@ -127,11 +134,28 @@ export function findPopulatedRuntimeSecretPaths(
   return paths
 }
 
+export interface NitroCloudflareContext {
+  /** The project directory Wrangler and Nitro read the authored config from. */
+  rootDir?: string
+  /** Whether Nuxt emits server source maps. */
+  serverSourceMaps?: boolean
+}
+
+function addNitroPlugin(nitro: NitroCloudflareShape, path: string): void {
+  nitro.plugins ??= []
+  if (!nitro.plugins.includes(path))
+    nitro.plugins.push(path)
+}
+
 export function configureNitroCloudflare(
   nitro: NitroCloudflareShape,
   options: ModuleOptions,
-  nuxtServerSourceMaps?: boolean,
+  context: NitroCloudflareContext = {},
 ): void {
+  const authored = readAuthoredWranglerConfig(context.rootDir)
+  if (authored._tag === 'invalid')
+    throw new Error(`[nuxt-cloudflare] Wrangler config "${authored.path}" cannot be parsed: ${authored.reason}`)
+
   nitro.preset ??= 'cloudflare-module'
   nitro.cloudflare ??= {}
   nitro.cloudflare.deployConfig = true
@@ -141,16 +165,15 @@ export function configureNitroCloudflare(
     logsSampleRate: options.logsSampleRate,
     requiredSecrets: options.requiredSecrets,
     tracesSampleRate: options.tracesSampleRate,
-    uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? nuxtServerSourceMaps ?? false,
+    uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? context.serverSourceMaps ?? false,
     versionMetadataBinding: options.versionMetadataBinding,
     workersCache: resolveModuleWorkersCachePolicy(options),
-  })
+  }, authored._tag === 'authored' ? authored.config : {})
 
-  if (nitro.cloudflare.wrangler.cache?.enabled) {
-    nitro.plugins ??= []
-    if (!nitro.plugins.includes(workersCachePluginPath))
-      nitro.plugins.push(workersCachePluginPath)
-  }
+  addNitroPlugin(nitro, runtimeConfigPluginPath)
+
+  if (nitro.cloudflare.wrangler.cache?.enabled)
+    addNitroPlugin(nitro, workersCachePluginPath)
 
   if (options.kvCache === false)
     return
@@ -167,6 +190,28 @@ export function configureNitroCloudflare(
     driver: cacheDriverPath,
     defaultTtl: configuredCache?.defaultTtl ?? 30 * 24 * 60 * 60,
   }
+}
+
+export type BindingTypeAudit
+  = | { _tag: 'compare', signature: string }
+    | { _tag: 'missing' }
+    | { _tag: 'skipped' }
+
+/**
+ * Decides whether the build compares generated binding types with the final
+ * Wrangler config.
+ *
+ * The signature exists only after the type template regenerates. A build that
+ * reuses a cached template must fail, not skip: a skipped comparison reports a
+ * clean build for types that no longer match the deployed config.
+ */
+export function resolveBindingTypeAudit(
+  bindingTypes: boolean | undefined,
+  signature: string | undefined,
+): BindingTypeAudit {
+  if (bindingTypes === false)
+    return { _tag: 'skipped' }
+  return signature ? { _tag: 'compare', signature } : { _tag: 'missing' }
 }
 
 async function auditGeneratedWranglerConfig(
@@ -188,13 +233,19 @@ async function auditGeneratedWranglerConfig(
   if (validated._tag === 'invalid')
     throw new Error('[nuxt-cloudflare] Generated Wrangler config fails Wrangler schema validation. Run Wrangler locally for validation details.')
 
-  if (bindingTypeSignature) {
+  const audit = resolveBindingTypeAudit(options.bindingTypes, bindingTypeSignature)
+  if (audit._tag === 'missing') {
+    throw new Error(
+      '[nuxt-cloudflare] Cloudflare binding types were not generated during this build, so the drift check could not run. Run `nuxt prepare`, or set `bindingTypes: false` when another tool owns the declaration.',
+    )
+  }
+  if (audit._tag === 'compare') {
     const { assertCloudflareBindingTypesCurrent } = await import('./binding-types')
     await assertCloudflareBindingTypesCurrent({
       buildDir,
       compatibilityDate: result.config.compatibility_date,
       config: result.config,
-      expectedSignature: bindingTypeSignature,
+      expectedSignature: audit.signature,
       nodeCompat: Boolean(nitro.options.cloudflare?.nodeCompat),
     })
   }
@@ -227,7 +278,10 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   const configure = () => configureNitroCloudflare(
     nuxt.options.nitro as NitroCloudflareShape,
     options,
-    Boolean(nuxt.options.sourcemap.server),
+    {
+      rootDir: nuxt.options.rootDir,
+      serverSourceMaps: Boolean(nuxt.options.sourcemap.server),
+    },
   )
 
   // Optional integration with `@harlan-zw/nuxt-wide-events`. Declaring the
@@ -257,10 +311,7 @@ export function setupCloudflareModule(options: ModuleOptions, nuxt: Nuxt): void 
   // the array first: this function is exported and called directly with partial
   // Nuxt objects, and a detection helper must not be the thing that throws.
   if (Array.isArray(nuxt.options.modules) && hasNuxtModule('@harlan-zw/nuxt-wide-events', nuxt)) {
-    const wideEventsNitro = nuxt.options.nitro as NitroCloudflareShape
-    wideEventsNitro.plugins ??= []
-    if (!wideEventsNitro.plugins.includes(wideEventsPluginPath))
-      wideEventsNitro.plugins.push(wideEventsPluginPath)
+    addNitroPlugin(nuxt.options.nitro as NitroCloudflareShape, wideEventsPluginPath)
   }
 
   let bindingTypeSignature: string | undefined

--- a/packages/nuxt-cloudflare/src/runtime/server/plugins/runtime-config.ts
+++ b/packages/nuxt-cloudflare/src/runtime/server/plugins/runtime-config.ts
@@ -1,0 +1,13 @@
+import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
+import { provideCloudflareRuntimeConfig } from '../../../bindings'
+
+/**
+ * Hands Nitro's runtime config reader to `useCloudflareRuntimeConfig`.
+ *
+ * Nitro bundles its plugins, so this file resolves `nitropack/runtime`. The
+ * bindings module cannot: applications import it outside a Nitro bundle, where
+ * that specifier fails to resolve.
+ */
+export default defineNitroPlugin(() => {
+  provideCloudflareRuntimeConfig(useRuntimeConfig)
+})

--- a/packages/nuxt-cloudflare/src/wrangler-file.ts
+++ b/packages/nuxt-cloudflare/src/wrangler-file.ts
@@ -58,3 +58,28 @@ export function findProjectWranglerConfig(cwd: string): string | undefined {
     directory = parent
   }
 }
+
+export type AuthoredWranglerConfigResult
+  = | { _tag: 'authored', config: WranglerConfigInput, path: string }
+    | { _tag: 'absent' }
+    | { _tag: 'invalid', path: string, reason: string }
+
+/**
+ * Reads the root Wrangler config the consumer authored.
+ *
+ * Nitro writes the deployed config as `defu(overrides, nitro.cloudflare.wrangler,
+ * thisFile, defaults)`, so every value in this file loses to a module default
+ * that names the same key. Module policy reads the file for that reason only:
+ * a value the consumer wrote here stays the value that deploys.
+ */
+export function readAuthoredWranglerConfig(rootDir: string | undefined): AuthoredWranglerConfigResult {
+  const path = rootDir === undefined ? undefined : findProjectWranglerConfig(rootDir)
+  if (!path)
+    return { _tag: 'absent' }
+  const loaded = readWranglerConfigFile(path)
+  if (loaded._tag === 'loaded')
+    return { _tag: 'authored', config: loaded.config, path }
+  if (loaded._tag === 'missing')
+    return { _tag: 'absent' }
+  return { _tag: 'invalid', path, reason: loaded.reason }
+}

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
-export type { WranglerConfigFileResult } from './wrangler-file'
-export { findProjectWranglerConfig, readWranglerConfigFile } from './wrangler-file'
+export type { AuthoredWranglerConfigResult, WranglerConfigFileResult } from './wrangler-file'
+export { findProjectWranglerConfig, readAuthoredWranglerConfig, readWranglerConfigFile } from './wrangler-file'
 
 export interface WranglerAssetsInput {
   directory?: string
@@ -377,47 +377,111 @@ function configuredRemoteBindings(config: WranglerConfigInput): Array<{ path: st
   return bindings
 }
 
+/**
+ * Applies module policy to the Wrangler config Nitro generates.
+ *
+ * Three layers decide every value. `config` is `nitro.cloudflare.wrangler`,
+ * which the application and its modules write. `authored` is the root
+ * `wrangler.jsonc` or `wrangler.toml`. Module options are last, because a
+ * default must never overrule a value the consumer wrote in either place.
+ *
+ * Nitro merges the generated config with `defu`, where `nitro.cloudflare.wrangler`
+ * outranks the authored file. So this function resolves the effective value and
+ * writes it back: without the authored layer the module default silently wins.
+ */
 export function applyCloudflareDefaults(
   config: WranglerConfigInput,
   options: CloudflareDefaultOptions = {},
+  authored: WranglerConfigInput = {},
 ): WranglerConfigInput {
-  const root = applyEnvironmentDefaults(config, options)
+  const root = applyEnvironmentDefaults(config, options, { authored })
   const environments = config.env && Object.fromEntries(
-    Object.entries(config.env).map(([name, environment]) => [name, applyEnvironmentDefaults(environment, {
-      ...options,
-      requiredSecrets: options.requiredSecrets,
-    }, root)]),
+    Object.entries(config.env).map(([name, environment]) => [name, applyEnvironmentDefaults(environment, options, {
+      // Named Wrangler environments inherit the authored root for the keys
+      // Wrangler itself inherits, and nothing else.
+      authored: resolveEnvironmentPolicy(authored, authored.env?.[name] ?? {}),
+      inherited: root,
+    })]),
   )
   return environments ? { ...root, env: environments } : root
+}
+
+/**
+ * Resolves the Node compatibility flags Workers accepts.
+ *
+ * Cloudflare rejects `nodejs_compat` together with `nodejs_compat_v2`, and
+ * `no_nodejs_compat_v2` is how a config opts out of v2. This is the resolution
+ * Nitro's config writer and the binding type generator both use.
+ */
+function withNodeCompatibilityFlags(flags: readonly string[]): string[] {
+  const resolved = new Set(flags)
+  if (resolved.has('nodejs_compat_v2') && resolved.has('no_nodejs_compat_v2'))
+    resolved.delete('nodejs_compat_v2')
+  if (!resolved.has('nodejs_compat_v2')) {
+    resolved.add('nodejs_compat')
+    resolved.add('no_nodejs_compat_v2')
+  }
+  return [...resolved]
+}
+
+interface CloudflareEnvironmentLayers {
+  /** The root Wrangler file. Outranks every module default. */
+  authored?: WranglerConfigInput
+  /** The resolved root environment, for named Wrangler environments. */
+  inherited?: WranglerConfigInput
 }
 
 function applyEnvironmentDefaults(
   config: WranglerConfigInput,
   options: CloudflareDefaultOptions,
-  inherited: WranglerConfigInput = {},
+  layers: CloudflareEnvironmentLayers = {},
 ): WranglerConfigInput {
-  const compatibilityDate = config.compatibility_date ?? inherited.compatibility_date ?? options.compatibilityDate
-  const compatibilityFlags = unique([...(config.compatibility_flags ?? inherited.compatibility_flags ?? []), 'nodejs_compat'])
-  const authoredCache = config.cache ?? inherited.cache
+  const authored = layers.authored ?? {}
+  const inherited = layers.inherited ?? {}
+  const compatibilityDate = config.compatibility_date
+    ?? authored.compatibility_date
+    ?? inherited.compatibility_date
+    ?? options.compatibilityDate
+  const declaredFlags = unique([...(config.compatibility_flags ?? []), ...(authored.compatibility_flags ?? [])])
+  const compatibilityFlags = withNodeCompatibilityFlags(
+    declaredFlags.length > 0 ? declaredFlags : (inherited.compatibility_flags ?? []),
+  )
+  // Workers Caching is the one policy the module keeps: it also decides whether
+  // the caching Nitro plugin is registered, so both must follow one option.
+  const authoredCache = config.cache ?? authored.cache ?? inherited.cache
   const cache = options.workersCache
     ? resolveWorkersCachePolicy(options.workersCache)
     : authoredCache
       ? { ...authoredCache, cross_version_cache: authoredCache.cross_version_cache ?? false }
       : resolveWorkersCachePolicy({ _tag: 'disabled' })
+  // Names the authored config already requires stay in the authored config.
+  // Restating them here would append a duplicate through Nitro's `defu` merge.
+  const authoredSecrets = new Set(authored.secrets?.required ?? [])
   const requiredSecrets = unique([...(config.secrets?.required ?? []), ...(options.requiredSecrets ?? [])])
+    .filter(name => !authoredSecrets.has(name))
   const logs = config.observability?.logs
+  const authoredLogs = authored.observability?.logs
   const inheritedLogs = inherited.observability?.logs
   const traces = config.observability?.traces
+  const authoredTraces = authored.observability?.traces
   const inheritedTraces = inherited.observability?.traces
-  const uploadSourceMaps = config.upload_source_maps ?? inherited.upload_source_maps ?? options.uploadSourceMaps ?? true
-  const previewUrls = config.preview_urls ?? inherited.preview_urls ?? false
-  const placement = config.placement ?? inherited.placement ?? { mode: 'smart' }
+  const uploadSourceMaps = config.upload_source_maps
+    ?? authored.upload_source_maps
+    ?? inherited.upload_source_maps
+    ?? options.uploadSourceMaps
+    ?? true
+  const previewUrls = config.preview_urls ?? authored.preview_urls ?? inherited.preview_urls ?? false
+  const placement = config.placement ?? authored.placement ?? inherited.placement ?? { mode: 'smart' }
+  const route = config.route ?? authored.route ?? inherited.route
+  const routes = config.routes ?? authored.routes ?? inherited.routes
   const workersDev = config.workers_dev
+    ?? authored.workers_dev
     ?? inherited.workers_dev
-    ?? ((config.route !== undefined || (config.routes?.length ?? 0) > 0) ? false : undefined)
+    ?? ((route !== undefined || (routes?.length ?? 0) > 0) ? false : undefined)
   const versionMetadataBinding = options.versionMetadataBinding ?? 'CF_VERSION_METADATA'
-  const localBindingNames = collectBindingNames(config)
+  const localBindingNames = new Set([...collectBindingNames(config), ...collectBindingNames(authored)])
   const versionMetadata = config.version_metadata
+    ?? authored.version_metadata
     ?? (inherited.version_metadata && !localBindingNames.has(inherited.version_metadata.binding)
       ? inherited.version_metadata
       : undefined)
@@ -430,20 +494,37 @@ function applyEnvironmentDefaults(
     compatibility_flags: compatibilityFlags,
     observability: {
       ...inherited.observability,
+      ...authored.observability,
       ...config.observability,
-      enabled: config.observability?.enabled ?? inherited.observability?.enabled ?? true,
+      enabled: config.observability?.enabled
+        ?? authored.observability?.enabled
+        ?? inherited.observability?.enabled
+        ?? true,
       logs: {
         ...inheritedLogs,
+        ...authoredLogs,
         ...logs,
-        enabled: logs?.enabled ?? inheritedLogs?.enabled ?? true,
-        head_sampling_rate: logs?.head_sampling_rate ?? inheritedLogs?.head_sampling_rate ?? options.logsSampleRate ?? 0.01,
-        invocation_logs: logs?.invocation_logs ?? inheritedLogs?.invocation_logs ?? true,
+        enabled: logs?.enabled ?? authoredLogs?.enabled ?? inheritedLogs?.enabled ?? true,
+        head_sampling_rate: logs?.head_sampling_rate
+          ?? authoredLogs?.head_sampling_rate
+          ?? inheritedLogs?.head_sampling_rate
+          ?? options.logsSampleRate
+          ?? 0.01,
+        invocation_logs: logs?.invocation_logs
+          ?? authoredLogs?.invocation_logs
+          ?? inheritedLogs?.invocation_logs
+          ?? true,
       },
       traces: {
         ...inheritedTraces,
+        ...authoredTraces,
         ...traces,
-        enabled: traces?.enabled ?? inheritedTraces?.enabled ?? true,
-        head_sampling_rate: traces?.head_sampling_rate ?? inheritedTraces?.head_sampling_rate ?? options.tracesSampleRate ?? 0.01,
+        enabled: traces?.enabled ?? authoredTraces?.enabled ?? inheritedTraces?.enabled ?? true,
+        head_sampling_rate: traces?.head_sampling_rate
+          ?? authoredTraces?.head_sampling_rate
+          ?? inheritedTraces?.head_sampling_rate
+          ?? options.tracesSampleRate
+          ?? 0.01,
       },
     },
     placement,
@@ -789,7 +870,10 @@ function diagnosePolicy(
     }
   }
 
-  if (options.requireNodeCompat && !config.compatibility_flags?.includes('nodejs_compat')) {
+  // `nodejs_compat_v2` is the other accepted mode. Cloudflare rejects both flags
+  // together, so a config carrying v2 already has Node compatibility.
+  const nodeCompatFlags = new Set(config.compatibility_flags ?? [])
+  if (options.requireNodeCompat && !nodeCompatFlags.has('nodejs_compat') && !nodeCompatFlags.has('nodejs_compat_v2')) {
     diagnostics.push({
       _tag: 'error',
       code: 'missing-nodejs-compat',

--- a/packages/nuxt-cloudflare/tests/bindings.test.ts
+++ b/packages/nuxt-cloudflare/tests/bindings.test.ts
@@ -1,12 +1,14 @@
 import type { H3Event } from 'h3'
-import type { TaskContext, TaskEvent } from 'nitropack/types'
+import type { NitroRuntimeConfig, TaskContext, TaskEvent } from 'nitropack/types'
 import { afterEach, describe, expect, expectTypeOf, it } from 'vitest'
 import {
   createCloudflareBindings,
   mergeCloudflareBindings,
+  provideCloudflareRuntimeConfig,
   resolveCloudflareBindings,
   runtimeConfigSource,
   setCloudflareBindings,
+  useCloudflareRuntimeConfig,
 } from '../src/bindings'
 
 interface TestEnvironment {
@@ -19,6 +21,68 @@ const taskEnvHost = globalThis as typeof globalThis & { __env__?: unknown }
 
 afterEach(() => {
   delete taskEnvHost.__env__
+})
+
+function runtimeConfig(apiToken: string): NitroRuntimeConfig {
+  return {
+    app: { baseURL: '/', buildAssetsDir: '_nuxt', buildId: 'test', cdnURL: '' },
+    nitro: {},
+    public: {},
+    apiToken,
+  }
+}
+
+describe('useCloudflareRuntimeConfig', () => {
+  afterEach(() => {
+    provideCloudflareRuntimeConfig(undefined)
+    delete taskEnvHost.__env__
+  })
+
+  it('reads the request event when one is available', () => {
+    const sources: unknown[] = []
+    provideCloudflareRuntimeConfig((event) => {
+      sources.push(event)
+      return runtimeConfig('from-event')
+    })
+    const event = { context: { nitro: {}, cloudflare: { env: { NUXT_API_TOKEN: 'secret' } } } } as unknown as H3Event
+
+    expect(useCloudflareRuntimeConfig(event).apiToken).toBe('from-event')
+    expect(sources).toEqual([event])
+  })
+
+  it('reads an eventless source that Nitro can initialize', () => {
+    const sources: unknown[] = []
+    provideCloudflareRuntimeConfig((event) => {
+      sources.push(event)
+      // Nitro writes the resolved config onto `context.nitro`. A source without
+      // it threw for every eventless read and returned a 500.
+      return runtimeConfig('from-env')
+    })
+    taskEnvHost.__env__ = { NUXT_API_TOKEN: 'secret' }
+
+    expect(useCloudflareRuntimeConfig().apiToken).toBe('from-env')
+    expect(sources).toEqual([{
+      context: {
+        nitro: {},
+        cloudflare: { env: { NUXT_API_TOKEN: 'secret' } },
+      },
+    }])
+  })
+
+  it('reads the shared config when no Cloudflare environment exists', () => {
+    const sources: unknown[] = []
+    provideCloudflareRuntimeConfig((event) => {
+      sources.push(event)
+      return runtimeConfig('')
+    })
+
+    expect(useCloudflareRuntimeConfig().apiToken).toBe('')
+    expect(sources).toEqual([undefined])
+  })
+
+  it('fails loudly when no Nitro runtime config reader was provided', () => {
+    expect(() => useCloudflareRuntimeConfig()).toThrow('nuxt-cloudflare')
+  })
 })
 
 describe('cloudflare bindings', () => {

--- a/packages/nuxt-cloudflare/tests/cli.test.ts
+++ b/packages/nuxt-cloudflare/tests/cli.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'pathe'
+import { describe, expect, it } from 'vitest'
+import { readCliVersion } from '../src/cli/meta'
+
+describe('readCliVersion', () => {
+  it('reports the version this package publishes', () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+    ) as { version: string }
+
+    expect(readCliVersion()).toBe(packageJson.version)
+  })
+})

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -1,7 +1,28 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { NitroCloudflareShape } from '../src/module'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { configureNitroCloudflare, findPopulatedRuntimeSecretPaths, setupCloudflareModule } from '../src/module'
+import {
+  configureNitroCloudflare,
+  findPopulatedRuntimeSecretPaths,
+  resolveBindingTypeAudit,
+  setupCloudflareModule,
+} from '../src/module'
+
+const directories: string[] = []
+
+function projectWithWranglerConfig(source: string): string {
+  const directory = mkdtempSync(join(tmpdir(), 'nuxt-cloudflare-module-'))
+  directories.push(directory)
+  writeFileSync(join(directory, 'wrangler.jsonc'), source)
+  return directory
+}
+
+afterEach(() => {
+  directories.splice(0).forEach(directory => rmSync(directory, { force: true, recursive: true }))
+})
 
 function nuxtWithCapturedHooks(dev: boolean, serverSourceMaps = false): {
   callbacks: Record<string, () => unknown>
@@ -58,9 +79,7 @@ describe('configureNitroCloudflare', () => {
       enabled: true,
       cross_version_cache: false,
     })
-    expect(nitro.plugins).toEqual([
-      expect.stringMatching(/\/runtime\/server\/plugins\/workers-cache\.ts$/),
-    ])
+    expect(nitro.plugins).toContainEqual(expect.stringMatching(/\/runtime\/server\/plugins\/workers-cache\.ts$/))
   })
 
   it('enables Smart Placement by default', () => {
@@ -95,7 +114,50 @@ describe('configureNitroCloudflare', () => {
       enabled: false,
       cross_version_cache: false,
     })
-    expect(nitro.plugins).toBeUndefined()
+    expect(nitro.plugins?.some(plugin => /workers-cache\.[jt]s$/.test(plugin))).toBeFalsy()
+  })
+
+  it('provides Nitro runtime config to eventless Cloudflare handlers', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, {})
+
+    expect(nitro.plugins).toContainEqual(expect.stringMatching(/\/runtime\/server\/plugins\/runtime-config\.ts$/))
+  })
+})
+
+describe('authored Wrangler config', () => {
+  it('keeps authored observability and source maps over module defaults', () => {
+    const rootDir = projectWithWranglerConfig(JSON.stringify({
+      observability: { logs: { head_sampling_rate: 1 } },
+      upload_source_maps: true,
+    }))
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, { logsSampleRate: 0.01 }, { rootDir, serverSourceMaps: false })
+
+    expect(nitro.cloudflare?.wrangler?.observability?.logs?.head_sampling_rate).toBe(1)
+    expect(nitro.cloudflare?.wrangler?.upload_source_maps).toBe(true)
+  })
+
+  it('fails loudly when the authored Wrangler config cannot be parsed', () => {
+    const rootDir = projectWithWranglerConfig('{ "observability": {')
+
+    expect(() => configureNitroCloudflare({}, {}, { rootDir })).toThrow('wrangler.jsonc')
+  })
+})
+
+describe('resolveBindingTypeAudit', () => {
+  it('compares the signature generated during the build', () => {
+    expect(resolveBindingTypeAudit(true, 'signature')).toEqual({ _tag: 'compare', signature: 'signature' })
+  })
+
+  it('reports a missing signature instead of skipping the drift check', () => {
+    expect(resolveBindingTypeAudit(true, undefined)).toEqual({ _tag: 'missing' })
+  })
+
+  it('skips the drift check only when another tool owns the declaration', () => {
+    expect(resolveBindingTypeAudit(false, undefined)).toEqual({ _tag: 'skipped' })
   })
 })
 

--- a/packages/nuxt-cloudflare/tests/nuxt.test.ts
+++ b/packages/nuxt-cloudflare/tests/nuxt.test.ts
@@ -58,7 +58,7 @@ describe('nuxt integration', () => {
     expect(nitro.cloudflare?.nodeCompat).toBe(true)
     expect(nitro.cloudflare?.wrangler).toMatchObject({
       cache: { enabled: true, cross_version_cache: false },
-      compatibility_flags: ['nodejs_compat'],
+      compatibility_flags: ['nodejs_compat', 'no_nodejs_compat_v2'],
       secrets: { required: ['SESSION_PASSWORD'] },
       upload_source_maps: false,
       version_metadata: { binding: 'CF_VERSION_METADATA' },

--- a/packages/nuxt-cloudflare/tests/wrangler-file.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler-file.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { findProjectWranglerConfig, readWranglerConfigFile } from '../src/wrangler-file'
+import { findProjectWranglerConfig, readAuthoredWranglerConfig, readWranglerConfigFile } from '../src/wrangler-file'
 
 const directories: string[] = []
 
@@ -54,5 +54,35 @@ describe('findProjectWranglerConfig', () => {
     writeFileSync(path, '{}')
 
     expect(findProjectWranglerConfig(nestedDirectory)).toBe(path)
+  })
+})
+
+describe('readAuthoredWranglerConfig', () => {
+  it('reads the root config Wrangler and Nitro both treat as the source of truth', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'nuxt-cloudflare-wrangler-'))
+    directories.push(directory)
+    const path = join(directory, 'wrangler.jsonc')
+    writeFileSync(path, '{ "observability": { "logs": { "head_sampling_rate": 1 } } }')
+
+    expect(readAuthoredWranglerConfig(directory)).toEqual({
+      _tag: 'authored',
+      config: { observability: { logs: { head_sampling_rate: 1 } } },
+      path,
+    })
+  })
+
+  it('reports an absent root config without a project directory', () => {
+    expect(readAuthoredWranglerConfig(undefined)).toEqual({ _tag: 'absent' })
+  })
+
+  it('returns an unparsable root config as a value', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'nuxt-cloudflare-wrangler-'))
+    directories.push(directory)
+    writeFileSync(join(directory, 'wrangler.jsonc'), '{ "observability": {')
+
+    expect(readAuthoredWranglerConfig(directory)).toMatchObject({
+      _tag: 'invalid',
+      path: join(directory, 'wrangler.jsonc'),
+    })
   })
 })

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -16,7 +16,7 @@ describe('applyCloudflareDefaults', () => {
     }, {
       requiredSecrets: ['API_TOKEN'],
     })).toMatchObject({
-      compatibility_flags: ['global_fetch_strictly_public', 'nodejs_compat'],
+      compatibility_flags: ['global_fetch_strictly_public', 'nodejs_compat', 'no_nodejs_compat_v2'],
       env: {
         production: { secrets: { required: ['PRODUCTION_ONLY_SECRET', 'API_TOKEN'] } },
       },
@@ -74,6 +74,80 @@ describe('applyCloudflareDefaults', () => {
     ]))
   })
 
+  describe('authored root Wrangler config', () => {
+    it('keeps the authored log sampling rate over the module default', () => {
+      const config = applyCloudflareDefaults({}, { logsSampleRate: 0.01 }, {
+        observability: { logs: { head_sampling_rate: 1 } },
+      })
+
+      expect(config.observability?.logs?.head_sampling_rate).toBe(1)
+      expect(config.observability?.traces?.head_sampling_rate).toBe(0.01)
+    })
+
+    it('keeps authored source-map upload over the Nitro source-map policy', () => {
+      expect(applyCloudflareDefaults({}, { uploadSourceMaps: false }, { upload_source_maps: true }))
+        .toMatchObject({ upload_source_maps: true })
+    })
+
+    it('keeps authored placement, preview URLs, and version metadata', () => {
+      const config = applyCloudflareDefaults({}, {}, {
+        placement: { region: 'gcp:us-east4' },
+        preview_urls: true,
+        version_metadata: { binding: 'BUILD_METADATA' },
+      })
+
+      expect(config.placement).toEqual({ region: 'gcp:us-east4' })
+      expect(config.preview_urls).toBe(true)
+      expect(config.version_metadata).toEqual({ binding: 'BUILD_METADATA' })
+    })
+
+    it('skips version metadata when an authored binding already owns the name', () => {
+      expect(applyCloudflareDefaults({}, {}, { vars: { CF_VERSION_METADATA: 'occupied' } }).version_metadata)
+        .toBeUndefined()
+    })
+
+    it('disables the workers.dev endpoint when the authored config carries a route', () => {
+      expect(applyCloudflareDefaults({}, {}, { routes: ['example.com/*'] }).workers_dev).toBe(false)
+    })
+
+    it('leaves authored required secrets to the authored config', () => {
+      const config = applyCloudflareDefaults({}, { requiredSecrets: ['SHARED_SECRET', 'MODULE_SECRET'] }, {
+        secrets: { required: ['SHARED_SECRET'] },
+      })
+
+      expect(config.secrets?.required).toEqual(['MODULE_SECRET'])
+    })
+
+    it('applies authored environment values to that environment only', () => {
+      const config = applyCloudflareDefaults({ env: { production: {} } }, { logsSampleRate: 0.01 }, {
+        env: { production: { observability: { logs: { head_sampling_rate: 0.5 } } } },
+      })
+
+      expect(config.env?.production?.observability?.logs?.head_sampling_rate).toBe(0.5)
+      expect(config.observability?.logs?.head_sampling_rate).toBe(0.01)
+    })
+  })
+
+  describe('node compatibility flags', () => {
+    it('never pairs nodejs_compat with nodejs_compat_v2', () => {
+      expect(applyCloudflareDefaults({ compatibility_flags: ['nodejs_compat_v2'] }).compatibility_flags)
+        .toEqual(['nodejs_compat_v2'])
+      expect(applyCloudflareDefaults({}, {}, { compatibility_flags: ['nodejs_compat_v2'] }).compatibility_flags)
+        .toEqual(['nodejs_compat_v2'])
+    })
+
+    it('resolves an authored opt-out of nodejs_compat_v2 the way Wrangler does', () => {
+      expect(applyCloudflareDefaults({}, {}, {
+        compatibility_flags: ['nodejs_compat_v2', 'no_nodejs_compat_v2'],
+      }).compatibility_flags).toEqual(['no_nodejs_compat_v2', 'nodejs_compat'])
+    })
+
+    it('adds the Nitro Node compatibility pair when no flag is authored', () => {
+      expect(applyCloudflareDefaults({}).compatibility_flags)
+        .toEqual(['nodejs_compat', 'no_nodejs_compat_v2'])
+    })
+  })
+
   it('preserves an explicit source-map opt-out', () => {
     expect(applyCloudflareDefaults({ upload_source_maps: false })).toMatchObject({ upload_source_maps: false })
   })
@@ -121,7 +195,7 @@ describe('applyCloudflareDefaults', () => {
 
     expect(config.env?.production).toMatchObject({
       compatibility_date: '2026-08-11',
-      compatibility_flags: ['global_fetch_strictly_public', 'nodejs_compat'],
+      compatibility_flags: ['global_fetch_strictly_public', 'nodejs_compat', 'no_nodejs_compat_v2'],
       observability: { enabled: false },
       secrets: { required: ['PRODUCTION_ONLY_SECRET', 'MODULE_SECRET'] },
       version_metadata: { binding: 'CF_VERSION_METADATA' },
@@ -761,6 +835,17 @@ describe('diagnoseWranglerConfig', () => {
     }, { now: new Date('2024-09-22T00:00:00Z') }))
       .not
       .toContainEqual(expect.objectContaining({ code: 'nodejs-compat-version-implicit' }))
+  })
+
+  it('accepts nodejs_compat_v2 as the Node compatibility choice', () => {
+    expect(diagnoseWranglerConfig({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat_v2'],
+      observability: { enabled: true },
+      workers_dev: false,
+    }, { now: new Date('2026-08-11T00:00:00Z') }))
+      .not
+      .toContainEqual(expect.objectContaining({ code: 'missing-nodejs-compat' }))
   })
 
   it('rejects named environments left in a generated deployment config', () => {


### PR DESCRIPTION
The module wrote its own defaults into `nitro.cloudflare.wrangler`, which Nitro merges as `defu(overrides, nitro.cloudflare.wrangler, wrangler.jsonc, defaults)`. A module default therefore outranked the root Wrangler file, and the module never read that file at all.

## What changed

1. **Authored config wins.** `configureNitroCloudflare` reads the root `wrangler.jsonc`, `wrangler.json`, or `wrangler.toml`. `applyCloudflareDefaults` resolves each value across three layers: inline `nitro.cloudflare.wrangler`, the authored file, then module options. Named environments inherit the authored root for the keys Wrangler itself inherits. The reader is shared with `binding-types.ts`, so both paths now read one file the same way, and an unparsable file fails the build with its path.
2. **Source maps follow the authored value.** `upload_source_maps: true` in the Wrangler file is no longer replaced by `sourcemap.server: false`, so the `source-maps-disabled` warning stops firing on repositories that already opted in.
3. **`nodejs_compat` no longer collides with `nodejs_compat_v2`.** `applyEnvironmentDefaults` uses the resolution `binding-types.ts` and Nitro already use: drop `nodejs_compat_v2` when `no_nodejs_compat_v2` is present, add `nodejs_compat` and `no_nodejs_compat_v2` only when v2 is absent. The `missing-nodejs-compat` diagnostic now accepts `nodejs_compat_v2`.
4. **`useCloudflareRuntimeConfig(event?)`.** It reads the request event when one exists, and otherwise wraps the Cloudflare entry environment (`globalThis.__env__`) as a source carrying `context.nitro`. A source missing `context.nitro` caused two documented outages downstream (500s, and about 1,100 failed email sends in 48 hours). A Nitro plugin supplies Nitro's `useRuntimeConfig`, because the bindings module is also loaded outside a Nitro bundle, where importing `nitropack/runtime` crashes the dev server at boot. `runtimeConfigSource` now returns a type that includes `H3Event`, so no call site casts.
5. **`nuxt-cloudflare --version` reads package.json.** It reported a hardcoded `0.0.13` while the package was `0.0.18`.
6. **A missing binding type signature fails the build.** It used to skip the drift check the README says always runs.

## BREAKING

Whose config wins changed. Each repository below now ships different values. No repository needs a code change for the fix itself, but the workarounds listed can be deleted.

**harlanzw.com**
- Ships `observability.logs.head_sampling_rate: 1` from `wrangler.jsonc`, not `0.01`. Log volume rises to the rate the file already asks for. Set `0.01` in `wrangler.jsonc` to keep the old rate.
- Ships `upload_source_maps: true` from `wrangler.jsonc`. The `source-maps-disabled` build warning stops.
- If `wrangler.jsonc` declares `routes` or `route`, the generated config now sets `workers_dev: false`. Set `workers_dev: true` in `wrangler.jsonc` to keep the workers.dev endpoint.

**mdream.dev**
- Same three items as harlanzw.com. The comment in its config claiming the authored sampling rate applies is now true.

**request-indexing**
- `wrangler.toml` sets `nodejs_compat_v2`. The generated config keeps only `nodejs_compat_v2`, with no `nodejs_compat` beside it. The `nuxt.config.ts` workaround at line 229 can be deleted.
- Authored `observability`, `upload_source_maps`, `placement`, and `preview_urls` values in `wrangler.toml` now reach the deployment.

**unlighthouse.dev**
- The `no_nodejs_compat_v2` workaround in `nuxt.config.ts` (lines 230 to 233) can be deleted. The module resolves the pair itself and ships `no_nodejs_compat_v2` plus `nodejs_compat`.

**Every consumer**
- Generated `compatibility_flags` now include `no_nodejs_compat_v2` alongside `nodejs_compat`. Nitro already added this pair when writing the config, so the deployed result is unchanged.
- `secrets.required` names already in the authored file are no longer restated in the generated overrides. The merged result is the same set, without duplicates.
- A production build with binding types enabled now fails when the type template did not regenerate. Run `nuxt prepare` before the build, or set `bindingTypes: false`.
- `configureNitroCloudflare` takes a context object (`{ rootDir, serverSourceMaps }`) instead of a boolean third argument. This is an internal export; no known consumer calls it.

## Verification

- `pnpm --filter @harlan-zw/nuxt-cloudflare test`: 15 files, 213 tests pass. 25 are new, written failing first.
- `pnpm --filter @harlan-zw/nuxt-cloudflare lint`: clean.
- `tsc --noEmit -p tsconfig.check.json` clean, and `@harlan-zw/nuxt-cf-jobs` still typechecks against the new `runtimeConfigSource` type.
- End to end on the test fixture: with `upload_source_maps: true`, `logs.head_sampling_rate: 1`, and a route in `wrangler.jsonc`, the generated `.output/server/wrangler.json` carries `upload_source_maps: true`, `head_sampling_rate: 1`, and `workers_dev: false`. With `compatibility_flags: ["nodejs_compat_v2"]`, it carries only `nodejs_compat_v2` and the build passes.
- `node dist/cli/index.mjs --version` prints `0.0.18`.
