### PR TITLE
feat(nuxt-dx)!: rebuild the size budget report around one verdict line

### DIFF
--- a/packages/nuxt-dx/README.md
+++ b/packages/nuxt-dx/README.md
@@ -185,21 +185,36 @@ nuxt-dx compare base/.nuxt/dx/size-budget.json .nuxt/dx/size-budget.json
 ```
 
 ```md
-### Bundle size budget
+### 📦 Runtime size budget
 
-- **Client runtime entries** 47.2 kB to 65.7 kB, **+18.5 kB**
-  - Nuxt plugins: 34.7 kB to 61.8 kB, +27.1 kB
-  - Nuxt middleware: 12.5 kB to 3.9 kB, -8.6 kB
-- **Server runtime entries** 6.4 kB to 6.4 kB, **+0 B**
-  - Nitro plugins: 6.4 kB to 6.4 kB, +0 B
+⚠️ **1 target past the 10 kB threshold** · net +27.2 kB · 🆕 1 new target
 
-**1 target grew past the 10 kB threshold:** `app/plugins/analytics.client.ts` +35.7 kB.
+| Target | Scope | Size | Δ |
+| --- | --- | --- | --- |
+| `app/plugins/analytics.client.ts` | Nuxt plugin | 7.6 kB → 43.3 kB | 🔴 +35.6 kB (+467.9%) |
+| `runtime/consent.client.ts`<br><sub>fixture-consent</sub> | Nuxt plugin | 0 B → 170 B | 🆕 new |
+| `app/middleware/legacy.global.ts` | Nuxt middleware | 12.5 kB → 3.9 kB | 🟢 -8.6 kB (-68.8%) |
 
-| Target | Module | Scope | Base | Head | Change |
-| --- | --- | --- | --- | --- | --- |
-| `app/plugins/analytics.client.ts` |  | Nuxt plugin | 7.6 kB | 43.3 kB | +35.7 kB |
-| `runtime/consent.client.ts` | `fixture-consent` | Nuxt plugin | 0 B | 170 B | +170 B (new) |
-| `app/middleware/legacy.global.ts` |  | Nuxt middleware | 12.5 kB | 3.9 kB | -8.6 kB |
+<details><summary>Bundle totals</summary>
+
+| Bundle | Size | Δ |
+| --- | --- | --- |
+| **Client** | 23.1 kB → 50.4 kB | +27.2 kB |
+| <sub>Nuxt plugins</sub> | <sub>10.6 kB → 46.5 kB</sub> | <sub>+35.8 kB</sub> |
+| <sub>Nuxt middleware</sub> | <sub>12.5 kB → 3.9 kB</sub> | <sub>-8.6 kB</sub> |
+| **Server** | 6.4 kB → 6.4 kB | +0 B |
+| <sub>Nitro plugins</sub> | <sub>6.4 kB → 6.4 kB</sub> | <sub>+0 B</sub> |
+</details>
+
+<details><summary>2 unchanged targets</summary>
+
+| Target | Scope | Size | Δ |
+| --- | --- | --- | --- |
+| `app/plugins/theme.client.ts` | Nuxt plugin | 3 kB → 3 kB | — |
+| `server/plugins/audit.ts` | Nitro plugin | 6.4 kB → 6.4 kB | — |
+</details>
+
+<sub>Each target is charged its own bundled bytes plus every module it alone pulls in. The threshold applies to each target on its own, not to the total.</sub>
 ```
 
 Markdown goes to stdout for job summaries. The local verdict goes to stderr. Client and server totals combine their disjoint runtime entries.

--- a/packages/nuxt-dx/src/size-budget/diff-report.ts
+++ b/packages/nuxt-dx/src/size-budget/diff-report.ts
@@ -3,9 +3,14 @@ import { colors } from 'consola/utils'
 import { SCOPE } from './scope'
 import { formatBytes, formatDelta } from './size'
 
-const SUFFIX: Partial<Record<EntryChange['kind'], string>> = {
-  added: ' (new)',
-  removed: ' (gone)',
+/** Heading on every report, so a reader finds the same block in a long summary. */
+const HEADING = '### 📦 Runtime size budget'
+
+const MARKER: Partial<Record<EntryChange['kind'], string>> = {
+  added: '🆕',
+  removed: '⚪',
+  grown: '🔴',
+  shrunk: '🟢',
 }
 
 /** A label is a file path or a package name; either can hold the character that ends a cell. */
@@ -13,35 +18,86 @@ function cell(text: string): string {
   return text.replaceAll('|', '\\|')
 }
 
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`
+}
+
+/** Growth reads differently at 200 B and at 200 kB, so the share of the base goes beside it. */
+function percent(deltaBytes: number, baseBytes: number): string {
+  if (baseBytes <= 0)
+    return ''
+  const share = (deltaBytes / baseBytes) * 100
+  return ` (${share > 0 ? '+' : '-'}${Math.abs(share).toFixed(1)}%)`
+}
+
+function deltaCell(change: EntryChange): string {
+  if (change.kind === 'added')
+    return '🆕 new'
+  if (change.kind === 'removed')
+    return '⚪ gone'
+  if (change.kind === 'unchanged')
+    return '—'
+  return `${MARKER[change.kind]} ${formatDelta(change.deltaBytes)}${percent(change.deltaBytes, change.baseBytes)}`
+}
+
+/** The owner rides under the target rather than in its own column, to keep the table narrow. */
+function targetCell(change: EntryChange): string {
+  const target = `\`${cell(change.label)}\``
+  return change.owner === undefined ? target : `${target}<br><sub>${cell(change.owner)}</sub>`
+}
+
 function row(change: EntryChange): string {
   const columns = [
-    `\`${cell(change.label)}\``,
-    change.owner === undefined ? '' : `\`${cell(change.owner)}\``,
+    targetCell(change),
     SCOPE[change.scope].noun,
-    formatBytes(change.baseBytes),
-    formatBytes(change.headBytes),
-    `${formatDelta(change.deltaBytes)}${SUFFIX[change.kind] ?? ''}`,
+    `${formatBytes(change.baseBytes)} → ${formatBytes(change.headBytes)}`,
+    deltaCell(change),
   ]
   return `| ${columns.join(' | ')} |`
 }
 
