### PR TITLE
fix(nuxt-github-sponsors): stop the tier defaults joining the authored list

### DIFF
--- a/packages/nuxt-github-sponsors/package.json
+++ b/packages/nuxt-github-sponsors/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-github-sponsors",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Experimental typed GitHub Sponsors data for Nuxt sites.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-github-sponsors/src/module.ts
+++ b/packages/nuxt-github-sponsors/src/module.ts
@@ -3,12 +3,11 @@ import type { SponsorOverride, SponsorTier } from './runtime/shared/types'
 import process from 'node:process'
 import { addImports, addServerHandler, addTypeTemplate, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
 import {
-  DEFAULT_TIERS,
   DEFAULT_TOKEN_ENV,
   normalizeRoute,
-  parseSponsorTiers,
   planSponsorDelivery,
   renderSponsorTierAugmentation,
+  resolveSponsorTiers,
   resolveSponsorToken,
 } from './options'
 
@@ -32,10 +31,15 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'githubSponsors',
     compatibility: { nuxt: '>=4.5.0 <5.0.0' },
   },
+  /**
+   * `tiers` is absent on purpose. Nuxt merges these defaults with `defu`, which
+   * concatenates arrays, so a declared default would append the shipped tiers to the
+   * authored ones. A site that names its own `top` tier then fails on a duplicate key.
+   * `setup` falls back to `DEFAULT_TIERS` instead, where a list replaces rather than joins.
+   */
   defaults: {
     mode: 'prerender',
     route: '/api/github-sponsors',
-    tiers: DEFAULT_TIERS,
     overrides: {},
     tokenEnv: DEFAULT_TOKEN_ENV,
   },
@@ -45,7 +49,7 @@ export default defineNuxtModule<ModuleOptions>({
     if (!login)
       throw new TypeError('githubSponsors.login must be a non-empty GitHub login')
     const route = normalizeRoute(options.route)
-    const tiers = parseSponsorTiers(options.tiers ?? DEFAULT_TIERS)
+    const tiers = resolveSponsorTiers(options.tiers)
     const tokenEnv = options.tokenEnv?.trim() || DEFAULT_TOKEN_ENV
     const mode = options.mode ?? 'prerender'
     const resolver = createResolver(import.meta.url)

--- a/packages/nuxt-github-sponsors/src/options.ts
+++ b/packages/nuxt-github-sponsors/src/options.ts
@@ -47,6 +47,15 @@ export function normalizeRoute(value = '/api/github-sponsors'): string {
   return route.replace(/\/$/, '') || '/'
 }
 
+/**
+ * The tiers a build runs with. The fallback lives here rather than in the module
+ * `defaults`, because Nuxt merges those with `defu`, which joins arrays instead of
+ * replacing them. See the note on `defaults` in module.ts.
+ */
+export function resolveSponsorTiers(input: SponsorTier[] | undefined): SponsorTier[] {
+  return parseSponsorTiers(input ?? DEFAULT_TIERS)
+}
+
 export function parseSponsorTiers(input: SponsorTier[]): SponsorTier[] {
   const keys = new Set<string>()
   return input.map((tier) => {

--- a/packages/nuxt-github-sponsors/tests/tier-defaults.test.ts
+++ b/packages/nuxt-github-sponsors/tests/tier-defaults.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import module from '../src/module'
+import { resolveSponsorTiers } from '../src/options'
+
+/** What Nuxt does with the module's declared defaults before `setup` sees them. */
+async function resolveOptions(inline: Record<string, unknown>) {
+  const nuxt = { options: { } } as never
+  return await (module as unknown as { getOptions: (i: unknown, n: never) => Promise<{ tiers: never[] }> }).getOptions(inline, nuxt)
+}
+
+describe('tier defaults', () => {
+  it('keeps only the tiers a site authored', async () => {
+    const authored = [{ key: 'top', minimumMonthlyDollars: 100 }]
+    const options = await resolveOptions({ login: 'harlan-zw', tiers: authored })
+    expect(resolveSponsorTiers(options.tiers)).toEqual(authored)
+  })
+
+  it('falls back to the shipped tiers when a site authors none', async () => {
+    const options = await resolveOptions({ login: 'harlan-zw' })
+    expect(resolveSponsorTiers(options.tiers).map(tier => tier.key)).toEqual(['top', 'gold'])
+  })
+})


### PR DESCRIPTION
Found while migrating unhead.unjs.io and unlighthouse.dev to 0.1.0. Both failed `pnpm install` until the `tiers` override was deleted.

## The defect

`tiers` was declared in the module `defaults`. Nuxt merges module defaults with `defu`, which JOINS arrays rather than replacing them. A site that authored two tiers got four: its own, plus the shipped pair appended.

Before 0.1.0 the shipped tiers were `partner` and `supporter`, so the join produced four distinct keys. The result was wrong, in that every site silently carried two tiers it never asked for, but nothing failed. 0.1.0 changed the shipped keys to `top` and `gold`, which is what most sites already name their own tiers, so the join now produces a duplicate key and `parseSponsorTiers` throws.

Every consumer that overrides `tiers` with a `top` or `gold` key is affected. That is all six.

## The fix

`tiers` leaves the `defaults` block, so `defu` never sees it. The fallback moves into `resolveSponsorTiers`, a pure function that replaces rather than joins. The `defaults` block carries a comment saying why no list-shaped option belongs there.

## Verification

Failing test written first, in `tests/tier-defaults.test.ts`, driving the module's real `getOptions` path so it reproduces exactly what Nuxt does with the declared defaults. It failed with `githubSponsors.tiers must have unique, non-empty keys` and passes now.

`pnpm --filter @harlan-zw/nuxt-github-sponsors test`: 19 passed, 4 files. Lint and typecheck clean.

## BREAKING

None. A site that authored tiers now gets exactly those tiers, which is what it always asked for. A site that authored none still gets `top` and `gold`.

Version bumped to 0.1.1. Tag `nuxt-github-sponsors-v0.1.1` after merge.