### PR TITLE
fix(nuxt-use-query)!: scan layered sites and revive dead signals

### DIFF
--- a/packages/nuxt-use-query/README.md
+++ b/packages/nuxt-use-query/README.md
@@ -85,6 +85,7 @@ export default defineNuxtConfig({
 The module auto-imports:
 
 - `useNuxtQuery`
+- `useNuxtAsyncQuery`
 - `useNuxtMutation`
 - `useNuxtRpc`
 - `useNuxtRpcQuery`
@@ -96,6 +97,8 @@ The module auto-imports:
 - `serializeNuxtRpcKey`
 - `useQueryCache`
 - `invalidateNuxtQueries`
+- `invalidateNuxtRpc`
+- `removeNuxtQueries`
 - `getQueryData`
 - `setQueryData`
 
@@ -403,6 +406,22 @@ await rpc.execute(siteQueries.update(siteId.value), { name: 'Docs' }, {
 })
 ```
 
+`useNuxtRpcQuery` takes its own `onError`. The client hook above covers `rpc.query` / `rpc.execute` only, so a reactive query needs this one:
+
+```ts
+const sites = useNuxtRpcQuery(siteQueries.list(), {
+  onError({ error, operation, durationMs }) {
+    console.error(operation.path, toHumanNuxtRpcError(error), durationMs)
+  },
+})
+```
+
+It fires once per failure, in the browser only. A failure raised during SSR is transferred in the payload and reported on hydration, so it is never reported twice.
+
+A `NuxtRpcError` is a real `Error` named `NuxtRpcError`. It carries the `type` discriminant and its variant payload, so `captureException` keeps the message and stack instead of stringifying a plain object.
+
+The module registers a payload reducer and reviver for it, so a failure raised during SSR crosses into the browser with its tag intact. The `cause` and `response` fields do not cross: they hold a `FetchError` and a `Response`, which cannot be serialized.
+
 ## Server Fetch Telemetry
 
 Enable server-side fetch telemetry to wrap Nitro's global `$fetch` during SSR. It also applies a default server `$fetch` timeout unless a call or created fetcher already provides one. It logs:
@@ -410,8 +429,8 @@ Enable server-side fetch telemetry to wrap Nitro's global `$fetch` during SSR. I
 - `slow fetch` when a completed server fetch exceeds `slowFetchThreshold`.
 - `large HTTP payload` when a completed server fetch's response `Content-Length` exceeds `largePayloadThreshold` (default `300_000` bytes).
 - `fetch timeout` when a server fetch is aborted by the configured timeout.
-- `fetch waterfall` when one incoming request performs multiple sequential fetches and the request fetch span exceeds `waterfallThreshold`. The warning includes request metrics and an aligned timeline of tracked `$fetch` calls.
-- `duplicate fetch` when one incoming request repeats the same internal GET at least `duplicateFetchThreshold` times.
+- `fetch waterfall` when one incoming request runs a chain of dependent fetches. The rule measures chain depth, not parallelism: a render can be six levels deep and seven fetches wide at each level, which is a waterfall even though it looks highly parallel. A chain is reported when the fetch span exceeds `waterfallThreshold`, the chain holds at least `waterfallMinChainDepth` serial levels, it explains at least `waterfallMinCriticalPathShare` of the wall time, and it costs at least `waterfallMinChainBeyondSlowestMs` more than its slowest single link. The warning lists the critical path plus an aligned timeline of tracked `$fetch` calls.
+- `duplicate fetch` when one incoming request repeats the same internal GET **path** at least `duplicateFetchThreshold` times. The query string is collected as a variant, not used as part of the key, because the query cache already coalesces identical urls. The repeat that costs real time is one handler entered once per filtered slice.
 - `nested fetch` when internal Nitro fetches chain at least `nestedFetchDepthThreshold` levels deep.
 - `recursive fetch` when an internal Nitro fetch calls a route already in its request stack.
 
@@ -429,6 +448,9 @@ export default defineNuxtConfig({
       largePayloadThreshold: 300_000,
       waterfallMinFetches: 2,
       waterfallThreshold: 3_000,
+      waterfallMinChainDepth: 2,
+      waterfallMinCriticalPathShare: 0.75,
+      waterfallMinChainBeyondSlowestMs: 1_000,
       console: true,
       debug: false,
     },
@@ -437,6 +459,8 @@ export default defineNuxtConfig({
 ```
 
 Use `telemetry: true` for the defaults. Set `timeout: false` to disable the default timeout, or pass `timeout` per `$fetch` call to override it. Set `duplicateFetchThreshold: false`, `nestedFetchDepthThreshold: false`, or `recursiveFetchWarning: false` to disable those specific internal-fetch warnings. Set `debug: true` to also log per-fetch timing and per-request summaries, including the per-request timeline. Set `console: false` to keep hook events enabled while suppressing package console output, including slow fetch, large payload, timeout, waterfall, duplicate, nested, and recursive warnings.
+
+Keep every `slowFetchThreshold` below `timeout`. A fetch is aborted at the timeout, so a threshold at or above it can never be reached and the signal is dead. The module warns at build time when a default or per-host threshold breaks this rule. To turn slow detection off, set the threshold to `false`; do not raise it above the timeout.
 
 `largePayloadThreshold` defaults to `300_000` bytes (mirroring Sentry's Large HTTP Payload detector). Like `slowFetchThreshold`, it accepts a per-host map so you can mute an upstream whose big responses are expected while keeping detection everywhere else, a plain `false`/`0` to turn it off globally, or a per-`$fetch`-call override:
 
@@ -529,11 +553,17 @@ export default defineNuxtConfig({
   nuxtUseQuery: {
     contracts: {
       enabled: true,
+      // 'error' fails the build (default); 'warn' logs and continues.
+      severity: 'error',
       apiPrefixes: ['/api/pro'],
       queryDirs: ['app/queries', 'layers/*/app/queries'],
       contractDirs: ['shared/contracts', 'layers/*/shared/contracts'],
       requireServerContracts: true,
       serverApiDirs: ['server/api', 'layers/*/server/api'],
+      // Directories the scanner walks, relative to the project root.
+      scanDirs: ['app', 'server', 'shared', 'modules', 'layers/**/app', 'layers/**/server', 'layers/**/shared'],
+      // Paths to skip, on top of the built-in ones (node_modules, .nuxt, ...).
+      ignore: ['app/generated'],
     },
   },
 })
@@ -544,6 +574,19 @@ With enforcement enabled:
 - API path literals must live in configured query directories.
 - Query files must define Zod-backed RPC operations.
 - Server API routes can be required to import shared contracts.
+
+### Path Patterns
+
+`queryDirs`, `contractDirs`, `serverApiDirs`, `scanDirs`, and `ignore` share one pattern syntax:
+
+- `*` matches one path segment, `**` matches any number of segments, `?` matches one character.
+- A pattern matches anywhere in the path, not only at the project root. `app/queries` therefore also covers `layers/pro/site/app/queries`, which is where a layered site keeps them.
+
+### What The Scanner Accepts
+
+- Server code is exempt from `api-literal-outside-query`. A route, a middleware, and a server util all read or call internal API paths by design. `server-route-missing-contract` still polices the routes.
+- Operation factories resolve through aliases. `import { defineNuxtRpcQuery as defineProQuery }`, `export { defineNuxtRpcQuery as defineProQuery }`, and `const defineProQuery = defineNuxtRpcQuery` all count as operations.
+- Inside a query directory, any factory call whose first argument is an operation object counts as an operation. The object must name a `path` plus a `key` (query) or a `method` (mutation). This covers a layer's own scoped factory, whose name cannot be resolved across files.
 
 Start without enforcement while migrating an existing site, then enable it once queries and contracts have been moved into the recommended directories.
 

--- a/packages/nuxt-use-query/src/enforcement/ast.ts
+++ b/packages/nuxt-use-query/src/enforcement/ast.ts
@@ -15,6 +15,12 @@ export interface SourceAstAnalysis {
   rpcOperationCalls: RpcOperationCall[]
 }
 
+/** Per-file facts the analyzer needs before it walks the AST. */
+export interface SourceAstContext {
+  /** Query files may define operations through their own wrapper factory. */
+  isQueryFile: boolean
+}
+
 const RPC_DEFINE_NAMES = new Set([
   'defineNuxtRpcQuery',
   'defineNuxtRpcMutation',
@@ -56,11 +62,11 @@ const ZOD_SCHEMA_FACTORY_NAMES = new Set([
  * Compile option-dependent matchers once per scan, then collect every fact the
  * rules need in one AST traversal per file.
  */
-export function createSourceAstAnalyzer(apiPrefixes: string[], contractDirs: string[]): (ast: any) => SourceAstAnalysis {
+export function createSourceAstAnalyzer(apiPrefixes: string[], contractDirs: string[]): (ast: any, context: SourceAstContext) => SourceAstAnalysis {
   const normalizedApiPrefixes = apiPrefixes.map(normalizeApiPrefix)
   const contractPatterns = contractDirs.map(directoryPatternToRegExp)
 
-  return (ast: any): SourceAstAnalysis => {
+  return (ast: any, context: SourceAstContext): SourceAstAnalysis => {
     const rpcOperationCalls: RpcOperationCall[] = []
     const zodNamespaces = new Set<string>()
     const zodFactories = new Set<string>()
@@ -68,6 +74,22 @@ export function createSourceAstAnalyzer(apiPrefixes: string[], contractDirs: str
     const zodFactoryCalls = new Set<string>()
     let hasApiLiteral = false
     let hasContractImport = false
+
+    // Module bindings resolve before the walk, because a call can appear above
+    // the import that names its factory. Import and export declarations are
+    // top-level only, so this pass stays cheap.
+    const rpcFactoryNames = collectRpcFactoryNames(ast.program)
+    for (const node of ast.program?.body ?? []) {
+      if (node?.type !== 'ImportDeclaration')
+        continue
+      const source = node.source?.value
+      if (typeof source !== 'string')
+        continue
+      if (!hasContractImport && contractPatterns.some(pattern => pattern.test(source)))
+        hasContractImport = true
+      if (source === 'zod' || source.startsWith('zod/'))
+        collectZodImports(node, zodNamespaces, zodFactories)
+    }
 
     new Visitor({
       Literal(node) {
@@ -78,18 +100,8 @@ export function createSourceAstAnalyzer(apiPrefixes: string[], contractDirs: str
         if (!hasApiLiteral && isApiLiteralNode(node, normalizedApiPrefixes))
           hasApiLiteral = true
       },
-      ImportDeclaration(node) {
-        const source = node.source?.value
-        if (typeof source !== 'string')
-          return
-        if (!hasContractImport && contractPatterns.some(pattern => pattern.test(source)))
-          hasContractImport = true
-        if (source !== 'zod' && !source.startsWith('zod/'))
-          return
-        collectZodImports(node, zodNamespaces, zodFactories)
-      },
       CallExpression(node) {
-        collectRpcOperationCall(node, rpcOperationCalls)
+        collectRpcOperationCall(node, rpcOperationCalls, rpcFactoryNames, context)
         if (node.callee?.type === 'MemberExpression' && node.callee.object?.type === 'Identifier') {
           const factory = getPropertyName(node.callee.property)
           if (factory && ZOD_SCHEMA_FACTORY_NAMES.has(factory))
@@ -163,16 +175,84 @@ function matchesNormalizedPrefix(value: string, prefix: string): boolean {
   return value === prefix || value.startsWith(`${prefix}/`) || value.startsWith(`${prefix}?`)
 }
 
-function collectRpcOperationCall(node: any, calls: RpcOperationCall[]): void {
+function collectRpcOperationCall(
+  node: any,
+  calls: RpcOperationCall[],
+  factoryNames: Map<string, string>,
+  context: SourceAstContext,
+): void {
   const name = getCalleeName(node.callee)
-  if (!name || !RPC_DEFINE_NAMES.has(name))
+  if (!name)
     return
-  if (name === 'defineNuxtQueryGroup') {
-    calls.push({ calleeName: name, argument: node.arguments?.[1] ?? null })
+  const canonical = factoryNames.get(name)
+  if (canonical == null) {
+    // A query file may wrap the shipped factories in its own scoped helper
+    // (`defineProQuery`, `defineBillingMutation`). The wrapper name cannot be
+    // resolved across files, so the operation object itself is the signal.
+    if (context.isQueryFile)
+      collectWrappedOperationObject(node.arguments?.[0], calls)
+    return
+  }
+  if (canonical === 'defineNuxtQueryGroup') {
+    calls.push({ calleeName: canonical, argument: node.arguments?.[1] ?? null })
     collectQueryGroupOperationObjects(node.arguments?.[1], calls)
     return
   }
-  calls.push({ calleeName: name, argument: node.arguments?.[0] ?? null })
+  calls.push({ calleeName: canonical, argument: node.arguments?.[0] ?? null })
+}
+
+/**
+ * Map every local name that reaches one of the shipped factories back to its
+ * canonical name. Covers `import { defineNuxtRpcQuery as defineProQuery }`,
+ * `export { defineNuxtRpcQuery as defineProQuery }`, and
+ * `const defineProQuery = defineNuxtRpcQuery`. The canonical names stay
+ * mapped to themselves, because Nuxt auto-imports them without any import.
+ */
+function collectRpcFactoryNames(program: any): Map<string, string> {
+  const names = new Map<string, string>()
+  for (const name of RPC_DEFINE_NAMES)
+    names.set(name, name)
+
+  for (const node of program?.body ?? []) {
+    if (node?.type === 'ImportDeclaration' || node?.type === 'ExportNamedDeclaration') {
+      for (const specifier of node.specifiers ?? []) {
+        const source = getPropertyName(specifier.imported ?? specifier.local)
+        const local = getPropertyName(specifier.local ?? specifier.exported)
+        const alias = getPropertyName(specifier.exported) ?? local
+        if (source == null || !RPC_DEFINE_NAMES.has(source))
+          continue
+        if (local != null)
+          names.set(local, source)
+        if (alias != null)
+          names.set(alias, source)
+      }
+    }
+    const declaration = node?.type === 'ExportNamedDeclaration' ? node.declaration : node
+    if (declaration?.type !== 'VariableDeclaration')
+      continue
+    for (const declarator of declaration.declarations ?? []) {
+      if (declarator.id?.type !== 'Identifier' || declarator.init?.type !== 'Identifier')
+        continue
+      const source = names.get(declarator.init.name)
+      if (source != null)
+        names.set(declarator.id.name, source)
+    }
+  }
+  return names
+}
+
+/**
+ * Read the first argument of an unknown factory call as an operation. An
+ * operation always names a `path` plus its cache `key` (query) or its HTTP
+ * `method` (mutation), which a route or navigation target does not.
+ */
+function collectWrappedOperationObject(node: any, calls: RpcOperationCall[]): void {
+  if (node?.type !== 'ObjectExpression')
+    return
+  const props = getObjectProperties(node)
+  if (!props.has('path') || (!props.has('key') && !props.has('method')))
+    return
+  collectOperationObject(node, calls)
 }
 
 function collectZodImports(node: any, namespaces: Set<string>, factories: Set<string>): void {

--- a/packages/nuxt-use-query/src/enforcement/options.ts
+++ b/packages/nuxt-use-query/src/enforcement/options.ts
@@ -1,38 +1,38 @@
 import type { ContractQueryEnforcementOptions, ResolvedContractQueryEnforcementOptions } from './types'
 import { normalize } from 'pathe'
 
+// Directory patterns match anywhere in the path, so one entry also covers the
+// same directory inside a layer (`layers/pro/site/app/queries`).
 const DEFAULT_QUERY_DIRS = [
   'app/queries',
-  'layers/*/app/queries',
 ]
 
 const DEFAULT_CONTRACT_DIRS = [
   'shared/contracts',
-  'layers/*/shared/contracts',
 ]
 
 const DEFAULT_SERVER_API_DIRS = [
   'server/api',
-  'layers/*/server/api',
 ]
 
 /**
  * Default Nuxt code roots. Walking only these directories keeps build-time
  * config files (`nuxt.config.ts`, vite config, etc.) out of the scan; their
  * own `apiPrefixes: ['/api/']` literal would otherwise trip the rule it
- * configures.
+ * configures. `**` reaches a layer at any depth, because a layer workspace
+ * nests them (`layers/pro/site/app`).
  */
 const DEFAULT_SCAN_DIRS = [
   'app',
   'server',
   'shared',
   'modules',
-  'layers/*/app',
-  'layers/*/server',
-  'layers/*/shared',
-  'apps/*/app',
-  'apps/*/server',
-  'apps/*/shared',
+  'layers/**/app',
+  'layers/**/server',
+  'layers/**/shared',
+  'apps/**/app',
+  'apps/**/server',
+  'apps/**/shared',
 ]
 
 const DEFAULT_IGNORE = [
@@ -65,15 +65,55 @@ export function createDirectoryMatcher(patterns: string[]): (file: string) => bo
   return (file: string) => matchers.some(pattern => pattern.test(file))
 }
 
+/**
+ * Compile one path pattern into a matcher. Every option that names paths
+ * (`queryDirs`, `contractDirs`, `serverApiDirs`, `ignore`) uses this, so they
+ * all share the same semantics:
+ *
+ * - `*` matches one path segment, `**` matches any number of segments, `?`
+ *   matches one character.
+ * - The pattern matches anywhere in the path, not only at the project root. A
+ *   pattern like `app/queries` therefore also covers
+ *   `layers/pro/site/app/queries`, which is where a layered site keeps them.
+ */
 export function directoryPatternToRegExp(pattern: string): RegExp {
-  const normalized = normalize(pattern).replace(/^\/+|\/+$/g, '')
-  const escaped = normalized
-    .split('/')
-    .map(part => part === '*' ? '[^/]+' : escapeRegExp(part))
-    .join('/')
-  return new RegExp(`(^|/)${escaped}(/|$)`)
+  return new RegExp(`(^|/)${globPatternSource(normalizePattern(pattern))}(/|$)`)
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+/** Compile one path pattern into a matcher for a single path segment. */
+export function segmentPatternToRegExp(pattern: string): RegExp {
+  return new RegExp(`^${globPatternSource(normalizePattern(pattern))}$`)
+}
+
+export function normalizePattern(pattern: string): string {
+  return normalize(pattern).replace(/^\.\//, '').replace(/^\/+|\/+$/g, '')
+}
+
+function globPatternSource(pattern: string): string {
+  let source = ''
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index]!
+    if (character === '*') {
+      if (pattern[index + 1] === '*') {
+        index++
+        if (pattern[index + 1] === '/') {
+          index++
+          source += '(?:.*/)?'
+        }
+        else {
+          source += '.*'
+        }
+      }
+      else {
+        source += '[^/]*'
+      }
+      continue
+    }
+    if (character === '?') {
+      source += '[^/]'
+      continue
+    }
+    source += character.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  }
+  return source
 }

--- a/packages/nuxt-use-query/src/enforcement/read.ts
+++ b/packages/nuxt-use-query/src/enforcement/read.ts
@@ -1,7 +1,8 @@
 import type { ContractQuerySourceFile, ResolvedContractQueryEnforcementOptions } from './types'
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import { basename, join, relative } from 'node:path'
 import { normalize } from 'pathe'
+import { createDirectoryMatcher, normalizePattern, segmentPatternToRegExp } from './options'
 
 const SOURCE_READ_CONCURRENCY = 32
 
@@ -12,7 +13,9 @@ interface DiscoveredSourceFile {
 
 export async function readSourceFilesFromDisk(rootDir: string, options: ResolvedContractQueryEnforcementOptions): Promise<ContractQuerySourceFile[]> {
   const discovered: DiscoveredSourceFile[] = []
-  const isIgnored = createIgnoreMatcher(options.ignore)
+  // `ignore` shares the matcher used by `queryDirs` and `contractDirs`, so one
+  // pattern means the same thing in every option.
+  const isIgnored = createDirectoryMatcher(options.ignore)
   const seen = new Set<string>()
 
   async function walk(dir: string) {
@@ -45,7 +48,7 @@ export async function readSourceFilesFromDisk(rootDir: string, options: Resolved
     }
   }
 
-  for (const dir of await expandScanDirs(rootDir, options.scanDirs))
+  for (const dir of await expandScanDirs(rootDir, options.scanDirs, isIgnored))
     await walk(dir)
 
   return mapConcurrent(discovered, SOURCE_READ_CONCURRENCY, async ({ file, path }) => ({
@@ -54,95 +57,85 @@ export async function readSourceFilesFromDisk(rootDir: string, options: Resolved
   }))
 }
 
-function createIgnoreMatcher(patterns: string[]): (path: string) => boolean {
-  const matchers = patterns.map((pattern) => {
-    const normalized = normalize(pattern).replace(/^\.\//, '').replace(/^\/+|\/+$/g, '')
-    const hasDirectory = normalized.includes('/')
-    const hasGlob = /[*?]/.test(normalized)
-
-    if (!hasGlob) {
-      return hasDirectory
-        ? (path: string) => path === normalized || path.startsWith(`${normalized}/`)
-        : (path: string) => normalize(path).split('/').includes(normalized)
-    }
-
-    const expression = globPatternToRegExp(normalized)
-    return hasDirectory
-      ? (path: string) => expression.test(normalize(path))
-      : (path: string) => expression.test(basename(path))
-  })
-
-  return path => matchers.some(matches => matches(path))
-}
-
-function globPatternToRegExp(pattern: string): RegExp {
-  let source = ''
-  for (let index = 0; index < pattern.length; index++) {
-    const character = pattern[index]!
-    if (character === '*') {
-      if (pattern[index + 1] === '*') {
-        index++
-        if (pattern[index + 1] === '/') {
-          index++
-          source += '(?:.*/)?'
-        }
-        else {
-          source += '.*'
-        }
-      }
-      else {
-        source += '[^/]*'
-      }
-      continue
-    }
-    if (character === '?') {
-      source += '[^/]'
-      continue
-    }
-    source += character.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-  }
-  return new RegExp(`^${source}$`)
-}
-
 /**
- * Expand `scanDirs` entries into absolute directory paths. Supports a single
- * `*` segment per pattern (e.g. `layers/*\/app`) by listing the parent dir and
- * appending the tail.
+ * Expand `scanDirs` entries into absolute directory paths. Every segment may
+ * hold a wildcard: `*` matches one directory name, `**` matches any depth. A
+ * layered site keeps its code under `layers/<layer>/<site>/app`, so a pattern
+ * has to survive more than one wildcard to reach it.
  */
-async function expandScanDirs(rootDir: string, patterns: string[]): Promise<string[]> {
-  const out: string[] = []
+async function expandScanDirs(
+  rootDir: string,
+  patterns: string[],
+  isIgnored: (path: string) => boolean,
+): Promise<string[]> {
+  const expanded = new Set<string>()
   for (const pattern of patterns) {
-    const parts = pattern.split('/')
-    const starIndex = parts.indexOf('*')
-    if (starIndex === -1) {
-      out.push(join(rootDir, ...parts))
-      continue
-    }
-    const head = parts.slice(0, starIndex)
-    const tail = parts.slice(starIndex + 1)
-    const parent = join(rootDir, ...head)
-    let entries
-    try {
-      entries = await readdir(parent, { withFileTypes: true })
-    }
-    catch {
-      // Wildcard scan roots are optional and commonly absent.
-      continue
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory())
-        continue
-      const candidate = join(parent, entry.name, ...tail)
-      if (tail.length === 0) {
-        out.push(candidate)
-        continue
-      }
-      const exists = await stat(candidate).then(s => s.isDirectory(), () => false)
-      if (exists)
-        out.push(candidate)
-    }
+    const segments = normalizePattern(pattern).split('/').filter(segment => segment && segment !== '.')
+    for (const dir of await expandSegments(rootDir, segments, rootDir, isIgnored))
+      expanded.add(dir)
   }
-  return out
+  return [...expanded]
+}
+
+async function expandSegments(
+  dir: string,
+  segments: string[],
+  rootDir: string,
+  isIgnored: (path: string) => boolean,
+): Promise<string[]> {
+  const [head, ...rest] = segments
+  // `walk` tolerates a scan root that does not exist, so a literal tail needs
+  // no existence check here.
+  if (head == null)
+    return [dir]
+
+  if (head === '**') {
+    // `**` matches this directory plus every descendant.
+    const matched = await expandSegments(dir, rest, rootDir, isIgnored)
+    for (const child of await listChildDirectories(dir, rootDir, isIgnored))
+      matched.push(...await expandSegments(child, segments, rootDir, isIgnored))
+    return matched
+  }
+
+  if (head.includes('*') || head.includes('?')) {
+    const matchesSegment = segmentPatternToRegExp(head)
+    const matched: string[] = []
+    for (const child of await listChildDirectories(dir, rootDir, isIgnored)) {
+      if (matchesSegment.test(basename(child)))
+        matched.push(...await expandSegments(child, rest, rootDir, isIgnored))
+    }
+    return matched
+  }
+
+  const next = join(dir, head)
+  if (isIgnored(normalize(relative(rootDir, next))))
+    return []
+  return expandSegments(next, rest, rootDir, isIgnored)
+}
+
+async function listChildDirectories(
+  dir: string,
+  rootDir: string,
+  isIgnored: (path: string) => boolean,
+): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  }
+  catch {
+    // Wildcard scan roots are optional and commonly absent.
+    return []
+  }
+  const directories: string[] = []
+  for (const entry of entries) {
+    if (!entry.isDirectory())
+      continue
+    const path = join(dir, entry.name)
+    if (isIgnored(normalize(relative(rootDir, path))))
+      continue
+    directories.push(path)
+  }
+  return directories
 }
 
 async function mapConcurrent<T, U>(

--- a/packages/nuxt-use-query/src/enforcement/rules/api-literal-outside-query.ts
+++ b/packages/nuxt-use-query/src/enforcement/rules/api-literal-outside-query.ts
@@ -2,10 +2,10 @@ import type { ContractRule } from '../types'
 
 export const apiLiteralOutsideQueryRule: ContractRule = {
   code: 'api-literal-outside-query',
-  // Query operations own client-side API paths; server routes are policed by
-  // `server-route-missing-contract` and legitimately need URL literals
-  // (handler paths, upstream proxy URLs, demo fixtures returned in payloads).
-  applies: ctx => !ctx.isQueryFile && !ctx.isServerApiFile,
+  // Query operations own client-side API paths. Server code is exempt: a
+  // route, a middleware, and a server util all read or call internal API
+  // paths by design, and `server-route-missing-contract` polices the routes.
+  applies: ctx => !ctx.isQueryFile && !ctx.isServerFile,
   detect: ctx => ctx.analysis.hasApiLiteral,
   message: file => `Move API path literals into an app/queries operation: ${file}`,
   terminal: true,

--- a/packages/nuxt-use-query/src/enforcement/scan.ts
+++ b/packages/nuxt-use-query/src/enforcement/scan.ts
@@ -11,6 +11,13 @@ import { extractScriptSource, parseSourceAst } from './parse'
 import { readSourceFilesFromDisk } from './read'
 import { contractRules } from './rules'
 
+/**
+ * Server code is exempt from the client-side API literal rule. A route
+ * handler, a middleware, and a server util all read or call internal API
+ * paths by design.
+ */
+const SERVER_DIRS = ['server']
+
 export function createContractQueryEnforcer(options: ContractQueryEnforcerOptions = {}) {
   const readSourceFiles = options.readSourceFiles ?? readSourceFilesFromDisk
 
@@ -22,6 +29,7 @@ export function createContractQueryEnforcer(options: ContractQueryEnforcerOption
       const analyzeAst = createSourceAstAnalyzer(resolved.apiPrefixes, resolved.contractDirs)
       const isQueryFile = createDirectoryMatcher(resolved.queryDirs)
       const isServerApiFile = createDirectoryMatcher(resolved.serverApiDirs)
+      const isServerFile = createDirectoryMatcher(SERVER_DIRS)
 
       for (const sourceFile of files) {
         const file = normalize(sourceFile.file)
@@ -30,13 +38,15 @@ export function createContractQueryEnforcer(options: ContractQueryEnforcerOption
           continue
 
         const ast = parseSourceAst(file, source)
+        const queryFile = isQueryFile(file)
         const ctx: RuleContext = {
-          analysis: analyzeAst(ast),
+          analysis: analyzeAst(ast, { isQueryFile: queryFile }),
           file,
           ast,
           options: resolved,
-          isQueryFile: isQueryFile(file),
+          isQueryFile: queryFile,
           isServerApiFile: isServerApiFile(file),
+          isServerFile: isServerFile(file),
         }
 
         runRulesForFile(ctx, violations)

--- a/packages/nuxt-use-query/src/enforcement/types.ts
+++ b/packages/nuxt-use-query/src/enforcement/types.ts
@@ -21,13 +21,18 @@ export interface ContractQueryEnforcementOptions {
   serverApiDirs?: string[]
   /** Require server/api route files to import from shared/contracts. */
   requireServerContracts?: boolean
-  /** Extra path globs to skip. */
+  /**
+   * Extra paths to skip, on top of the built-in ones. Uses the same pattern
+   * syntax as `queryDirs`, so `app/queries` also skips
+   * `layers/pro/site/app/queries`.
+   */
   ignore?: string[]
   /**
    * Directories (relative to `rootDir`) the scanner walks. Limiting the scan to
    * Nuxt app/server code roots keeps build-time config (`nuxt.config.ts`, vite
-   * config, etc.) out of contract enforcement. Supports a single `*` segment
-   * for layer/module fan-out (e.g. `layers/<asterisk>/app`).
+   * config, etc.) out of contract enforcement. Every segment may hold a
+   * wildcard: `*` matches one directory name, `**` matches any depth. A layer
+   * workspace needs that, because it nests layers (`layers/pro/site/app`).
    */
   scanDirs?: string[]
 }
@@ -77,6 +82,8 @@ export interface RuleContext {
   options: ResolvedContractQueryEnforcementOptions
   isQueryFile: boolean
   isServerApiFile: boolean
+  /** Any file under a `server/` directory, not only `serverApiDirs`. */
+  isServerFile: boolean
 }
 
 export interface ContractRule {

--- a/packages/nuxt-use-query/src/module.ts
+++ b/packages/nuxt-use-query/src/module.ts
@@ -7,9 +7,11 @@ import { setupFetchTelemetryModule } from './module/telemetry'
 // `useAsyncData`. Built on Nuxt primitives (refreshNuxtData, clearNuxtData,
 // `_asyncData`); cache state lives on the Nuxt app instance for SSR safety.
 //
-// Exposes auto-imports: useNuxtQuery, useNuxtMutation, useNuxtRpc,
-// useNuxtRpcQuery, useNuxtSubscription, useQueryCache, invalidateNuxtQueries,
-// removeNuxtQueries, getQueryData, setQueryData.
+// Exposes auto-imports: useNuxtQuery, useNuxtAsyncQuery, useNuxtMutation,
+// useNuxtRpc, useNuxtRpcQuery, useNuxtSubscription, nuxtWebSocketSource,
+// useQueryCache, invalidateNuxtQueries, invalidateNuxtRpc, removeNuxtQueries,
+// getQueryData, setQueryData, defineNuxtQueryGroup, defineNuxtRpcQuery,
+// defineNuxtRpcMutation, serializeNuxtRpcKey.
 
 export interface ModuleOptions {
   /**
@@ -88,6 +90,10 @@ export {}
     // Server-only: serializes the per-request `lastFetched` map into the
     // payload so the client seeds exact fetch timestamps.
     addPlugin({ mode: 'server', src: resolver.resolve('./runtime/plugin.server') })
+
+    // Both runtimes: the reducer runs on the server, the reviver on the
+    // client, so a `NuxtRpcError` survives the payload with its tag.
+    addPlugin({ src: resolver.resolve('./runtime/plugin-rpc-payload') })
 
     setupFetchTelemetryModule(
       options.telemetry,

--- a/packages/nuxt-use-query/src/module/telemetry.ts
+++ b/packages/nuxt-use-query/src/module/telemetry.ts
@@ -1,6 +1,11 @@
 import type { FetchTelemetryRuntimeOptions } from '../runtime/telemetry'
 import { addServerPlugin } from '@nuxt/kit'
-import { DEFAULT_FETCH_TELEMETRY_OPTIONS } from '../runtime/telemetry'
+import { consola } from 'consola'
+import {
+  collectFetchTelemetryOptionWarnings,
+  DEFAULT_FETCH_TELEMETRY_OPTIONS,
+  normalizeFetchTelemetryOptions,
+} from '../runtime/telemetry'
 
 export type ModuleTelemetryOptions = boolean | Partial<FetchTelemetryRuntimeOptions>
 
@@ -25,8 +30,19 @@ export function setupFetchTelemetryModule(
   if (!telemetry.enabled)
     return
 
+  reportTelemetryOptionWarnings(telemetry)
   setRuntimeTelemetryConfig(runtimeConfig, telemetry)
   addServerPlugin(serverPlugin)
+}
+
+/**
+ * Surface unreachable telemetry configuration at build time. A dead threshold
+ * looks identical to a healthy site: both report nothing.
+ */
+function reportTelemetryOptionWarnings(telemetry: FetchTelemetryRuntimeOptions): void {
+  const logger = consola.withTag('nuxt-use-query')
+  for (const warning of collectFetchTelemetryOptionWarnings(normalizeFetchTelemetryOptions(telemetry)))
+    logger.warn(warning.message)
 }
 
 function resolveModuleTelemetryOptions(input: ModuleTelemetryOptions | undefined): FetchTelemetryRuntimeOptions {

--- a/packages/nuxt-use-query/src/runtime/composables/useNuxtRpc.ts
+++ b/packages/nuxt-use-query/src/runtime/composables/useNuxtRpc.ts
@@ -1,9 +1,10 @@
-import type { MaybeRefOrGetter } from 'vue'
+import type { ComputedRef, MaybeRefOrGetter } from 'vue'
 import type { z } from 'zod'
 import type {
   NuxtRpcClientOptions,
   NuxtRpcError,
   NuxtRpcKey,
+  NuxtRpcOperationContext,
   NuxtRpcQueryOperation,
 } from '../rpc/core'
 import type { KeysOf, NuxtQuery, UseNuxtQueryOptions } from './useNuxtQuery'
@@ -35,13 +36,31 @@ export function invalidateNuxtRpc(operationOrKey: NuxtRpcKey | { key: NuxtRpcKey
   return invalidateNuxtQueries(serializeNuxtRpcKey(key))
 }
 
+export interface NuxtRpcQueryErrorEvent {
+  operation: NuxtRpcOperationContext
+  error: NuxtRpcError
+  /**
+   * How long the failing request was in flight. Undefined when the failure
+   * arrived with the server-rendered payload, because the request ran in the
+   * previous runtime.
+   */
+  durationMs?: number
+}
+
 // `DefaultT` must stay a generic so the `default` factory drives its own
 // inference. Without it `DefaultT` pins to `undefined` and `default` collapses
 // to `() => Ref<undefined, undefined> | undefined`, rejecting every real value.
 export type UseNuxtRpcQueryOptions<TData, DefaultT = undefined> = Omit<
   UseNuxtQueryOptions<TData, TData, KeysOf<TData>, DefaultT>,
   'body' | 'key' | 'method' | 'query' | 'transform'
->
+> & {
+  /**
+   * Called once for each failure of this query. The imperative client hook of
+   * the same name covers `rpc.query` / `rpc.execute` only, so without this a
+   * reactive query failure reaches no handler.
+   */
+  onError?: (event: NuxtRpcQueryErrorEvent) => void
+}
 
 export function useNuxtRpcQuery<
   TResponseSchema extends z.ZodTypeAny,
@@ -54,8 +73,11 @@ export function useNuxtRpcQuery<
   const resolved = () => toValue(operation)
   const request = computed(() => resolveQueryRequestState(resolved()))
   const userOnRequest = options.onRequest
+  // `onError` belongs to this composable, not to `useFetch`. Strip it so it
+  // never reaches the fetch options.
+  const { onError, ...queryOptions } = options
   const query = (useNuxtQuery as any)(() => resolved().path, {
-    ...options,
+    ...queryOptions,
     key: () => request.value._tag === 'ok' ? request.value.request.key : request.value.key,
     method: computed(() => request.value._tag === 'ok' ? request.value.request.method : request.value.method),
     query: computed(() => resolved().query),
@@ -99,7 +121,64 @@ export function useNuxtRpcQuery<
     get: () => (rawError.value == null ? undefined : normalizeNuxtRpcQueryError(rawError.value, request.value)),
     set: value => void (rawError.value = value),
   }) as typeof query.error
+
+  if (onError)
+    useQueryErrorReporter(query, rawError, resolved, request, onError)
+
   return query
+}
+
+/**
+ * Report each failure of a reactive query once.
+ *
+ * The hook runs outside server rendering. A failure raised during SSR is
+ * transferred in the payload and reported on hydration, so a hook that ran in
+ * both runtimes would report the same failure twice.
+ */
+function useQueryErrorReporter(
+  query: { status?: { value: string } },
+  rawError: { value: unknown },
+  resolved: () => NuxtRpcQueryOperation<z.ZodTypeAny, unknown>,
+  request: ComputedRef<ReturnType<typeof resolveQueryRequestState>>,
+  onError: (event: NuxtRpcQueryErrorEvent) => void,
+): void {
+  if (import.meta.server)
+    return
+
+  let startedAt: number | undefined
+  if (query.status) {
+    watch(() => query.status!.value, (status) => {
+      if (status === 'pending')
+        startedAt = Date.now()
+    })
+  }
+
+  // A normalized error keeps its identity across reads, so object identity is
+  // what separates a new failure from a re-read of the same one.
+  const reported = new WeakSet<object>()
+  watch(rawError, (value) => {
+    if (value == null || typeof value !== 'object')
+      return
+    if (reported.has(value))
+      return
+    reported.add(value)
+    const durationMs = startedAt == null ? undefined : Date.now() - startedAt
+    startedAt = undefined
+    onError({
+      durationMs,
+      error: normalizeNuxtRpcQueryError(value, request.value),
+      operation: describeQueryOperation(resolved()),
+    })
+  }, { immediate: true })
+}
+
+function describeQueryOperation(operation: NuxtRpcQueryOperation<z.ZodTypeAny, unknown>): NuxtRpcOperationContext {
+  return {
+    kind: 'query',
+    key: operation.key,
+    method: operation.method === 'POST' ? 'POST' : 'GET',
+    path: operation.path,
+  }
 }
 
 function normalizeNuxtRpcQueryError(

--- a/packages/nuxt-use-query/src/runtime/plugin-rpc-payload.ts
+++ b/packages/nuxt-use-query/src/runtime/plugin-rpc-payload.ts
@@ -1,0 +1,13 @@
+import type { NuxtRpcErrorData } from './rpc/core'
+import { definePayloadPlugin, definePayloadReducer, definePayloadReviver } from '#app'
+import { createNuxtRpcError, isNuxtRpcError, toSerializableNuxtRpcError } from './rpc/core'
+
+// A failing query parks its error in `payload._errors`, which Nuxt serializes
+// with devalue. An `Error` is not a plain object, so without this pair the
+// render fails with "Cannot stringify arbitrary non-POJOs". The reducer keeps
+// the tag and the diagnosis fields; the reviver rebuilds the same `Error` on
+// the client, so a hydrated failure discriminates exactly like a fresh one.
+export default definePayloadPlugin(() => {
+  definePayloadReducer('NuxtRpcError', (value: unknown) => isNuxtRpcError(value) && toSerializableNuxtRpcError(value))
+  definePayloadReviver('NuxtRpcError', (data: NuxtRpcErrorData) => createNuxtRpcError(data))
+})

--- a/packages/nuxt-use-query/src/runtime/query-lifecycle.ts
+++ b/packages/nuxt-use-query/src/runtime/query-lifecycle.ts
@@ -89,7 +89,15 @@ export function applyQueryLifecycle<TQuery extends LifecycleQuery>(
       void query.refresh()
   })
 
-  if (enabled.value && shouldRefetchOnMount(query, cache, key.value, staleTime, refetchOnMount)) {
+  if (enabled.value && shouldRefetchOnMount({
+    cache,
+    data: query.data.value,
+    isServerRender: import.meta.server,
+    key: key.value,
+    option: refetchOnMount,
+    staleTime,
+    status: query.status.value,
+  })) {
     void query.refresh()
   }
 
@@ -133,22 +141,31 @@ function normalizeRefetchInterval(value: number | false | null | undefined): num
     : 0
 }
 
-function shouldRefetchOnMount(
-  query: { data: { value: unknown }, refresh: () => Promise<void>, status: { value: string } },
-  cache: ReturnType<typeof useQueryCache>,
-  key: string,
-  staleTime: QueryStaleTime,
-  option: boolean | 'always',
-): boolean {
-  if (!option || query.status.value === 'pending')
-    return false
-  if (option === 'always')
-    return true
-  return hasResolvedQueryData(query) && isQueryStale(cache, key, staleTime)
+export interface RefetchOnMountInput {
+  cache: ReturnType<typeof useQueryCache>
+  data: unknown
+  /**
+   * Refetch on mount is a browser behaviour. During server rendering the data
+   * was fetched moments ago in the same render, so a sibling mount that
+   * refetches only doubles the upstream load and races the response.
+   */
+  isServerRender: boolean
+  key: string
+  option: boolean | 'always'
+  staleTime: QueryStaleTime
+  status: string
 }
 
-function hasResolvedQueryData(query: { data: { value: unknown }, status: { value: string } }): boolean {
-  return query.status.value === 'success' || query.data.value !== undefined
+export function shouldRefetchOnMount(input: RefetchOnMountInput): boolean {
+  if (input.isServerRender || !input.option || input.status === 'pending')
+    return false
+  if (input.option === 'always')
+    return true
+  return hasResolvedQueryData(input) && isQueryStale(input.cache, input.key, input.staleTime)
+}
+
+function hasResolvedQueryData(input: Pick<RefetchOnMountInput, 'data' | 'status'>): boolean {
+  return input.status === 'success' || input.data !== undefined
 }
 
 function refetchIfAllowed(

--- a/packages/nuxt-use-query/src/runtime/rpc/core.ts
+++ b/packages/nuxt-use-query/src/runtime/rpc/core.ts
@@ -301,7 +301,10 @@ export interface NuxtRpcValidationIssue {
   path: string
 }
 
-export type NuxtRpcError
+/**
+ * The payload of one RPC failure. Discriminate on `type`.
+ */
+export type NuxtRpcErrorData
   = | {
     type: 'fetch'
     message: string
@@ -330,6 +333,60 @@ export type NuxtRpcError
     message: string
     cause: unknown
   }
+
+type AsRpcError<TData> = TData extends unknown ? Error & TData : never
+
+/**
+ * A tagged RPC failure. It is a real `Error`, so a reporter (Sentry, a log
+ * drain) keeps the message and the stack instead of stringifying a plain
+ * object, and it still carries the `type` discriminant and the payload of its
+ * variant. `name` is always `NuxtRpcError`.
+ */
+export type NuxtRpcError = AsRpcError<NuxtRpcErrorData>
+
+/**
+ * Build a tagged RPC failure from its payload. The only place a
+ * `NuxtRpcError` is constructed.
+ */
+export function createNuxtRpcError<TData extends NuxtRpcErrorData>(data: TData): Error & TData {
+  const error = new Error(data.message, { cause: data.cause }) as Error & TData
+  Object.assign(error, data)
+  error.name = 'NuxtRpcError'
+  return error
+}
+
+/**
+ * Reduce a failure to the fields that survive the server-rendered payload.
+ *
+ * `cause` and `response` hold runtime objects, a `FetchError` and a `Response`.
+ * Neither can be serialized, and neither means anything in the other runtime.
+ * The tag, the message, and the diagnosis fields do survive.
+ */
+export function toSerializableNuxtRpcError(error: NuxtRpcError): NuxtRpcErrorData {
+  if (error.type === 'request-validation' || error.type === 'response-validation') {
+    return {
+      type: error.type,
+      message: error.message,
+      issues: error.issues,
+      cause: undefined as unknown as ZodError,
+    }
+  }
+  if (error.type === 'fetch') {
+    return {
+      type: 'fetch',
+      message: error.message,
+      status: error.status,
+      statusMessage: error.statusMessage,
+      data: error.data,
+      cause: undefined,
+    }
+  }
+  return {
+    type: error.type,
+    message: error.message,
+    cause: undefined,
+  }
+}
 
 /**
  * Tagged outcome of an RPC call. The `*Safe` client methods return this
@@ -537,15 +594,20 @@ export function isAuthRpcError(error: NuxtRpcError): boolean {
 export function normalizeNuxtRpcError(error: unknown, zodType: 'request-validation' | 'response-validation' = 'response-validation'): NuxtRpcError {
   if (isNuxtRpcError(error))
     return error
+  // A tagged failure that crossed the SSR payload arrives as a plain object:
+  // devalue keeps the fields and drops the prototype. Rebuild it so the client
+  // sees the same `Error` the server threw.
+  if (isNuxtRpcErrorData(error))
+    return createNuxtRpcError(error)
   if (error instanceof ZodError) {
-    return {
+    return createNuxtRpcError({
       type: zodType,
       message: zodType === 'request-validation'
         ? 'Request validation failed.'
         : 'Response validation failed.',
       issues: formatNuxtRpcValidationIssues(error),
       cause: error,
-    }
+    })
   }
   const fetchLike = error as {
     message?: string
@@ -563,15 +625,15 @@ export function normalizeNuxtRpcError(error: unknown, zodType: 'request-validati
   if (status == null && fetchLike.response == null) {
     const transient = detectTransientErrorType(error)
     if (transient != null) {
-      return {
+      return createNuxtRpcError({
         type: transient,
         message: fetchLike.message || transient,
         cause: error,
-      }
+      })
     }
   }
   if (status != null || fetchLike.response != null || fetchLike.data !== undefined) {
-    return {
+    return createNuxtRpcError({
       type: 'fetch',
       message: fetchLike.message || fetchLike.statusMessage || 'Request failed.',
       status,
@@ -579,13 +641,13 @@ export function normalizeNuxtRpcError(error: unknown, zodType: 'request-validati
       data: fetchLike.data ?? fetchLike.response?._data,
       response: fetchLike.response,
       cause: error,
-    }
+    })
   }
-  return {
+  return createNuxtRpcError({
     type: 'unknown',
     message: fetchLike.message || 'Unknown RPC error.',
     cause: error,
-  }
+  })
 }
 
 // Classifies a responseless thrown error into a transient transport tag.
@@ -633,11 +695,18 @@ export function parseNuxtRpcResponse<TResponseSchema extends z.ZodTypeAny>(schem
   }
 }
 
-function isNuxtRpcError(error: unknown): error is NuxtRpcError {
+const NUXT_RPC_ERROR_TYPES = ['fetch', 'request-validation', 'response-validation', 'timeout', 'connection', 'aborted', 'unknown']
+
+function isNuxtRpcErrorData(error: unknown): error is NuxtRpcErrorData {
   return typeof error === 'object'
     && error != null
     && 'type' in error
-    && ['fetch', 'request-validation', 'response-validation', 'timeout', 'connection', 'aborted', 'unknown'].includes((error as { type?: string }).type || '')
+    && NUXT_RPC_ERROR_TYPES.includes((error as { type?: string }).type || '')
+}
+
+/** True for a tagged RPC failure built by {@link createNuxtRpcError}. */
+export function isNuxtRpcError(error: unknown): error is NuxtRpcError {
+  return error instanceof Error && isNuxtRpcErrorData(error)
 }
 
 function formatNuxtRpcValidationIssue(issue: ZodIssue): NuxtRpcValidationIssue {

--- a/packages/nuxt-use-query/src/runtime/rpc/index.ts
+++ b/packages/nuxt-use-query/src/runtime/rpc/index.ts
@@ -10,21 +10,25 @@ export {
   useNuxtRpcQuery,
 } from '../composables/useNuxtRpc'
 export type {
+  NuxtRpcQueryErrorEvent,
   UseNuxtRpcOptions,
   UseNuxtRpcQueryOptions,
 } from '../composables/useNuxtRpc'
 export {
   createNuxtRpcClient,
+  createNuxtRpcError,
   defineNuxtQueryGroup,
   defineNuxtRpcMutation,
   defineNuxtRpcQuery,
   isAuthRpcError,
+  isNuxtRpcError,
   isRetryableRpcError,
   normalizeNuxtRpcError,
   parseNuxtRpcResponse,
   rpcErrorCategory,
   serializeNuxtRpcKey,
   toHumanNuxtRpcError,
+  toSerializableNuxtRpcError,
 } from './core'
 export type {
   NuxtRpcBodylessMutationOperation,
@@ -33,6 +37,7 @@ export type {
   NuxtRpcClientOptions,
   NuxtRpcError,
   NuxtRpcErrorCategory,
+  NuxtRpcErrorData,
   NuxtRpcErrorEvent,
   NuxtRpcGetQueryOperation,
   NuxtRpcKey,

--- a/packages/nuxt-use-query/src/runtime/server/plugins/fetch-telemetry.ts
+++ b/packages/nuxt-use-query/src/runtime/server/plugins/fetch-telemetry.ts
@@ -2,6 +2,7 @@ import type { DuplicateFetchTelemetryEvent, FetchSummaryTelemetryEvent, FetchTel
 import { consola } from 'consola'
 import { defineNitroPlugin, useEvent, useRuntimeConfig } from 'nitropack/runtime'
 import {
+  analyseFetchChain,
   callTelemetryHook,
   createFetchTelemetryState,
   endFetchTelemetry,
@@ -17,6 +18,7 @@ import {
   isFetchWaterfall,
   normalizeFetchTelemetryOptions,
   NUXT_USE_QUERY_TELEMETRY_HOOKS,
+  recordDuplicateFetch,
   recordFetchTelemetry,
   resolveLargePayloadThreshold,
   resolveSlowFetchThreshold,
@@ -118,9 +120,11 @@ export default defineNitroPlugin((nitroApp) => {
       logger.debug(formatFetchSummaryTelemetryEvent(summaryEvent))
     }
 
-    if (isFetchWaterfall(summary, options)) {
+    const chain = analyseFetchChain(summary.timeline)
+    if (isFetchWaterfall(summary, chain, options)) {
       const waterfallEvent: FetchWaterfallTelemetryEvent = {
         ...summaryEvent,
+        ...chain,
         minFetches: options.waterfallMinFetches,
         thresholdMs: options.waterfallThreshold,
       }
@@ -328,17 +332,18 @@ export default defineNitroPlugin((nitroApp) => {
     }
 
     if (target.method === 'GET' && options.duplicateFetchThreshold !== false) {
-      const count = (state.duplicateFetchCounts[target.key] ?? 0) + 1
-      state.duplicateFetchCounts[target.key] = count
-      if (count >= options.duplicateFetchThreshold && !state.reportedDuplicateFetches[target.key]) {
-        state.reportedDuplicateFetches[target.key] = true
+      const group = recordDuplicateFetch(state, target.method, target.path, target.query)
+      const groupKey = `${group.method} ${group.path}`
+      if (group.count >= options.duplicateFetchThreshold && !state.reportedDuplicateFetches[groupKey]) {
+        state.reportedDuplicateFetches[groupKey] = true
         const event: DuplicateFetchTelemetryEvent = {
-          count,
-          method: target.method,
+          count: group.count,
+          method: group.method,
+          path: group.path,
           request: state.request,
           server: true,
           threshold: options.duplicateFetchThreshold,
-          url: target.url,
+          variants: [...group.variants],
         }
         callTelemetryHook(nitroApp.hooks, NUXT_USE_QUERY_TELEMETRY_HOOKS.fetchDuplicate, event)
         if (options.console)
@@ -478,16 +483,19 @@ function resolveInternalFetchTarget(
   request: unknown,
   opts: Record<string, unknown> | undefined,
   state: FetchTelemetryState,
-): { key: string, method: string, url: string } | undefined {
+): { key: string, method: string, path: string, query: string, url: string } | undefined {
   const rawUrl = describeRequest(request)
   const path = resolveInternalPath(rawUrl, state.origin)
   if (!path)
     return undefined
   const method = describeMethod(request, opts)
   const normalizedPath = normalizeInternalPath(withFetchQuery(path, opts?.query ?? opts?.params))
+  const queryIndex = normalizedPath.indexOf('?')
   return {
     key: `${method} ${normalizedPath}`,
     method,
+    path: queryIndex === -1 ? normalizedPath : normalizedPath.slice(0, queryIndex),
+    query: queryIndex === -1 ? '' : normalizedPath.slice(queryIndex),
     url: shortUrl(normalizedPath),
   }
 }

--- a/packages/nuxt-use-query/src/runtime/telemetry.ts
+++ b/packages/nuxt-use-query/src/runtime/telemetry.ts
@@ -59,13 +59,35 @@ export interface FetchTelemetryRuntimeOptions {
   recursiveFetchWarning: boolean
   slowFetchThreshold: SlowFetchThreshold
   timeout: number | false
+  /**
+   * How much more the whole chain must cost than its slowest single link, in
+   * ms. Keeps "one slow upstream plus a cheap follow-up" a slow-fetch story.
+   */
+  waterfallMinChainBeyondSlowestMs: number
+  /** How many serial levels a chain needs before it is reported. */
+  waterfallMinChainDepth: number
+  /** Share of the wall time the chain must explain, from 0 to 1. */
+  waterfallMinCriticalPathShare: number
   waterfallMinFetches: number
   waterfallThreshold: number
 }
 
+/** Repeats of one request path inside a single server render. */
+export interface DuplicateFetchGroup {
+  count: number
+  method: string
+  /** Query-stripped path, e.g. `/api/pro/sites/1/audit/pages`. */
+  path: string
+  /**
+   * The distinct query strings seen for this path. Identical entries mean the
+   * cache missed. Differing entries mean one handler ran once per variant.
+   */
+  variants: string[]
+}
+
 export interface FetchTelemetryState {
   active: number
-  duplicateFetchCounts: Record<string, number>
+  duplicateFetchGroups: Record<string, DuplicateFetchGroup>
   fetches: number
   firstStartedAt: number | undefined
   internalFetchStack: string[]
@@ -135,10 +157,12 @@ export interface NestedFetchTelemetryEvent {
 export interface DuplicateFetchTelemetryEvent {
   count: number
   method: string
+  /** Query-stripped path. Repeats differing only by query still group here. */
+  path: string
   request?: string
   server: true
   threshold: number
-  url: string
+  variants: string[]
 }
 
 export interface RecursiveFetchTelemetryEvent {
@@ -155,7 +179,7 @@ export interface FetchSummaryTelemetryEvent extends FetchTelemetrySummary {
   server: true
 }
 
-export interface FetchWaterfallTelemetryEvent extends FetchSummaryTelemetryEvent {
+export interface FetchWaterfallTelemetryEvent extends FetchSummaryTelemetryEvent, FetchChainAnalysis {
   minFetches: number
   thresholdMs: number
 }
@@ -213,6 +237,13 @@ export const DEFAULT_FETCH_TELEMETRY_OPTIONS: FetchTelemetryRuntimeOptions = {
   recursiveFetchWarning: true,
   slowFetchThreshold: 3_000,
   timeout: 20_000,
+  // Validated against reconstructed production chains: depth 1 means every
+  // fetch overlapped, so the render is slow because an upstream is slow. A
+  // chain has to hold at least two real levels, explain most of the wall
+  // time, and cost a second more than its slowest single link.
+  waterfallMinChainBeyondSlowestMs: 1_000,
+  waterfallMinChainDepth: 2,
+  waterfallMinCriticalPathShare: 0.75,
   waterfallMinFetches: 2,
   waterfallThreshold: 3_000,
 }
@@ -231,14 +262,13 @@ export const NUXT_USE_QUERY_TELEMETRY_HOOKS = {
   queryStart: 'nuxt-use-query:telemetry:query:start',
 } as const
 
-const MOSTLY_SEQUENTIAL_RATIO = 1.25
 const TIMELINE_LIMIT = 12
 const TIMELINE_WIDTH = 32
 
 export function createFetchTelemetryState(): FetchTelemetryState {
   return {
     active: 0,
-    duplicateFetchCounts: {},
+    duplicateFetchGroups: {},
     fetches: 0,
     firstStartedAt: undefined,
     internalFetchStack: [],
@@ -264,9 +294,66 @@ export function normalizeFetchTelemetryOptions(input: Partial<FetchTelemetryRunt
     recursiveFetchWarning: booleanOption(input.recursiveFetchWarning, DEFAULT_FETCH_TELEMETRY_OPTIONS.recursiveFetchWarning),
     slowFetchThreshold: normalizeSlowFetchThreshold(input.slowFetchThreshold, DEFAULT_FETCH_TELEMETRY_OPTIONS.slowFetchThreshold),
     timeout: timeoutOption(input.timeout, DEFAULT_FETCH_TELEMETRY_OPTIONS.timeout),
+    waterfallMinChainBeyondSlowestMs: numberOption(input.waterfallMinChainBeyondSlowestMs, DEFAULT_FETCH_TELEMETRY_OPTIONS.waterfallMinChainBeyondSlowestMs),
+    waterfallMinChainDepth: numberOption(input.waterfallMinChainDepth, DEFAULT_FETCH_TELEMETRY_OPTIONS.waterfallMinChainDepth),
+    waterfallMinCriticalPathShare: numberOption(input.waterfallMinCriticalPathShare, DEFAULT_FETCH_TELEMETRY_OPTIONS.waterfallMinCriticalPathShare),
     waterfallMinFetches: numberOption(input.waterfallMinFetches, DEFAULT_FETCH_TELEMETRY_OPTIONS.waterfallMinFetches),
     waterfallThreshold: numberOption(input.waterfallThreshold, DEFAULT_FETCH_TELEMETRY_OPTIONS.waterfallThreshold),
   }
+}
+
+/**
+ * A configuration fault that makes a telemetry signal unreachable.
+ * Discriminate on `_tag`.
+ */
+export interface FetchTelemetryOptionWarning {
+  _tag: 'slow-fetch-threshold-above-timeout'
+  /** The host the threshold applies to, absent for the default threshold. */
+  host?: string
+  message: string
+  thresholdMs: number
+  timeoutMs: number
+}
+
+/**
+ * Report configuration that can never produce a signal. A slow-fetch
+ * threshold at or above the fetch timeout is the known case: the request is
+ * aborted before it can be reported slow, so the bar collects no rows while
+ * the timeout collects every one of them.
+ */
+export function collectFetchTelemetryOptionWarnings(options: FetchTelemetryRuntimeOptions): FetchTelemetryOptionWarning[] {
+  const timeoutMs = options.timeout
+  if (timeoutMs === false)
+    return []
+
+  const warnings: FetchTelemetryOptionWarning[] = []
+  const threshold = options.slowFetchThreshold
+  const entries: Array<[host: string | undefined, value: number | false]> = typeof threshold === 'object'
+    ? [[undefined, threshold.default], ...Object.entries(threshold.hosts).map(([host, value]) => [host, value] as [string, number | false])]
+    : [[undefined, threshold]]
+
+  for (const [host, value] of entries) {
+    if (value === false || value < timeoutMs)
+      continue
+    warnings.push({
+      _tag: 'slow-fetch-threshold-above-timeout',
+      host,
+      message: formatSlowFetchThresholdWarning(host, value, timeoutMs),
+      thresholdMs: value,
+      timeoutMs,
+    })
+  }
+  return warnings
+}
+
+function formatSlowFetchThresholdWarning(host: string | undefined, thresholdMs: number, timeoutMs: number): string {
+  const target = host ? `for ${host}` : 'default'
+  return [
+    `The ${target} slowFetchThreshold is ${formatDuration(thresholdMs)}.`,
+    `The fetch timeout is ${formatDuration(timeoutMs)}.`,
+    'A fetch aborts before it can be reported slow.',
+    'Set the threshold below the timeout.',
+  ].join(' ')
 }
 
 export function startFetchTelemetry(state: FetchTelemetryState, startedAt: number): void {
@@ -313,10 +400,109 @@ export function summarizeFetchTelemetry(state: FetchTelemetryState): FetchTeleme
   }
 }
 
-export function isFetchWaterfall(summary: FetchTelemetrySummary, options: Pick<FetchTelemetryRuntimeOptions, 'waterfallMinFetches' | 'waterfallThreshold'>): boolean {
+/** A fetch depends on an earlier one when it could not start until that one ended. */
+export interface FetchChainAnalysis {
+  /** Links on the longest dependency chain. 1 means everything overlapped. */
+  chainDepth: number
+  /** Short urls along that chain, in order. This is the thing to go and fix. */
+  criticalPath: string[]
+  /** Summed duration of the fetches on that chain. */
+  criticalPathMs: number
+  /** Longest single fetch anywhere in the request. */
+  slowestMs: number
+  /** First start to last end across every fetch. */
+  wallMs: number
+}
+
+/**
+ * Longest chain of fetches where each link started at or after the previous
+ * one ended.
+ *
+ * Depth is the measure, not parallelism. A render can be 6 levels deep and 7
+ * fetches wide at every level: it is highly parallel and still a waterfall,
+ * because the levels run one after another. A ratio of total time to wall time
+ * cannot see that, so it reports nothing on exactly the renders that hurt.
+ *
+ * No slack is applied. An overlap of even 1ms means two fetches were in flight
+ * together, so neither waited for the other.
+ */
+export function analyseFetchChain(timeline: readonly FetchTelemetryTimelineEntry[]): FetchChainAnalysis {
+  if (timeline.length === 0)
+    return { chainDepth: 0, criticalPath: [], criticalPathMs: 0, slowestMs: 0, wallMs: 0 }
+
+  const sorted = timeline.slice().sort(sortTimelineEntries)
+  const bestMs = sorted.map(entry => entry.durationMs)
+  const bestDepth = sorted.map(() => 1)
+  const previous = sorted.map(() => -1)
+
+  for (let index = 0; index < sorted.length; index++) {
+    for (let earlier = 0; earlier < index; earlier++) {
+      if (sorted[index]!.startedAt < sorted[earlier]!.endedAt)
+        continue
+      const candidate = bestMs[earlier]! + sorted[index]!.durationMs
+      if (candidate > bestMs[index]!) {
+        bestMs[index] = candidate
+        bestDepth[index] = bestDepth[earlier]! + 1
+        previous[index] = earlier
+      }
+    }
+  }
+
+  let end = 0
+  for (let index = 1; index < sorted.length; index++) {
+    if (bestMs[index]! > bestMs[end]!)
+      end = index
+  }
+
+  const criticalPath: string[] = []
+  for (let index = end; index !== -1; index = previous[index]!)
+    criticalPath.unshift(sorted[index]!.url)
+
+  return {
+    chainDepth: bestDepth[end]!,
+    criticalPath,
+    criticalPathMs: bestMs[end]!,
+    slowestMs: Math.max(...sorted.map(entry => entry.durationMs)),
+    wallMs: Math.max(...sorted.map(entry => entry.endedAt)) - Math.min(...sorted.map(entry => entry.startedAt)),
+  }
+}
+
+export function isFetchWaterfall(
+  summary: FetchTelemetrySummary,
+  analysis: FetchChainAnalysis,
+  options: Pick<
+    FetchTelemetryRuntimeOptions,
+    'waterfallMinChainBeyondSlowestMs' | 'waterfallMinChainDepth' | 'waterfallMinCriticalPathShare' | 'waterfallMinFetches' | 'waterfallThreshold'
+  >,
+): boolean {
   if (summary.fetches < options.waterfallMinFetches || summary.wallMs < options.waterfallThreshold)
     return false
-  return summary.maxParallel <= 1 || summary.parallelismRatio <= MOSTLY_SEQUENTIAL_RATIO
+  if (analysis.chainDepth < options.waterfallMinChainDepth)
+    return false
+  if (analysis.criticalPathMs < options.waterfallMinCriticalPathShare * analysis.wallMs)
+    return false
+  return analysis.criticalPathMs - analysis.slowestMs >= options.waterfallMinChainBeyondSlowestMs
+}
+
+/**
+ * Count one GET against its path and return the group it joined.
+ *
+ * The key drops the query string. What a render repeats is a handler, called
+ * once per filtered slice, so an exact repeat of a full url is close to
+ * unreachable: the query cache already coalesces those.
+ */
+export function recordDuplicateFetch(
+  state: FetchTelemetryState,
+  method: string,
+  path: string,
+  query: string,
+): DuplicateFetchGroup {
+  const key = `${method} ${path}`
+  const group = state.duplicateFetchGroups[key] ?? { count: 0, method, path, variants: [] }
+  group.count++
+  group.variants.push(query)
+  state.duplicateFetchGroups[key] = group
+  return group
 }
 
 export function callTelemetryHook(
@@ -384,10 +570,17 @@ export function formatNestedFetchTelemetryEvent(event: NestedFetchTelemetryEvent
 
 export function formatDuplicateFetchTelemetryEvent(event: DuplicateFetchTelemetryEvent): string {
   return formatTelemetryBlock('duplicate server fetch', [
-    ['fetch', `${event.method} ${event.url}`],
+    ['fetch', `${event.method} ${event.path}`],
     ['count', `${event.count} (threshold ${event.threshold})`],
+    ['variants', formatDuplicateVariants(event.variants)],
     event.request ? ['request', event.request] : undefined,
   ])
+}
+
+function formatDuplicateVariants(variants: string[]): string {
+  const shown = variants.slice(0, 4).map(variant => variant || '(none)')
+  const hidden = variants.length - shown.length
+  return hidden > 0 ? `${shown.join(', ')}, ... ${hidden} more` : shown.join(', ')
 }
 
 export function formatRecursiveFetchTelemetryEvent(event: RecursiveFetchTelemetryEvent): string {
@@ -412,7 +605,7 @@ export function formatFetchWaterfallTelemetryEvent(event: FetchWaterfallTelemetr
     ...formatFetchMetricRows(event),
     ['threshold', `${formatDuration(event.thresholdMs)} wall, ${formatCount(event.minFetches, 'fetch', 'fetches')}`],
     ['next step', 'Start independent fetches together with Promise.all, or combine shared data in one server endpoint.'],
-  ], [formatFetchTimeline(event.timeline, event.wallMs)])
+  ], [formatWaterfallChain(event.criticalPath), formatFetchTimeline(event.timeline, event.wallMs)])
 }
 
 export function formatQueryTelemetryStartEvent(event: QueryTelemetryStartEvent): string {
@@ -455,9 +648,16 @@ function formatFetchMetricRows(event: FetchTelemetrySummary): TelemetryRow[] {
 }
 
 function formatWaterfallReason(event: FetchWaterfallTelemetryEvent): string {
-  if (event.maxParallel <= 1)
-    return 'tracked fetches ran one at a time'
-  return `mostly sequential; parallelism only reached ${formatParallelismRatio(event.parallelismRatio)}x`
+  return `${formatCount(event.chainDepth, 'serial level', 'serial levels')} cost ${formatDuration(event.criticalPathMs)} of ${formatDuration(event.wallMs)} wall time`
+}
+
+function formatWaterfallChain(criticalPath: string[]): string | undefined {
+  if (criticalPath.length === 0)
+    return undefined
+  return [
+    'critical path:',
+    ...criticalPath.map((url, index) => `  ${index + 1}. ${url}`),
+  ].join('\n')
 }
 
 function formatFetchTimeline(timeline: FetchTelemetryTimelineEntry[] | undefined, wallMs: number): string | undefined {

--- a/packages/nuxt-use-query/test/enforcement-rules.test.ts
+++ b/packages/nuxt-use-query/test/enforcement-rules.test.ts
@@ -19,13 +19,15 @@ import { parseSourceAst } from '../src/enforcement/parse'
 function makeCtx(file: string, source: string, overrides: Partial<RuleContext['options']> = {}): RuleContext {
   const options = resolveContractQueryEnforcementOptions(overrides)
   const ast = parseSourceAst(file, source)
+  const isQueryFile = matchesAnyDirectory(file, options.queryDirs)
   return {
-    analysis: createSourceAstAnalyzer(options.apiPrefixes, options.contractDirs)(ast),
+    analysis: createSourceAstAnalyzer(options.apiPrefixes, options.contractDirs)(ast, { isQueryFile }),
     file,
     ast,
     options,
-    isQueryFile: matchesAnyDirectory(file, options.queryDirs),
+    isQueryFile,
     isServerApiFile: matchesAnyDirectory(file, options.serverApiDirs),
+    isServerFile: matchesAnyDirectory(file, ['server']),
   }
 }
 

--- a/packages/nuxt-use-query/test/enforcement.test.ts
+++ b/packages/nuxt-use-query/test/enforcement.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { createContractQueryEnforcer, formatContractQueryViolations } from '../src/enforcement'
 import { resolveContractQueryEnforcementOptions } from '../src/enforcement/options'
@@ -204,5 +204,179 @@ describe('contract query enforcer', () => {
     })
 
     expect(violations.map(violation => violation.code)).toContain('missing-contract-import')
+  })
+})
+
+describe('contract query scan directories', () => {
+  async function withTempRoot(build: (rootDir: string) => Promise<void>): Promise<string> {
+    const rootDir = await mkdtemp(join(tmpdir(), 'nuxt-use-query-scan-'))
+    await build(rootDir)
+    return rootDir
+  }
+
+  async function writeFileAt(rootDir: string, file: string, source: string): Promise<void> {
+    const path = join(rootDir, file)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, source)
+  }
+
+  it('expands every wildcard segment in a scan dir pattern', async () => {
+    const rootDir = await withTempRoot(async (root) => {
+      await writeFileAt(root, 'layers/pro/site/app/pages/index.vue', '<script setup>await $fetch("/api/pro/sites")</script>')
+      await writeFileAt(root, 'layers/site/marketing/app/pages/home.vue', '<script setup>await $fetch("/api/home")</script>')
+    })
+
+    const enforcer = createContractQueryEnforcer()
+    const violations = await enforcer.scan(rootDir, {
+      scanDirs: ['layers/*/*/app'],
+    }).finally(() => rm(rootDir, { force: true, recursive: true }))
+
+    expect(violations.map(violation => violation.file).sort()).toEqual([
+      'layers/pro/site/app/pages/index.vue',
+      'layers/site/marketing/app/pages/home.vue',
+    ])
+  })
+
+  it('expands a globstar scan dir across any nesting depth', async () => {
+    const rootDir = await withTempRoot(async (root) => {
+      await writeFileAt(root, 'layers/core/app/x.ts', 'await $fetch("/api/a")')
+      await writeFileAt(root, 'layers/pro/site/app/y.ts', 'await $fetch("/api/b")')
+      await writeFileAt(root, 'layers/pro/node_modules/dep/app/z.ts', 'await $fetch("/api/c")')
+    })
+
+    const enforcer = createContractQueryEnforcer()
+    const violations = await enforcer.scan(rootDir, {
+      scanDirs: ['layers/**/app'],
+    }).finally(() => rm(rootDir, { force: true, recursive: true }))
+
+    expect(violations.map(violation => violation.file).sort()).toEqual([
+      'layers/core/app/x.ts',
+      'layers/pro/site/app/y.ts',
+    ])
+  })
+
+  it('matches an ignore pattern anywhere in the path, like queryDirs', async () => {
+    const rootDir = await withTempRoot(async (root) => {
+      await writeFileAt(root, 'layers/pro/site/app/queries/sites.ts', 'export const sites = { path: "/api/sites" }')
+      await writeFileAt(root, 'layers/core/app/composables/nav.ts', 'export const docs = "/api/docs"')
+      await writeFileAt(root, 'layers/core/app/pages/index.vue', '<script setup>await $fetch("/api/kept")</script>')
+    })
+
+    const enforcer = createContractQueryEnforcer()
+    const violations = await enforcer.scan(rootDir, {
+      ignore: ['app/queries', 'app/composables/nav.ts'],
+      scanDirs: ['layers/*/app', 'layers/*/*/app'],
+    }).finally(() => rm(rootDir, { force: true, recursive: true }))
+
+    expect(violations.map(violation => violation.file)).toEqual([
+      'layers/core/app/pages/index.vue',
+    ])
+  })
+})
+
+describe('rpc operation factories', () => {
+  const contractImport = 'import { siteSchema } from "@/shared/contracts/site";'
+
+  it('resolves an rpc factory imported under an alias', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        {
+          file: 'layers/saas/app/queries/rpc.ts',
+          source: `import { defineNuxtRpcQuery as defineProQuery } from "@harlan-zw/nuxt-use-query/rpc"; ${contractImport} export const sites = defineProQuery({ key: "sites", path: "/api/sites", response: siteSchema })`,
+        },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations).toEqual([])
+  })
+
+  it('checks an aliased operation for its response schema', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        {
+          file: 'app/queries/rpc.ts',
+          source: `import { defineNuxtRpcQuery as defineProQuery } from "@harlan-zw/nuxt-use-query/rpc"; ${contractImport} export const sites = defineProQuery({ key: "sites", path: "/api/sites" })`,
+        },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations.map(violation => violation.code)).toEqual(['operation-response-schema-missing'])
+  })
+
+  it('resolves a local alias of an auto-imported rpc factory', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        {
+          file: 'app/queries/local-alias.ts',
+          source: `${contractImport} const defineProQuery = defineNuxtRpcQuery; export const sites = defineProQuery({ key: "sites", path: "/api/sites", response: siteSchema })`,
+        },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations).toEqual([])
+  })
+
+  it('accepts a wrapper factory in a query file when it takes an operation object', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        {
+          file: 'layers/pro/app/queries/sites.ts',
+          source: `${contractImport} export const sites = defineProQuery({ key: "sites", path: "/api/sites", response: siteSchema })`,
+        },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations).toEqual([])
+  })
+
+  it('does not read a navigation target as an rpc operation', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        {
+          file: 'app/queries/nav.ts',
+          source: 'export function goToSites() { return navigateTo({ path: "/api/sites" }) }',
+        },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations.map(violation => violation.code)).toEqual(['query-file-without-operation'])
+  })
+})
+
+describe('server directory exemption', () => {
+  it('does not flag api path literals in server code outside server/api', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        { file: 'server/middleware/auth.ts', source: 'export default defineEventHandler((event) => { if (event.path.startsWith("/api/pro")) return }) ' },
+        { file: 'server/utils/proxy.ts', source: 'export const upstream = () => $fetch("/api/pro/sites")' },
+        { file: 'layers/pro/server/plugins/warm.ts', source: 'export default () => $fetch("/api/pro/sites")' },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations).toEqual([])
+  })
+
+  it('still flags api path literals in app code', async () => {
+    const enforcer = createContractQueryEnforcer({
+      readSourceFiles: async () => [
+        { file: 'app/components/Sites.vue', source: '<script setup>await $fetch("/api/pro/sites")</script>' },
+      ],
+    })
+
+    const violations = await enforcer.scan('/app')
+
+    expect(violations.map(violation => violation.code)).toEqual(['api-literal-outside-query'])
   })
 })

--- a/packages/nuxt-use-query/test/fixture/app.vue
+++ b/packages/nuxt-use-query/test/fixture/app.vue
@@ -71,6 +71,15 @@ const mutationOperation = defineNuxtRpcMutation({
 })
 const rpcKey = serializeNuxtRpcKey(['fixture', 'rpc-query'])
 
+// A query that fails during SSR. Proves the tagged error survives the render
+// and that the payload still serializes with an `Error` in the error ref.
+const failingQuery = defineNuxtRpcQuery({
+  key: ['fixture', 'fail'],
+  path: '/api/fail',
+  response: echoSchema,
+})
+const { error: rpcQueryError } = await useNuxtRpcQuery(failingQuery)
+
 // Resolve the cache that's been attached to the Nuxt app. `useQueryCache()`
 // is the seam this whole module is built on. Stamp two keys directly to prove
 // the returned object is a real, mutable cache (the SSR `pending → success`
@@ -116,6 +125,9 @@ const probe = {
   rpcDefault,
   rpcKey,
   rpcQuery: rpcQuery.value,
+  rpcQueryError: rpcQueryError.value
+    ? { isError: rpcQueryError.value instanceof Error, name: rpcQueryError.value.name, status: rpcQueryError.value.type === 'fetch' ? rpcQueryError.value.status : undefined, type: rpcQueryError.value.type }
+    : null,
 }
 </script>
 

--- a/packages/nuxt-use-query/test/fixture/nuxt.config.ts
+++ b/packages/nuxt-use-query/test/fixture/nuxt.config.ts
@@ -12,7 +12,9 @@ export default defineNuxtConfig({
   nuxtUseQuery: {
     telemetry: {
       console: false,
-      slowFetchThreshold: 60_000,
+      // The fixture drives timeouts, not slow fetches. `false` mutes slow
+      // detection; a threshold above the timeout would only be dead config.
+      slowFetchThreshold: false,
       timeout: 100,
       waterfallThreshold: 60_000,
     },

--- a/packages/nuxt-use-query/test/fixture/server/api/fail.get.ts
+++ b/packages/nuxt-use-query/test/fixture/server/api/fail.get.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  throw createError({ statusCode: 503, statusMessage: 'Upstream down' })
+})

--- a/packages/nuxt-use-query/test/runtime.test.ts
+++ b/packages/nuxt-use-query/test/runtime.test.ts
@@ -43,10 +43,11 @@ interface Probe {
   rpcPostQuery: { limit: number, term: string } | null
   rpcKey: string
   rpcQuery: { value: string, call: number } | null
+  rpcQueryError: { isError: boolean, name: string, status?: number, type: string } | null
 }
 
 interface TelemetryStore {
-  duplicates: Array<{ count?: number, threshold?: number, url?: string }>
+  duplicates: Array<{ count?: number, path?: string, threshold?: number, variants?: string[] }>
   fetches: Array<{ request?: string, url?: string }>
   nested: Array<{ depth?: number, stack?: string[], threshold?: number, url?: string }>
   recursive: Array<{ depth?: number, stack?: string[], url?: string }>
@@ -102,6 +103,16 @@ describe('nuxt-use-query · e2e', () => {
     expect(probe.cachedManualWrite).toEqual({ ok: true })
   })
 
+  it('keeps a failing SSR query tagged and still serializes the payload', async () => {
+    const probe = await readProbe()
+    expect(probe.rpcQueryError).toEqual({
+      isError: true,
+      name: 'NuxtRpcError',
+      status: 503,
+      type: 'fetch',
+    })
+  })
+
   it('registers fetch telemetry through the module option and Nitro plugin', async () => {
     await $fetch('/api/telemetry', { query: { reset: '1' } })
 
@@ -141,7 +152,7 @@ describe('nuxt-use-query · e2e', () => {
 
     const telemetry = await $fetch<TelemetryStore>('/api/telemetry')
     expect(telemetry.duplicates.some(event =>
-      event.url === '/api/echo'
+      event.path === '/api/echo'
       && event.count === 2
       && event.threshold === 2,
     )).toBe(true)

--- a/packages/nuxt-use-query/test/telemetry.test.ts
+++ b/packages/nuxt-use-query/test/telemetry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  analyseFetchChain,
+  collectFetchTelemetryOptionWarnings,
   createFetchTelemetryState,
   endFetchTelemetry,
   formatDuplicateFetchTelemetryEvent,
@@ -16,6 +18,7 @@ import {
   normalizeFetchTelemetryOptions,
   normalizeLargePayloadThreshold,
   normalizeSlowFetchThreshold,
+  recordDuplicateFetch,
   recordFetchTelemetry,
   resolveLargePayloadThreshold,
   resolveSlowFetchThreshold,
@@ -60,7 +63,10 @@ describe('fetch telemetry', () => {
       { durationMs: 1_500, offsetMs: 0, url: '/api/a' },
       { durationMs: 1_700, offsetMs: 1_500, url: '/api/b' },
     ])
-    expect(isFetchWaterfall(summary, {
+    expect(isFetchWaterfall(summary, analyseFetchChain(summary.timeline), {
+      waterfallMinChainBeyondSlowestMs: 1_000,
+      waterfallMinChainDepth: 2,
+      waterfallMinCriticalPathShare: 0.75,
       waterfallMinFetches: 2,
       waterfallThreshold: 3_000,
     })).toBe(true)
@@ -77,7 +83,10 @@ describe('fetch telemetry', () => {
     const summary = summarizeFetchTelemetry(state)!
     expect(summary.maxParallel).toBe(2)
     expect(summary.upstreamMs).toBeGreaterThan(summary.wallMs)
-    expect(isFetchWaterfall(summary, {
+    expect(isFetchWaterfall(summary, analyseFetchChain(summary.timeline), {
+      waterfallMinChainBeyondSlowestMs: 1_000,
+      waterfallMinChainDepth: 2,
+      waterfallMinCriticalPathShare: 0.75,
       waterfallMinFetches: 2,
       waterfallThreshold: 1_000,
     })).toBe(false)
@@ -255,14 +264,16 @@ describe('fetch telemetry', () => {
     expect(formatDuplicateFetchTelemetryEvent({
       count: 2,
       method: 'GET',
+      path: '/api/sites',
       request: 'GET /dashboard',
       server: true,
       threshold: 2,
-      url: '/api/sites',
+      variants: ['?page=1', '?page=2'],
     })).toBe(`duplicate server fetch
-  fetch  : GET /api/sites
-  count  : 2 (threshold 2)
-  request: GET /dashboard`)
+  fetch   : GET /api/sites
+  count   : 2 (threshold 2)
+  variants: ?page=1, ?page=2
+  request : GET /dashboard`)
 
     expect(formatNestedFetchTelemetryEvent({
       depth: 3,
@@ -300,6 +311,9 @@ describe('fetch telemetry', () => {
 
   it('formats waterfall events with a readable timeline', () => {
     const output = formatFetchWaterfallTelemetryEvent({
+      chainDepth: 2,
+      criticalPath: ['/api/a', '/api/b'],
+      criticalPathMs: 310,
       fetches: 2,
       maxParallel: 1,
       minFetches: 2,
@@ -334,7 +348,8 @@ describe('fetch telemetry', () => {
 
     expect(output).toContain('likely server fetch waterfall')
     expect(output).toContain('request      : GET /dashboard')
-    expect(output).toContain('reason       : tracked fetches ran one at a time')
+    expect(output).toContain('reason       : 2 serial levels cost 310ms of 310ms wall time')
+    expect(output).toContain('critical path:')
     expect(output).toContain('upstream time: 310ms (1.00x wall)')
     expect(output).toContain('timeline (0ms -> 310ms):')
     expect(output).toContain('[###################-------------] GET /api/a')
@@ -360,5 +375,151 @@ describe('fetch telemetry', () => {
       startedAt: 1_000,
       status: 'success',
     })).toBe('query hello -> /api/hello succeeded in 24ms on client')
+  })
+})
+
+describe('fetch telemetry option warnings', () => {
+  it('reports a slow-fetch threshold that the timeout can never reach', () => {
+    const warnings = collectFetchTelemetryOptionWarnings(normalizeFetchTelemetryOptions({
+      slowFetchThreshold: 30_000,
+      timeout: 20_000,
+    }))
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toMatchObject({
+      _tag: 'slow-fetch-threshold-above-timeout',
+      thresholdMs: 30_000,
+      timeoutMs: 20_000,
+    })
+    expect(warnings[0]?.message).toContain('below the timeout')
+  })
+
+  it('reports each host threshold that the timeout can never reach', () => {
+    const warnings = collectFetchTelemetryOptionWarnings(normalizeFetchTelemetryOptions({
+      slowFetchThreshold: {
+        default: 3_000,
+        hosts: { 'gscdump.com': 30_000, 'ok.com': 5_000 },
+      },
+      timeout: 20_000,
+    }))
+
+    expect(warnings.map(warning => warning.host)).toEqual(['gscdump.com'])
+  })
+
+  it('stays silent when every threshold sits below the timeout', () => {
+    const warnings = collectFetchTelemetryOptionWarnings(normalizeFetchTelemetryOptions({
+      slowFetchThreshold: { default: 3_000, hosts: { 'gscdump.com': 15_000 } },
+      timeout: 20_000,
+    }))
+
+    expect(warnings).toEqual([])
+  })
+
+  it('stays silent when the timeout is disabled', () => {
+    const warnings = collectFetchTelemetryOptionWarnings(normalizeFetchTelemetryOptions({
+      slowFetchThreshold: 30_000,
+      timeout: false,
+    }))
+
+    expect(warnings).toEqual([])
+  })
+})
+
+describe('fetch chain analysis', () => {
+  function timelineOf(entries: Array<[url: string, startedAt: number, endedAt: number]>) {
+    const state = createFetchTelemetryState()
+    for (const [, startedAt] of entries)
+      startFetchTelemetry(state, startedAt)
+    for (const [url, startedAt, endedAt] of entries) {
+      endFetchTelemetry(state, startedAt, endedAt)
+      recordFetchTelemetry(state, {
+        durationMs: endedAt - startedAt,
+        endedAt,
+        method: 'GET',
+        ok: true,
+        startedAt,
+        url,
+      })
+    }
+    return summarizeFetchTelemetry(state)!
+  }
+
+  const waterfallOptions = {
+    waterfallMinChainBeyondSlowestMs: 1_000,
+    waterfallMinChainDepth: 2,
+    waterfallMinCriticalPathShare: 0.75,
+    waterfallMinFetches: 2,
+    waterfallThreshold: 3_000,
+  }
+
+  it('measures the longest dependency chain, not the parallelism ratio', () => {
+    const summary = timelineOf([
+      ['/api/a1', 0, 2_000],
+      ['/api/a2', 0, 1_900],
+      ['/api/a3', 0, 1_800],
+      ['/api/b1', 2_000, 4_000],
+      ['/api/b2', 2_000, 3_900],
+      ['/api/c1', 4_000, 6_000],
+    ])
+
+    const analysis = analyseFetchChain(summary.timeline)
+
+    expect(analysis).toMatchObject({
+      chainDepth: 3,
+      criticalPathMs: 6_000,
+      slowestMs: 2_000,
+      wallMs: 6_000,
+    })
+    expect(analysis.criticalPath).toEqual(['/api/a1', '/api/b1', '/api/c1'])
+    expect(isFetchWaterfall(summary, analysis, waterfallOptions)).toBe(true)
+  })
+
+  it('leaves one slow upstream with parallel siblings alone', () => {
+    const summary = timelineOf([
+      ['/api/slow', 0, 10_000],
+      ['/api/fast', 0, 500],
+    ])
+
+    const analysis = analyseFetchChain(summary.timeline)
+
+    expect(analysis.chainDepth).toBe(1)
+    expect(isFetchWaterfall(summary, analysis, waterfallOptions)).toBe(false)
+  })
+
+  it('leaves a short chain of cheap follow-ups alone', () => {
+    const summary = timelineOf([
+      ['/api/slow', 0, 3_500],
+      ['/api/cheap', 3_500, 3_600],
+    ])
+
+    const analysis = analyseFetchChain(summary.timeline)
+
+    expect(analysis.chainDepth).toBe(2)
+    expect(isFetchWaterfall(summary, analysis, waterfallOptions)).toBe(false)
+  })
+})
+
+describe('duplicate fetch grouping', () => {
+  it('groups repeats of one path across differing query strings', () => {
+    const state = createFetchTelemetryState()
+
+    recordDuplicateFetch(state, 'GET', '/api/pro/audit/pages', '?slice=a')
+    const group = recordDuplicateFetch(state, 'GET', '/api/pro/audit/pages', '?slice=b')
+
+    expect(group).toMatchObject({
+      count: 2,
+      method: 'GET',
+      path: '/api/pro/audit/pages',
+    })
+    expect(group.variants).toEqual(['?slice=a', '?slice=b'])
+  })
+
+  it('keeps different paths apart', () => {
+    const state = createFetchTelemetryState()
+
+    recordDuplicateFetch(state, 'GET', '/api/a', '')
+    const group = recordDuplicateFetch(state, 'GET', '/api/b', '')
+
+    expect(group.count).toBe(1)
   })
 })

--- a/packages/nuxt-use-query/test/use-nuxt-query.test.ts
+++ b/packages/nuxt-use-query/test/use-nuxt-query.test.ts
@@ -389,6 +389,52 @@ describe('useNuxtQuery refetchInterval', () => {
   })
 })
 
+describe('shouldRefetchOnMount', () => {
+  it('refetches stale resolved data in the browser', async () => {
+    const { shouldRefetchOnMount } = await import('../src/runtime/query-lifecycle')
+    cache.lastFetched.set('q', Date.now() - 10_000)
+
+    expect(shouldRefetchOnMount({
+      cache,
+      data: { n: 1 },
+      isServerRender: false,
+      key: 'q',
+      option: true,
+      staleTime: 1,
+      status: 'success',
+    })).toBe(true)
+  })
+
+  it('never refetches during server rendering', async () => {
+    const { shouldRefetchOnMount } = await import('../src/runtime/query-lifecycle')
+    cache.lastFetched.set('q', Date.now() - 10_000)
+
+    expect(shouldRefetchOnMount({
+      cache,
+      data: { n: 1 },
+      isServerRender: true,
+      key: 'q',
+      option: true,
+      staleTime: 1,
+      status: 'success',
+    })).toBe(false)
+  })
+
+  it('never refetches during server rendering with refetchOnMount always', async () => {
+    const { shouldRefetchOnMount } = await import('../src/runtime/query-lifecycle')
+
+    expect(shouldRefetchOnMount({
+      cache,
+      data: { n: 1 },
+      isServerRender: true,
+      key: 'q',
+      option: 'always',
+      staleTime: 0,
+      status: 'success',
+    })).toBe(false)
+  })
+})
+
 describe('useNuxtQuery refetchOnMount', () => {
   it('refreshes stale resolved data on mount when refetchOnMount is true', () => {
     fetchState.data.value = { n: 1 }

--- a/packages/nuxt-use-query/test/use-nuxt-rpc.test.ts
+++ b/packages/nuxt-use-query/test/use-nuxt-rpc.test.ts
@@ -735,3 +735,97 @@ describe('rpc error helpers', () => {
       .toBe('We could not find that resource.')
   })
 })
+
+describe('nuxtRpcError shape', () => {
+  it('is a real Error that keeps its tag', () => {
+    const error = normalizeNuxtRpcError(Object.assign(new Error('boom'), {
+      status: 500,
+      response: { status: 500, statusText: 'Server Error' },
+    }))
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.name).toBe('NuxtRpcError')
+    expect(error.type).toBe('fetch')
+    expect(error.message).toBe('boom')
+    expect(typeof error.stack).toBe('string')
+  })
+
+  it('rebuilds a tagged plain object into an Error', () => {
+    const error = normalizeNuxtRpcError({
+      type: 'timeout',
+      message: 'took too long',
+      cause: new Error('TimeoutError'),
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.type).toBe('timeout')
+    expect(error.message).toBe('took too long')
+  })
+
+  it('makes a validation failure an Error with its issues', () => {
+    const schema = z.object({ id: z.string() })
+    let error: any
+    try {
+      schema.parse({ id: 1 })
+    }
+    catch (thrown) {
+      error = normalizeNuxtRpcError(thrown, 'response-validation')
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.type).toBe('response-validation')
+    expect(error.issues).toHaveLength(1)
+  })
+})
+
+describe('useNuxtRpcQuery onError', () => {
+  const operation = () => defineNuxtRpcQuery({
+    key: 'site:1',
+    path: '/api/sites/1',
+    response: z.object({ id: z.string() }),
+  })
+
+  async function tick() {
+    const { nextTick } = await import('vue')
+    await nextTick()
+  }
+
+  it('reports a query failure through onError', async () => {
+    const onError = vi.fn()
+    useNuxtRpcQuery(operation(), { onError })
+
+    mocks.queryError!.value = Object.assign(new Error('[GET] "/api/sites/1": 404'), {
+      status: 404,
+      response: { status: 404, statusText: 'Not Found' },
+    })
+    await tick()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0]![0]).toMatchObject({
+      error: { status: 404, type: 'fetch' },
+      operation: { kind: 'query', method: 'GET', path: '/api/sites/1' },
+    })
+  })
+
+  it('reports one failure once, however often the error is read', async () => {
+    const onError = vi.fn()
+    const result = useNuxtRpcQuery(operation(), { onError }) as any
+
+    mocks.queryError!.value = Object.assign(new Error('[GET] "/api/sites/1": 500'), {
+      status: 500,
+      response: { status: 500, statusText: 'Server Error' },
+    })
+    await tick()
+    void result.error.value
+    void result.error.value
+    await tick()
+
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps onError out of the underlying query options', async () => {
+    const result = useNuxtRpcQuery(operation(), { onError: vi.fn() }) as any
+
+    expect(result.opts.onError).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Eight findings against `packages/nuxt-use-query`, most important first. Each one is a real defect with a consumer workaround in the wild.

## What was wrong

**1. The scanner read almost nothing on the largest consumer.** `expandScanDirs` expanded one `*` per pattern, so nuxtseo.com's `layers/*/app` resolved to `layers/pro/app`, which does not exist. The real path is `layers/pro/<site>/app`. All 13 query directories under `layers/pro/**` and `layers/site/**` were never read. Every segment now takes `*` or `**`, and expansion skips ignored directories so `**` never walks `node_modules`.

**2. `ignore` and `queryDirs` used different glob semantics.** `queryDirs` matched anywhere in the path; `ignore` was anchored at the root. nuxtseo's `ignore: ['app/queries', 'app/composables/nav.ts']` therefore matched zero files. Both now compile through one matcher: `*` is one segment, `**` is any depth, and a pattern matches anywhere in the path.

**3. The AST analyzer knew three literal factory names.** `defineNuxtRpcQuery as defineProQuery` read as "no operation". That gap is what forced the dead ignore list and `severity: 'warn'`. Aliases now resolve through imports, re-exports, and local `const` bindings. Inside a query directory, a call to an unresolvable wrapper factory also counts when its first argument is an operation object (`path` plus `key` or `method`), which covers a layer's own scoped factory. A navigation target with a bare `path` is still not an operation.

**4. `api-literal-outside-query` fired on server middleware and utils.** It exempted `serverApiDirs` only. gscdump narrowed `apiPrefixes` and nuxtseo narrowed `scanDirs` to escape it. All `server/` is exempt now; `server-route-missing-contract` still polices the routes.

**5. `refetchOnMount` was not client gated** although focus and reconnect were. With the default `staleTime: 0` a sibling mount refetched mid-render during SSR. gscdump pins `refetchOnMount: import.meta.client` in four composables and carries a regression test. The decision moved into a pure `shouldRefetchOnMount` that takes the runtime as an argument.

**6. `useNuxtRpcQuery` had no error hook.** Only the imperative client fired `onError`, so nuxtseo hand rolled a `watch(query.error)` with WeakSet dedupe. The query options take `onError` now, fire once per failure with `{ operation, error, durationMs }`, in the browser only.

`NuxtRpcError` is now a real `Error` named `NuxtRpcError` that keeps its `type` tag, so `captureException` keeps the message and the stack. nuxtseo can drop its Sentry rewrap.

**Found while testing this:** an error in `payload._errors` is serialized with devalue, and neither the old plain object (its `cause` held a `FetchError`) nor a new `Error` is a POJO. The module now ships a payload reducer and reviver, and a new SSR e2e test renders a page whose RPC query fails. Without the pair that page returns 500 with `Cannot stringify arbitrary non-POJOs`.

**7. A `slowFetchThreshold` above `timeout` can never fire.** nuxtseo documented it: a 30s bar under a 20s timeout produced 9.7k aborts and roughly zero warnings. The module warns at build time for the default and for each host. To disable detection, set the threshold to `false`.

**8. The waterfall and duplicate detectors never fired** (0 rows against 2,709 `fetch_slow`). The waterfall rule needed `maxParallel <= 1 || ratio <= 1.25`, which a deep but wide SSR chain slips straight under. It measures chain depth now: longest run of fetches where each started at or after the previous one ended, with thresholds for depth, share of wall time, and cost beyond the slowest single link. The warning prints the critical path. Duplicate detection keys on the request path and collects query strings as variants, because the query cache already coalesces identical urls. Ported from nuxtseo's 216-line reimplementation over `fetch:summary`.

README: the enforcement block gained `severity`, `ignore`, and `scanDirs`, plus sections on pattern syntax and what the scanner accepts. The auto-import list gained `useNuxtAsyncQuery`, `invalidateNuxtRpc`, and `removeNuxtQueries`.

## Consumer impact

Fixing the scanner makes enforcement fire on code that was silently unscanned. This is real, and it is the point of the change.

**nuxtseo.com** (loudest). The 13 query directories under `layers/pro/**` and `layers/site/**` are scanned for the first time. Expect new violations on the first build.
- Keep `severity: 'warn'` for one build, read the list, then flip to `'error'`.
- Change `layers/*/...` patterns to `layers/**/...`, or drop them: the defaults now cover a layer at any depth.
- Drop `ignore: ['app/queries']`. Scoped factories such as `defineProQuery` and `defineBillingMutation` are recognised now.
- Keep `ignore: ['app/composables/nav.ts']`. Those are documentation paths in app code, which the rule still owns.
- Restore full `server` scanning in `scanDirs`. The narrowing existed only to dodge finding 4.
- Drop the `watch(query.error)` block in `layers/core/app/utils/rpc.ts` for `onError`.
- Drop the Sentry rewrap in `sentry-rpc.client.ts`; capture the error directly.
- Replace `layers/core/server/utils/fetch-telemetry.ts` with the package hooks.

**gscdump.com**
- Drop `refetchOnMount: import.meta.client` from the four composables. Keep the regression test.
- Widen `apiPrefixes` back to `['/api']`. Server code no longer trips the rule.
- Check that every `slowFetchThreshold` sits below `timeout`, or the build warns.
- If a `fetch:duplicate` consumer reads `event.url`, read `event.path`.

**request-indexing, zhead.dev**. No action unless they read the changed telemetry event fields or run contract enforcement. If they run enforcement on a layered layout, expect the same first-build widening as nuxtseo.

## BREAKING

Per repo, exact action:

1. **All consumers reading fetch telemetry hooks.** `DuplicateFetchTelemetryEvent.url` is replaced by `path` plus `variants`. Rename the field in any hook handler. gscdump and nuxtseo both consume this hook.
2. **All consumers calling `isFetchWaterfall` directly.** It takes `(summary, analysis, options)` now. Call `analyseFetchChain(summary.timeline)` first. Only nuxtseo touches this, through its own reimplementation, which it should now delete.
3. **All consumers reading `FetchTelemetryState`.** `duplicateFetchCounts` is replaced by `duplicateFetchGroups`. No consumer is known to read it.
4. **All consumers handling `NuxtRpcError`.** It is an `Error` now. `error.cause` and `error.response` are dropped when the failure crosses the SSR payload; the tag, message, status, data, and issues survive. nuxtseo must delete the Sentry rewrap that assumed a plain object.
5. **Consumers extending enforcement rules.** `createSourceAstAnalyzer` returns `(ast, context)` and `RuleContext` gains `isServerFile`. No consumer is known to do this.
6. **All consumers with contract enforcement enabled.** More files are scanned, `ignore` patterns now match anywhere in the path, and server code is exempt from `api-literal-outside-query`. Review the first build's violation list before flipping severity to `'error'`.
7. **All consumers using `refetchOnMount`.** It no longer runs during server rendering. A site that depended on the SSR refetch loses one duplicate upstream call per sibling mount, which is the fix.

## Verification

- `pnpm --filter @harlan-zw/nuxt-use-query test`: 25 files, 289 tests passed, no type errors (was 260).
- `pnpm --filter @harlan-zw/nuxt-use-query lint`: clean.
- Every fix landed as a failing test first. The SSR payload defect in finding 6 was caught by its own e2e test before the reducer existed.
- No version bump, no publish.