-function summary(diff: SnapshotDiff): string[] {
-  const lines: string[] = []
-  for (const { bundle, baseBytes, headBytes, deltaBytes } of diff.bundleTotals) {
-    lines.push(`- **${bundle === 'client' ? 'Client' : 'Server'} runtime entries** ${formatBytes(baseBytes)} to ${formatBytes(headBytes)}, **${formatDelta(deltaBytes)}**`)
-    for (const total of diff.scopeTotals.filter(total => SCOPE[total.scope].bundle === bundle))
-      lines.push(`  - ${SCOPE[total.scope].plural}: ${formatBytes(total.baseBytes)} to ${formatBytes(total.headBytes)}, ${formatDelta(total.deltaBytes)}`)
-  }
-  return lines
+function table(changes: EntryChange[]): string[] {
+  return [
+    '| Target | Scope | Size | Δ |',
+    '| --- | --- | --- | --- |',
+    ...changes.map(row),
+  ]
 }
 
+/**
+ * One line that answers the only question a reviewer opens the comment with: did this
+ * pull request add JavaScript, and does anything need a decision.
+ */
 function verdict(diff: SnapshotDiff): string {
-  const { breaches, thresholdBytes } = diff
-  const limit = formatBytes(thresholdBytes)
-  if (!breaches.length)
-    return `No single target grew past the ${limit} threshold.`
-  const named = breaches.map(change => `\`${cell(change.label)}\` ${formatDelta(change.deltaBytes)}`).join(', ')
-  return `**${breaches.length} target${breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold:** ${named}.`
+  const moved = diff.changes.filter(change => change.kind !== 'unchanged')
+  const added = moved.filter(change => change.kind === 'added')
+  const net = moved.reduce((total, change) => total + change.deltaBytes, 0)
+  const limit = formatBytes(diff.thresholdBytes)
+
+  const parts: string[] = []
+  if (diff.breaches.length)
+    parts.push(`⚠️ **${plural(diff.breaches.length, 'target')} past the ${limit} threshold** · net ${formatDelta(net)}`)
+  else if (!moved.length)
+    parts.push('✅ **No runtime entry changed size**')
+  else if (net > 0)
+    parts.push(`🟡 **${plural(moved.length, 'target')} changed** · net ${formatDelta(net)}`)
+  else
+    parts.push(`🟢 **${plural(moved.length, 'target')} changed** · net ${formatDelta(net)}`)
+
+  if (added.length)
+    parts.push(`🆕 ${plural(added.length, 'new target')}`)
+  return parts.join(' · ')
+}
+
+/** Bundle and scope totals, folded away: they answer a follow-up question, not the first one. */
+function totals(diff: SnapshotDiff): string[] {
+  const rows: string[] = ['| Bundle | Size | Δ |', '| --- | --- | --- |']
+  for (const { bundle, baseBytes, headBytes, deltaBytes } of diff.bundleTotals) {
+    rows.push(`| **${bundle === 'client' ? 'Client' : 'Server'}** | ${formatBytes(baseBytes)} → ${formatBytes(headBytes)} | ${formatDelta(deltaBytes)} |`)
+    for (const total of diff.scopeTotals.filter(total => SCOPE[total.scope].bundle === bundle))
+      rows.push(`| <sub>${SCOPE[total.scope].plural}</sub> | <sub>${formatBytes(total.baseBytes)} → ${formatBytes(total.headBytes)}</sub> | <sub>${formatDelta(total.deltaBytes)}</sub> |`)
+  }
+  return ['<details><summary>Bundle totals</summary>', '', ...rows, '</details>']
 }
 
 /**
@@ -51,39 +107,47 @@ function verdict(diff: SnapshotDiff): string {
  */
 export function formatMissingBaselineMarkdown(path: string, reason?: string): string {
   return [
-    '### Bundle size budget',
+    HEADING,
+    '',
+    'ℹ️ **No baseline to compare against**',
     '',
     reason === undefined
-      ? `No baseline report was found at \`${path}\`, so there is nothing to compare this build against.`
-      : `The baseline report at \`${path}\` cannot be read, so there is nothing to compare this build against. ${reason}`,
+      ? `No baseline report was found at \`${path}\`.`
+      : `The baseline report at \`${path}\` cannot be read. ${reason}`,
     '',
     'This run leaves its own report behind, which the next one can measure against.',
   ].join('\n')
 }
 
 /**
- * The diff as GitHub-flavoured markdown, ready to append to a step summary. Unchanged
- * targets are counted rather than listed: a report of forty plugins that all held still
- * is noise around the one that did not.
+ * The diff as GitHub-flavoured markdown, for a step summary and a pull request comment.
+ * The verdict and the targets that moved carry the whole story; every unchanged target
+ * sits behind a fold, because a report of forty plugins that all held still is noise
+ * around the one that did not.
  */
 export function formatDiffMarkdown(diff: SnapshotDiff): string {
-  const lines = ['### Bundle size budget', '']
+  const lines = [HEADING, '']
   if (!diff.changes.length)
     return [...lines, 'Neither build measured a runtime entry.'].join('\n')
 
   const moved = diff.changes.filter(change => change.kind !== 'unchanged')
-  lines.push(...summary(diff), '', verdict(diff), '')
-  if (moved.length) {
+  lines.push(verdict(diff), '')
+  if (moved.length)
+    lines.push(...table(moved), '')
+  lines.push(...totals(diff), '')
+
+  const unchanged = diff.changes.filter(change => change.kind === 'unchanged')
+  if (unchanged.length) {
     lines.push(
-      '| Target | Module | Scope | Base | Head | Change |',
-      '| --- | --- | --- | --- | --- | --- |',
-      ...moved.map(row),
+      `<details><summary>${plural(unchanged.length, 'unchanged target')}</summary>`,
+      '',
+      ...table(unchanged),
+      '</details>',
       '',
     )
   }
 
-  const unchanged = diff.changes.length - moved.length
-  lines.push(`<sub>${unchanged} target${unchanged === 1 ? '' : 's'} unchanged. Each target is charged its own bundled bytes plus every module it alone pulls in, and the threshold applies to each target on its own rather than to the total.</sub>`)
+  lines.push('<sub>Each target is charged its own bundled bytes plus every module it alone pulls in. The threshold applies to each target on its own, not to the total.</sub>')
   return lines.join('\n')
 }
 
@@ -92,8 +156,8 @@ export function formatDiffVerdict(diff: SnapshotDiff): string {
   const limit = formatBytes(diff.thresholdBytes)
   if (!diff.breaches.length) {
     const moved = diff.changes.filter(change => change.kind !== 'unchanged').length
-    return colors.green(`✔ no target grew past the ${limit} threshold`) + colors.dim(` (${moved} target${moved === 1 ? '' : 's'} changed size)`)
+    return colors.green(`✔ no target grew past the ${limit} threshold`) + colors.dim(` (${plural(moved, 'target')} changed size)`)
   }
   const named = diff.breaches.map(change => `${change.label} ${formatDelta(change.deltaBytes)}`).join(', ')
-  return colors.red(`✖ ${diff.breaches.length} target${diff.breaches.length === 1 ? '' : 's'} grew past the ${limit} threshold: `) + named
+  return colors.red(`✖ ${plural(diff.breaches.length, 'target')} grew past the ${limit} threshold: `) + named
 }

--- a/packages/nuxt-dx/tests/diff-report.test.ts
+++ b/packages/nuxt-dx/tests/diff-report.test.ts
@@ -26,66 +26,70 @@ function markdown(base: SizeBudgetSnapshot, head: SizeBudgetSnapshot, thresholdB
 }
 
 describe('formatDiffMarkdown', () => {
-  it('leads with what each scope gained or lost', () => {
+  it('opens with a verdict naming the breach count and the net change', () => {
     const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })))
-    expect(report).toContain('- **Client runtime entries** 10 kB to 50 kB, **+40 kB**')
-    expect(report).toContain('  - Nuxt plugins: 10 kB to 50 kB, +40 kB')
+    expect(report.split('\n')[2]).toBe('⚠️ **1 target past the 10 kB threshold** · net +40 kB')
   })
 
-  it('adds disjoint runtime entry kinds within one bundle', () => {
-    const plugin = entry({ scope: 'client', path: 'modules/telemetry/runtime/plugin.ts', totalBytes: 12 * KB })
-    const middleware = entry({ scope: 'client-middleware', path: 'middleware/auth.ts', totalBytes: 4 * KB })
-    const report = markdown(snapshot(plugin, middleware), snapshot(plugin, middleware))
-    expect(report).toContain('- **Client runtime entries** 16 kB to 16 kB, **+0 B**')
-    expect(report).toContain('  - Nuxt plugins: 12 kB to 12 kB, +0 B')
-    expect(report).toContain('  - Nuxt middleware: 4 kB to 4 kB, +0 B')
+  it('calls a run clean when nothing moved', () => {
+    const held = snapshot(entry({ totalBytes: KB }))
+    expect(markdown(held, held)).toContain('✅ **No runtime entry changed size**')
   })
 
-  it('names the targets that grew past the threshold', () => {
-    const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 50 * KB })))
-    expect(report).toContain('**1 target grew past the 10 kB threshold:** `app/plugins/analytics.ts` +40 kB.')
+  it('separates growth under the threshold from a shrink', () => {
+    const base = snapshot(entry({ totalBytes: 10 * KB }))
+    expect(markdown(base, snapshot(entry({ totalBytes: 11 * KB })))).toContain('🟡 **1 target changed** · net +1 kB')
+    expect(markdown(base, snapshot(entry({ totalBytes: 9 * KB })))).toContain('🟢 **1 target changed** · net -1 kB')
   })
 
-  it('says so when everything stayed within the threshold', () => {
-    const report = markdown(snapshot(entry({ totalBytes: 10 * KB })), snapshot(entry({ totalBytes: 11 * KB })))
-    expect(report).toContain('No single target grew past the 10 kB threshold.')
+  it('counts new targets beside the verdict', () => {
+    const head = snapshot(entry({ path: 'a.ts', totalBytes: KB }), entry({ path: 'b.ts', totalBytes: KB }))
+    expect(markdown(snapshot(), head)).toContain('· 🆕 2 new targets')
   })
 
-  it('states that the threshold is per target rather than cumulative', () => {
-    const report = markdown(snapshot(entry({ totalBytes: KB })), snapshot(entry({ totalBytes: 2 * KB })))
-    expect(report).toContain('the threshold applies to each target on its own rather than to the total')
+  it('gives each changed target one row with both sizes, a marker and a share', () => {
+    const base = snapshot(entry({ scope: 'client-middleware', path: 'middleware/auth.ts', totalBytes: 10 * KB }))
+    const head = snapshot(entry({ scope: 'client-middleware', path: 'middleware/auth.ts', totalBytes: 50 * KB }))
+    expect(markdown(base, head)).toContain('| `middleware/auth.ts` | Nuxt middleware | 10 kB → 50 kB | 🔴 +40 kB (+400.0%) |')
   })
 
-  it('gives each changed target a row with both sizes and the change', () => {
-    const base = snapshot(entry({ scope: 'client-middleware', path: 'middleware/auth.ts', owner: '@nuxt/auth', totalBytes: 10 * KB }))
-    const head = snapshot(entry({ scope: 'client-middleware', path: 'middleware/auth.ts', owner: '@nuxt/auth', totalBytes: 50 * KB }))
-    expect(markdown(base, head)).toContain('| `middleware/auth.ts` | `@nuxt/auth` | Nuxt middleware | 10 kB | 50 kB | +40 kB |')
+  it('carries the owning module under the target rather than in its own column', () => {
+    const base = snapshot(entry({ path: 'runtime/auth.ts', owner: '@nuxt/auth', totalBytes: 10 * KB }))
+    const head = snapshot(entry({ path: 'runtime/auth.ts', owner: '@nuxt/auth', totalBytes: 12 * KB }))
+    expect(markdown(base, head)).toContain('| `runtime/auth.ts`<br><sub>@nuxt/auth</sub> | Nuxt plugin |')
   })
 
   it('marks a target that appeared and one that disappeared', () => {
-    const base = snapshot(entry({ path: 'gone.ts', totalBytes: 4 * KB }))
-    const head = snapshot(entry({ path: 'new.ts', totalBytes: 4 * KB }))
-    const report = markdown(base, head)
-    expect(report).toContain('| `new.ts` |  | Nuxt plugin | 0 B | 4 kB | +4 kB (new) |')
-    expect(report).toContain('| `gone.ts` |  | Nuxt plugin | 4 kB | 0 B | -4 kB (gone) |')
+    const report = markdown(snapshot(entry({ path: 'gone.ts', totalBytes: 4 * KB })), snapshot(entry({ path: 'new.ts', totalBytes: 4 * KB })))
+    expect(report).toContain('| `new.ts` | Nuxt plugin | 0 B → 4 kB | 🆕 new |')
+    expect(report).toContain('| `gone.ts` | Nuxt plugin | 4 kB → 0 B | ⚪ gone |')
   })
 
   it('names the bundle each scope was measured in', () => {
     const base = snapshot(entry({ scope: 'nitro', path: 'server/plugins/queue.ts', totalBytes: KB }))
     const head = snapshot(entry({ scope: 'nitro', path: 'server/plugins/queue.ts', totalBytes: 2 * KB }))
-    expect(markdown(base, head)).toContain('| `server/plugins/queue.ts` |  | Nitro plugin |')
+    expect(markdown(base, head)).toContain('| `server/plugins/queue.ts` | Nitro plugin |')
   })
 
-  it('counts the targets that held still instead of listing them', () => {
+  it('folds bundle and scope totals away', () => {
+    const plugin = entry({ scope: 'client', path: 'modules/telemetry/runtime/plugin.ts', totalBytes: 12 * KB })
+    const middleware = entry({ scope: 'client-middleware', path: 'middleware/auth.ts', totalBytes: 4 * KB })
+    const report = markdown(snapshot(plugin, middleware), snapshot(plugin, middleware))
+    expect(report).toContain('<details><summary>Bundle totals</summary>')
+    expect(report).toContain('| **Client** | 16 kB → 16 kB | +0 B |')
+    expect(report).toContain('| <sub>Nuxt plugins</sub> | <sub>12 kB → 12 kB</sub> | <sub>+0 B</sub> |')
+  })
+
+  it('folds unchanged targets away instead of dropping or listing them', () => {
     const held = snapshot(entry({ path: 'a.ts', totalBytes: KB }), entry({ path: 'b.ts', totalBytes: KB }))
     const report = markdown(held, held)
-    expect(report).toContain('2 targets unchanged.')
-    expect(report).not.toContain('| `a.ts` |')
+    expect(report).toContain('<details><summary>2 unchanged targets</summary>')
+    expect(report.indexOf('| `a.ts` |')).toBeGreaterThan(report.indexOf('<details><summary>2 unchanged'))
   })
 
-  it('drops the table when nothing moved', () => {
-    const held = snapshot(entry({ totalBytes: KB }))
-    expect(markdown(held, held)).not.toContain('| Target |')
+  it('states that the threshold is per target rather than cumulative', () => {
+    const report = markdown(snapshot(entry({ totalBytes: KB })), snapshot(entry({ totalBytes: 2 * KB })))
+    expect(report).toContain('The threshold applies to each target on its own, not to the total.')
   })
 
   it('says nothing was measured when both builds are empty', () => {
@@ -101,7 +105,8 @@ describe('formatDiffMarkdown', () => {
 describe('formatMissingBaselineMarkdown', () => {
   it('says which report was missing rather than reporting a false clean run', () => {
     const report = formatMissingBaselineMarkdown('base/.nuxt/dx/size-budget.json')
-    expect(report).toContain('### Bundle size budget')
+    expect(report).toContain('### 📦 Runtime size budget')
+    expect(report).toContain('ℹ️ **No baseline to compare against**')
     expect(report).toContain('No baseline report was found at `base/.nuxt/dx/size-budget.json`')
     expect(report).not.toContain('threshold')
   })


### PR DESCRIPTION
The budget comment led with four lines of bundle totals, then a sentence, then a six column table. A reviewer had to read all of it to learn whether the pull request added JavaScript. Modelled on the bundle size comment in `mdream`.

## Now

```md
### 📦 Runtime size budget

⚠️ **1 target past the 10 kB threshold** · net +27.2 kB · 🆕 1 new target

| Target | Scope | Size | Δ |
| --- | --- | --- | --- |
| `app/plugins/analytics.client.ts` | Nuxt plugin | 7.6 kB → 43.3 kB | 🔴 +35.6 kB (+467.9%) |
| `runtime/consent.client.ts`<br><sub>fixture-consent</sub> | Nuxt plugin | 0 B → 170 B | 🆕 new |
| `app/middleware/legacy.global.ts` | Nuxt middleware | 12.5 kB → 3.9 kB | 🟢 -8.6 kB (-68.8%) |
```

Bundle totals and unchanged targets follow behind `<details>`.

## What changed

- One verdict line carries the answer: breach count, net change, and new targets. Its icon states the outcome (⚠️ over threshold, 🟡 grew, 🟢 shrank, ✅ no change).
- Six columns become four. The owning module moved under the target, and base and head share one `7.6 kB → 43.3 kB` cell.
- Every delta carries a marker and its share of the base, so 200 B of growth never reads like 200 kB.
- Bundle and scope totals fold away. They answer a follow-up question, not the first one.
- Unchanged targets are listed behind a fold instead of only counted, so a reader can still check one.
- The missing baseline report gets the same heading and an ℹ️ verdict line.

## BREAKING

The report heading changes from `### Bundle size budget` to `### 📦 Runtime size budget`. Any consumer grepping the step summary for the old heading must update. No consumer is known to do this.

## Verification

`pnpm --filter @harlan-zw/nuxt-dx test`: 179 passed, 19 files. Lint clean. The README sample is the real rendered output, not hand written.