### PR TITLE
feat(nuxt-sentry): one Sentry Report Policy for nine sites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
       - 'nuxt-github-sponsors-v*'
       - 'nuxt-cloudflare-v*'
       - 'nuxt-wide-events-v*'
+      - 'nuxt-sentry-v*'
       - 'comark-content-v*'
 
 permissions:
@@ -73,6 +74,10 @@ jobs:
       - name: Publish nuxt-wide-events
         if: startsWith(github.ref_name, 'nuxt-wide-events-v')
         run: npm publish packages/nuxt-wide-events/.pack/*.tgz --access public --provenance
+
+      - name: Publish nuxt-sentry
+        if: startsWith(github.ref_name, 'nuxt-sentry-v')
+        run: npm publish packages/nuxt-sentry/.pack/*.tgz --access public --provenance
 
       - name: Publish comark-content
         if: startsWith(github.ref_name, 'comark-content-v')

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -16,10 +16,16 @@ Canonical vocabulary for this project. Public APIs, docs, routes, and messages u
 | Field | `@harlan-zw/nuxt-wide-events/server` | planned | Nuxt server code | "field" |
 | Wrangler Diagnostic | `@harlan-zw/nuxt-cloudflare` | published | developers and CI | "warning" |
 | Collection | `@harlan-zw/comark-content/server` | published | Nuxt server code | "collection" |
+| Error Report | `@harlan-zw/nuxt-sentry` | planned | Nuxt app and server code | "error" |
+| Report Policy | `@harlan-zw/nuxt-sentry` | planned | developers | "reporting rules" |
+| Drop Rule | `@harlan-zw/nuxt-sentry/server` | planned | developers | "filter" |
+| Redaction Rule | `@harlan-zw/nuxt-sentry/server` | planned | developers | "redaction" |
 
 Collisions
 
 `Diagnostic` belongs to `nuxt-dx`. `nuxt-cloudflare` always qualifies its findings as `Wrangler Diagnostic`.
+
+`Event` belongs to `Wide Event` and `Domain Event`. Sentry's own word for a captured error is "event", so `nuxt-sentry` never carries that word into its API. It says `Error Report`.
 
 ## Terms
 
@@ -86,6 +92,34 @@ Collisions
 **Never:** Diagnostic on its own, wrangler warning, lint error.
 **Casing:** `Wrangler Diagnostic` in headings and `Wrangler diagnostic` elsewhere.
 
+### Error Report
+
+**Is:** one captured exception sent to the error tracker.
+**Use for:** `nuxt-sentry` APIs, configuration, docs, and developer messages.
+**Never:** event, Sentry event, issue, exception report.
+**Casing:** `Error Report` in headings, `error report` in prose, and `errorReport` in identifiers.
+
+### Report Policy
+
+**Is:** the rules that decide whether an Error Report is sent and what it carries.
+**Use for:** `nuxt-sentry` options, docs, and developer messages.
+**Never:** filter config, beforeSend config, scrubbing rules, event policy, client error policy, query policy.
+**Casing:** `Report Policy` in headings, `report policy` in prose, and `reportPolicy` in identifiers.
+
+### Drop Rule
+
+**Is:** one predicate that stops an Error Report before it is sent.
+**Use for:** `nuxt-sentry` options, docs, and developer messages.
+**Never:** filter, ignore rule, exclusion.
+**Casing:** `Drop Rule` in headings, `drop rule` in prose, and `dropRule` in identifiers.
+
+### Redaction Rule
+
+**Is:** one transform that removes a secret or personal value from an Error Report.
+**Use for:** `nuxt-sentry` options, docs, and developer messages.
+**Never:** scrub, sanitiser, masker.
+**Casing:** `Redaction Rule` in headings, `redaction rule` in prose, and `redactionRule` in identifiers.
+
 ### Collection
 
 **Is:** a named set of markdown files that `comark-content` ingests, queries, and serves.
@@ -99,6 +133,8 @@ Collisions
 | --- | --- | --- |
 | canonical log | Wide Event | The industry also uses this for unrelated aggregation patterns. |
 | event log | Wide Event or Domain Event | It collapses two distinct concepts. |
+| Sentry event | Error Report | `Event` already names two other concepts here. |
+| scrub, sanitise, mask | Redaction Rule | Three words for one transform. |
 | powerful, seamless, robust | (cut) | These words do not describe behaviour. |
 
 ## Open questions

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Every package here publishes to npm with provenance. Versions and release notes 
 | [`@harlan-zw/nuxt-github-sponsors`](./packages/nuxt-github-sponsors) | 💖 Typed GitHub Sponsors data with tiers, profile overrides, a public route, and a composable. |
 | [`@harlan-zw/nuxt-wide-events`](./packages/nuxt-wide-events) | 📝 Minimal Wide Events with build-time Field enforcement and a small production runtime. |
 | [`@harlan-zw/nuxt-cloudflare`](./packages/nuxt-cloudflare) | 🌩️ Opinionated Cloudflare defaults, generated Wrangler config, and Wrangler diagnostics for Nuxt. |
+| [`@harlan-zw/nuxt-sentry`](./packages/nuxt-sentry) | 🛡️ One Sentry Report Policy: registration, enable gate, Drop Rules, and Redaction Rules for the client and the server. |
 | [`@harlan-zw/comark-content`](./packages/comark-content) | 📄 Markdown-only Nuxt content powered by Comark, with Collection queries, navigation, and search sections. |
 
 ## Development

--- a/packages/nuxt-sentry/.attw.json
+++ b/packages/nuxt-sentry/.attw.json
@@ -1,0 +1,5 @@
+{
+  "ignoreRules": [
+    "cjs-resolves-to-esm"
+  ]
+}

--- a/packages/nuxt-sentry/LICENSE.md
+++ b/packages/nuxt-sentry/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harlan Wilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/nuxt-sentry/MIGRATION.md
+++ b/packages/nuxt-sentry/MIGRATION.md
@@ -1,0 +1,235 @@
+# Migrating a site to `@harlan-zw/nuxt-sentry`
+
+One section per site. Line counts are measured, not estimated. "Delete" means the whole file goes.
+
+Every site does the same three things first.
+
+1. `pnpm add @harlan-zw/nuxt-sentry`.
+2. Add `'@harlan-zw/nuxt-sentry'` to `modules`, after `'@sentry/nuxt/module'`.
+3. Delete the `sentry` build option block, the `sourcemap` block and the `runtimeConfig.sentry` block from `nuxt.config.ts`. The module writes all three.
+
+## Deploy workflow fix, four sites
+
+`zhead.dev`, `mdream.dev`, `unlighthouse.dev` and `request-indexing` deploy on a `workflow_run` event and read the ambient `GITHUB_SHA`. On that event `GITHUB_SHA` is the default branch tip, not the commit that was built, so the release names code that was never deployed.
+
+The build still reports, because a release identity is present. It is simply the wrong one. Add this to the build step of `.github/workflows/deploy-cloudflare.yml`, copying `unhead.unjs.io/.github/workflows/deploy-cloudflare.yml:75-78`:
+
+```yaml
+- run: pnpm build
+  env:
+    # `GITHUB_SHA` is the default branch tip on a `workflow_run` event, so
+    # the release tag named a commit this build does not contain. Sentry
+    # then blamed live errors on code that was never deployed.
+    SENTRY_RELEASE: ${{ github.event.workflow_run.head_sha || github.sha }}
+```
+
+`harlanzw.com`, `gscdump.com` and `nuxtseo.com` deploy from a plain `push` job, so their ambient `GITHUB_SHA` is already correct. `unhead.unjs.io` already has the fix. `scripts.nuxt.com` builds on Vercel, and the module reads `VERCEL_GIT_COMMIT_SHA`.
+
+## zhead.dev
+
+Delete: `sentry.client.config.ts` (16), `server/plugins/sentry.ts` (16), `shared/sentry.ts` (19).
+Edit `nuxt.config.ts`: remove lines 3, 6-7, 12-17, 35-41 and 145-166.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: 'https://110494db6f0342ee0da4882bd2bfa8e4@o4510507748163584.ingest.us.sentry.io/4511887363014656',
+    project: 'zhead',
+  },
+})
+```
+
+Removed: 51 file lines plus about 44 config lines. **95 lines, 3 files.**
+
+## unhead.unjs.io
+
+Delete: `sentry.client.config.ts` (16), `server/plugins/sentry.ts` (16), `shared/sentry.ts` (54), `tests/sentry-target.test.ts` (58). The gate moves into the module and is tested there.
+Edit `nuxt.config.ts`: remove lines 4, 6-9, 153-158 and 426-451.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: 'https://f3ae6ad9827cb10d4527a1a47d3fc4de@o4510507748163584.ingest.us.sentry.io/4511887362686976',
+    project: 'unhead',
+  },
+})
+```
+
+Keep: the `SENTRY_RELEASE` line in `.github/workflows/deploy-cloudflare.yml:78`.
+
+Removed: 144 file lines plus about 37 config lines. **181 lines, 4 files.**
+
+## mdream.dev
+
+Delete: `sentry.client.config.ts` (16), `server/plugins/sentry.ts` (17).
+Shrink `shared/sentry.ts` to the site rules only, about 18 lines. Keep `test/sentry-reporting.test.ts` for them.
+Edit `nuxt.config.ts`: remove lines 5, 7-8, 193-199 and 348-369.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: SENTRY_DSN,
+    project: 'mdream',
+    policy: { ignoreErrors: [EXPECTED_UPSTREAM_ERROR_RE, 'Not supported in zeroRuntime mode.'] },
+  },
+})
+```
+
+Removed: 33 file lines, 20 lines from `shared/sentry.ts`, about 33 config lines. **86 lines, 2 files.**
+
+## harlanzw.com
+
+Delete: `sentry.client.config.ts` (17), `server/plugins/sentry.ts` (16), `shared/sentry.ts` (53), `test/unit/sentry.test.ts` (56).
+`isLocalPreviewHost` becomes the module's browser gate. The 404 Drop Rule becomes `policy.dropClientStatus` and now also applies on the server, which fixes the oversight.
+Edit `nuxt.config.ts`: remove lines 3, 6-7, 22-26, 59-65 and 293-314.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: 'https://8b3cdae1f3b66b32c99644bdc5da7529@o4510507748163584.ingest.us.sentry.io/4511887363211264',
+    project: 'harlanzw-com',
+  },
+})
+```
+
+Removed: 142 file lines plus about 42 config lines. **184 lines, 4 files.**
+
+## scripts.nuxt.com
+
+Delete: `sentry.client.config.ts` (16), `shared/sentry.ts` (27), `test/unit/sentry.test.ts` (13).
+Keep `sentry.server.config.ts` (13) and rebuild its `beforeSend` from the shared policy. This is the only non Cloudflare site, so the module registers no server plugin for it.
+Edit `nuxt.config.ts`: remove lines 7, 14-15 and 407-429. Keep `autoInjectServerSentry: 'top-level-import'` on the root `sentry` key.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: 'https://7d71e39eb88d57b207e13bd4c05df8cf@o4510507748163584.ingest.us.sentry.io/4511887362818048',
+    project: 'nuxt-scripts',
+    environment: { 'preview.': 'preview' },
+    policy: { dropServerStatus: [[400, 499]] },
+  },
+})
+```
+
+Removed: 56 file lines plus about 26 config lines. **82 lines, 3 files.**
+
+## unlighthouse.dev
+
+Delete: `sentry.client.config.ts` (18), `server/plugins/sentry.ts` (17), `tests/sentry-redaction.test.ts` (40), `tests/sentry-config.test.ts` (53).
+Shrink `shared/sentry.ts` to the `EXPECTED_UPSTREAM_FAILURE` marker and its predicate, about 40 lines. Trim `tests/sentry-filter.test.ts` to that half.
+The redaction becomes `dataCollection: 'scrubbed'`. The `iabjs://` deny entry is now a module default. The stackless manifest filter is covered by the built in stale chunk rules.
+Edit `nuxt.config.ts`: remove lines 7, 9-10, 159-164 and 506-527.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: SENTRY_DSN,
+    project: 'unlighthouse',
+  },
+})
+```
+
+Removed: 128 file lines, 126 lines from `shared/sentry.ts`, about 33 config lines. **287 lines, 4 files.**
+
+## request-indexing
+
+Delete: `sentry.client.config.ts` (25), `server/plugins/sentry.ts` (18).
+Shrink `shared/sentry.ts` to `errorStatusCode` if other code uses it, otherwise delete it. `resolveSentryInitialization` becomes `gate: 'release'`. `dropExpectedNotFound` becomes the client default. Trim `tests/sentry.test.ts`.
+Edit `nuxt.config.ts`: remove lines 9, 12-14, 43-49, 371-377 and 388-409. Also remove lines 72-85, which strip the Sentry rollup and vite plugins by hand.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: SENTRY_DSN,
+    project: 'request-indexing',
+  },
+})
+```
+
+401 and 403 now drop on the client by default, which is the dominant noise class for a signed in app.
+
+Removed: 43 file lines, up to 89 lines from `shared/sentry.ts`, about 43 config lines. **up to 175 lines, 2 to 3 files.**
+
+## gscdump.com
+
+Delete: `sentry.client.config.ts` (56), `server/utils/sentry-event-policy.ts` (34), `server/utils/sentry-attribution.ts` (35), `test/sentry-attribution.test.ts` (43). The BigInt scrub is now part of `redactValue`, and the Worker attribution is a module option.
+Shrink `server/plugins/sentry.ts` from 52 lines to zero.
+Keep: `server/utils/expected-error.ts` (88), which encodes D1, R2, KV and iron rules no other site has; `server/internal/sentry-queue.ts` (71); `server/utils/sentry-job-sink.ts` (69); `server/utils/sentry-protocol-sink.ts` (48); both `sentry-use-query` bridges; `app/utils/sentry-query-policy.ts` (22).
+Edit `nuxt.config.ts`: remove lines 52-63, 1085-1113 and most of 1178-1198.
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    dsn: 'https://5a73fdc73e42eb95936085b70f7ebd12@o4510507748163584.ingest.us.sentry.io/4511584664354816',
+    project: 'gscdump',
+    app: 'gscdump',
+    environment: { 'staging.': 'staging' },
+    tracesSampleRate: { production: 0.1, staging: 1 },
+    dataCollection: 'scrubbed',
+    logs: true,
+  },
+})
+```
+
+**This site currently sends unredacted PII on three clients.** `dataCollection: 'scrubbed'` is what fixes it. Pass the same `beforeSend` into `runWithQueueSentry`, so the queue client redacts too:
+
+```ts
+import { createBeforeSend } from '@harlan-zw/nuxt-sentry/server'
+
+const { nuxtSentry } = useRuntimeConfig().public
+runWithQueueSentry({ queue, context, options: { ...base, beforeSend: createBeforeSend(nuxtSentry.server) } }, run)
+```
+
+Removed: 168 file lines across 4 files, plus 52 plugin lines and about 50 config lines. **about 270 lines.**
+
+## nuxtseo.com
+
+Delete: `apps/site/sentry.client.config.ts` (42), `apps/pro/sentry.client.config.ts` (47), `layers/core/shared/logging/sentry-environment.ts` (55), `layers/site-shell/app/utils/client-error-policy.ts` (75), `layers/core/server/plugins/sentry.ts` (37).
+Keep `layers/core/shared/logging/redact.ts`, because the D1 logging chokepoint uses it. Only the Sentry half moves.
+Keep: `layers/saas/server/utils/sentry-cron.ts`, `sentry-queue.ts`, `sentry-job-sink.ts`, `layers/core/app/plugins/sentry-rpc.client.ts`, both `sentry-use-query` bridges.
+`layers/core/server/plugins/wide-event-sentry.ts` (11) becomes `wideEvents: true`.
+`layers/core/shared/logging/expected-server-error.ts` (27) can go, or stay as `policy.dropServerStatus: [[400, 499]]`.
+
+```ts
+export default defineNuxtConfig({
+  // layers/core/nuxt.config.ts
+  nuxtSentry: {
+    gate: 'ci',
+    dataCollection: 'scrubbed',
+    environment: { 'staging.': 'staging' },
+    tracesSampleRate: { production: 0.05, staging: 1 },
+    logs: true,
+    wideEvents: true,
+    policy: { denyUrls: [/carbon\.js/, /carbonads\.(?:com|net)/] },
+  },
+  // apps/site/nuxt.config.ts
+  nuxtSentry: { app: 'site', project: 'nuxtseo-site', dsn: '...' },
+  // apps/pro/nuxt.config.ts
+  nuxtSentry: {
+    app: 'pro',
+    project: 'nuxtseo-pro',
+    dsn: '...',
+    tracesSampleRate: { production: 0.1, staging: 1 },
+    policy: { dropClientStatus: [401, 403, 404, 429, 503] },
+  },
+})
+```
+
+**The server now receives a release**, which fixes gap 9: uploaded client maps bound to an unnamed release.
+
+Removed: 256 file lines across 5 files, plus about 60 config lines. **about 316 lines.**
+
+## Cost summary
+
+| Repo | Files deleted | Lines removed |
+| --- | --- | --- |
+| `scripts.nuxt.com` | 3 | ~82 |
+| `mdream.dev` | 2 | ~86 |
+| `zhead.dev` | 3 | ~95 |
+| `request-indexing` | 2 to 3 | ~175 |
+| `unhead.unjs.io` | 4 | ~181 |
+| `harlanzw.com` | 4 | ~184 |
+| `gscdump.com` | 4 | ~270 |
+| `unlighthouse.dev` | 4 | ~287 |
+| `nuxtseo.com` | 5 | ~316 |
+| **Total** | **31 to 32** | **~1,676** |

--- a/packages/nuxt-sentry/README.md
+++ b/packages/nuxt-sentry/README.md
@@ -1,0 +1,205 @@
+<h1>@harlan-zw/nuxt-sentry</h1>
+
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![License][license-src]][license-href]
+[![Nuxt][nuxt-src]][nuxt-href]
+
+Nuxt Sentry owns one Report Policy for a whole estate of sites. It registers the client and server Sentry clients, decides who may report, and applies the same Drop Rules and Redaction Rules on both sides.
+
+It does not wrap the Sentry SDK. Your code keeps importing `@sentry/nuxt` and `@sentry/cloudflare` directly.
+
+Status: experimental. APIs may change before the first release.
+
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<sub>Made possible by my <a href="https://github.com/sponsors/harlan-zw">Sponsor Program 💖</a><br> Follow me <a href="https://twitter.com/harlan_zw">@harlan_zw</a> 🐦 • Join <a href="https://discord.gg/275MBUBvgP">Discord</a> for help</sub><br>
+</td>
+</tbody>
+</table>
+</p>
+
+## Features
+
+- 🚦 **One enable gate:** a release identity proves a deploy produced the build, so `wrangler dev` and `nuxt preview` cannot report as production.
+- 🧹 **Redaction Rules:** credentials are removed by key name and by value shape, on every report, on both sides.
+- 🎯 **Drop Rules:** status codes, transient upstream failures, browser noise and extension frames, decided by one pure function.
+- 🏷️ **Release and environment naming:** resolved once at build time, then shared by the client and the server.
+- 📦 **Registered from the module:** `@harlan-zw/nuxt-dx` attributes the bundle entry to this package instead of to an anonymous site plugin.
+- ☁️ **Cloudflare Worker version tags:** read from the `CF_VERSION_METADATA` binding, so a report names the exact Worker version.
+
+## Installation
+
+```bash
+pnpm add @harlan-zw/nuxt-sentry @sentry/nuxt
+```
+
+On Cloudflare Workers, also add `@sentry/cloudflare`.
+
+```ts
+export default defineNuxtConfig({
+  modules: ['@sentry/nuxt/module', '@harlan-zw/nuxt-sentry'],
+  nuxtSentry: {
+    dsn: 'https://key@o0.ingest.us.sentry.io/0',
+    project: 'my-project',
+  },
+})
+```
+
+Set `SENTRY_AUTH_TOKEN` in CI to upload source maps. Set `SENTRY_RELEASE` in the deploy workflow, because the default gate needs it.
+
+## Vocabulary
+
+| Term | Meaning |
+| --- | --- |
+| Error Report | One captured exception sent to the error tracker. |
+| Report Policy | The rules that decide whether an Error Report is sent and what it carries. |
+| Drop Rule | One predicate that stops an Error Report before it is sent. |
+| Redaction Rule | One transform that removes a secret or personal value from an Error Report. |
+
+## Options
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `true` | Register anything at all. |
+| `dsn` | required | The public Sentry DSN. |
+| `org` | `'harlan-zw'` | Sentry organisation slug. |
+| `project` | none | Sentry project slug. Required when source maps upload. |
+| `app` | none | The `app` tag, for one organisation serving several deployments. |
+| `gate` | `'release'` | Who may send an Error Report. See Gates. |
+| `environment` | `'production'` | Environment name, or a host prefix map. |
+| `tracesSampleRate` | `0.05` | Fraction of requests traced, or a rate per environment. |
+| `dataCollection` | `'scrubbed'` | How much of the request a report carries. |
+| `policy` | see below | Report Policy. |
+| `sourceMaps` | `true` | Emit and upload client source maps when a token is present. |
+| `logs` | `false` | Forward `console.warn` and `console.error` to Sentry Logs. |
+| `workerVersionBinding` | `'CF_VERSION_METADATA'` | Cloudflare binding holding the Worker version. |
+| `wideEvents` | `false` | Forward failing Wide Events to Sentry Logs. |
+
+### Gates
+
+`gate` decides who may send an Error Report.
+
+| Value | Requires |
+| --- | --- |
+| `'release'` | A production build that carries a release identity. |
+| `'ci'` | A production build produced in CI. |
+| `'always'` | Any production build. |
+
+The default is `'release'`. A release identity is the proof that a deploy produced the build. `nuxt preview` and `wrangler dev` both run a production build with `NODE_ENV=production`, so `NODE_ENV` alone lets a laptop file issues against the live project. One site measured 232 events from a single local session against 223 real errors org wide in the same day.
+
+The release comes from `SENTRY_RELEASE`, then `GITHUB_SHA`. Set `SENTRY_RELEASE` explicitly in a deploy workflow. On a `workflow_run` event `GITHUB_SHA` is the default branch tip rather than the commit that was built, so the release names code that was never deployed.
+
+```yaml
+env:
+  SENTRY_RELEASE: ${{ github.event.workflow_run.head_sha || github.sha }}
+```
+
+The browser applies one more gate that a build cannot see. A bundle served from a loopback or RFC1918 host is never a deployment, so it reports nothing.
+
+### Data collection
+
+`dataCollection: 'scrubbed'` sends the request, then applies every Redaction Rule. `'none'` sends no personal data at all.
+
+Redaction runs on every report under both settings. `'none'` suppresses the request fields, but an ofetch error message still quotes the failing URL, query string and all, and no data collection setting stops that.
+
+### Report Policy
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    policy: {
+      // Server statuses that never report. Default `[404]`.
+      dropServerStatus: [404, [500, 599]],
+      // Client statuses that never report. Default `[401, 403, 404]`.
+      dropClientStatus: [401, 403, 404],
+      // Drop TimeoutError, AbortError and the abort messages. Default `true`.
+      dropTransient: true,
+      // Extra message patterns, on top of the built-in browser noise list.
+      ignoreErrors: [/^Failed to fetch https?:\/\/\S+$/],
+      // Extra source URL patterns, on top of the built-in extension list.
+      denyUrls: [/carbonads\.(?:com|net)/],
+      // Use the built-in browser noise lists. Default `true`.
+      browserNoise: true,
+      // Extra key names every Redaction Rule treats as secret.
+      secretKeys: ['dataForSeoLogin'],
+    },
+  },
+})
+```
+
+The server default is 404 only. 401, 403 and 429 keep reporting, because an auth regression or a rate limit spike must stay visible. The client default adds 401 and 403, where the same status is an expired session racing a redirect to the login page.
+
+### Environment and sampling
+
+```ts
+export default defineNuxtConfig({
+  nuxtSentry: {
+    environment: { 'staging.': 'staging' },
+    tracesSampleRate: { production: 0.05, staging: 1 },
+  },
+})
+```
+
+The browser resolves the environment from its hostname. The server has no hostname, so it takes `SENTRY_ENVIRONMENT` when set, and `'production'` otherwise.
+
+## What it does not do
+
+- **It does not wrap or re-export the Sentry SDK.** Keep importing `@sentry/nuxt` and `@sentry/cloudflare` for `captureException`, `withScope` and `addBreadcrumb`.
+- **It does not replace `@sentry/nuxt/module`.** That module still owns the build plugin, the source map upload and the client entry injection. This module configures it.
+- **It does not own the queue Sentry client.** `runWithQueueSentry` lives in `@harlan-zw/nuxt-cf-jobs/sentry`. Build its `beforeSend` from `@harlan-zw/nuxt-sentry/server`.
+- **It does not write a Wrangler file.** `@harlan-zw/nuxt-cloudflare` owns that, and `upload_source_maps` with it.
+- **It does not capture per request errors twice.** It never hooks the Nitro `error` event itself.
+- **It does not add Sentry Cron monitors or RPC capture.** Those cost a billed monitor seat and one site each uses them.
+- **It does not redact application log payloads.** Only the Sentry road is covered.
+
+## Non Cloudflare presets
+
+The server plugin is registered only on a Cloudflare Nitro preset, because `@sentry/cloudflare` is the only SDK that runs on Workers and it cannot be bundled into a Node build. On any other preset the module logs a warning and registers no server plugin. Keep the site's own `sentry.server.config.ts` and build its `beforeSend` from the shared policy:
+
+```ts
+import { createBeforeSend } from '@harlan-zw/nuxt-sentry/server'
+import * as Sentry from '@sentry/nuxt'
+
+const { nuxtSentry } = useRuntimeConfig().public
+
+Sentry.init({
+  dsn: nuxtSentry.target.dsn,
+  beforeSend: createBeforeSend(nuxtSentry.server),
+})
+```
+
+## Wide Events
+
+With `@harlan-zw/nuxt-wide-events` installed, two bridges are wired and neither package imports the other.
+
+The Sentry trace identity is written into every request's Wide Event as `sentry.traceId` and `sentry.spanId`, so the two sinks can be joined. The fields are declared through the `wide-events:fields` build hook, so the allowlist stays exhaustive.
+
+With `wideEvents: true` and the Wide Events `drain` option on, a failing Wide Event is forwarded to Sentry Logs. A log, never an error: a Wide Event carries no stack in production, and Sentry already captured the same failure from the same request.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev:prepare
+pnpm test
+```
+
+## License
+
+Licensed under the [MIT license](https://github.com/harlan-zw/harlan-nuxt/blob/main/LICENSE.md).
+
+<!-- Badges -->
+[npm-version-src]: https://img.shields.io/npm/v/@harlan-zw/nuxt-sentry/latest.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-version-href]: https://npmjs.com/package/@harlan-zw/nuxt-sentry
+
+[npm-downloads-src]: https://img.shields.io/npm/dm/@harlan-zw/nuxt-sentry.svg?style=flat&colorA=18181B&colorB=28CF8D
+[npm-downloads-href]: https://npmjs.com/package/@harlan-zw/nuxt-sentry
+
+[license-src]: https://img.shields.io/github/license/harlan-zw/harlan-nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D
+[license-href]: https://github.com/harlan-zw/harlan-nuxt/blob/main/LICENSE.md
+
+[nuxt-src]: https://img.shields.io/badge/Nuxt-18181B?logo=nuxt
+[nuxt-href]: https://nuxt.com

--- a/packages/nuxt-sentry/build.config.ts
+++ b/packages/nuxt-sentry/build.config.ts
@@ -1,0 +1,16 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  failOnWarn: false,
+  entries: ['src/module'],
+  externals: [
+    '#app',
+    '#imports',
+    '@sentry/cloudflare',
+    '@sentry/nuxt',
+    '@sentry/nuxt/module/plugins',
+    'nitropack',
+    'nitropack/runtime',
+    'nitropack/types',
+  ],
+})

--- a/packages/nuxt-sentry/eslint.config.mjs
+++ b/packages/nuxt-sentry/eslint.config.mjs
@@ -1,0 +1,9 @@
+import antfu from '@antfu/eslint-config'
+
+export default antfu({
+  type: 'lib',
+  rules: {
+    'no-console': 'off',
+    'ts/explicit-function-return-type': 'off',
+  },
+})

--- a/packages/nuxt-sentry/index.ts
+++ b/packages/nuxt-sentry/index.ts
@@ -1,0 +1,2 @@
+export { default } from './src/module'
+export type { ModuleOptions } from './src/types'

--- a/packages/nuxt-sentry/nuxt.config.ts
+++ b/packages/nuxt-sentry/nuxt.config.ts
@@ -1,0 +1,8 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  imports: { autoImport: false },
+  nitro: {
+    imports: { autoImport: false },
+  },
+})

--- a/packages/nuxt-sentry/package.json
+++ b/packages/nuxt-sentry/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@harlan-zw/nuxt-sentry",
+  "type": "module",
+  "version": "0.1.0",
+  "description": "One Sentry Report Policy for Nuxt: registration, gating, drop rules, and redaction.",
+  "author": {
+    "name": "Harlan Wilton",
+    "email": "harlan@harlanzw.com",
+    "url": "https://harlanzw.com/"
+  },
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/harlan-zw",
+  "homepage": "https://github.com/harlan-zw/harlan-nuxt/tree/main/packages/nuxt-sentry#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/harlan-zw/harlan-nuxt.git",
+    "directory": "packages/nuxt-sentry"
+  },
+  "bugs": {
+    "url": "https://github.com/harlan-zw/harlan-nuxt/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/types.d.mts",
+      "import": "./dist/module.mjs"
+    },
+    "./server": {
+      "types": "./dist/runtime/server/index.d.ts",
+      "import": "./dist/runtime/server/index.js"
+    }
+  },
+  "main": "./dist/module.mjs",
+  "types": "./dist/types.d.mts",
+  "typesVersions": {
+    "*": {
+      "server": ["dist/runtime/server/index.d.ts"]
+    }
+  },
+  "files": ["dist"],
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "scripts": {
+    "build": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt-module-build build",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare",
+    "prepack": "pnpm run build",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
+    "test:attw": "attw --pack",
+    "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
+  },
+  "peerDependencies": {
+    "@sentry/cloudflare": "catalog:",
+    "@sentry/nuxt": "catalog:",
+    "nuxt": ">=4.5.0 <5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@sentry/cloudflare": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@nuxt/kit": "catalog:",
+    "pathe": "catalog:"
+  },
+  "devDependencies": {
+    "@antfu/eslint-config": "catalog:",
+    "@arethetypeswrong/cli": "catalog:",
+    "@nuxt/module-builder": "catalog:",
+    "@nuxt/schema": "catalog:",
+    "@sentry/cloudflare": "catalog:",
+    "@sentry/nuxt": "catalog:",
+    "@types/node": "catalog:",
+    "eslint": "catalog:",
+    "h3": "catalog:",
+    "nitropack": "catalog:",
+    "nuxt": "catalog:",
+    "typescript": "catalog:",
+    "unbuild": "catalog:",
+    "vitest": "catalog:",
+    "vue": "catalog:"
+  }
+}

--- a/packages/nuxt-sentry/src/build/policy.ts
+++ b/packages/nuxt-sentry/src/build/policy.ts
@@ -1,0 +1,113 @@
+import type {
+  DataCollection,
+  MessagePattern,
+  ReportPolicy,
+  ReportScope,
+  SerializedPattern,
+  StatusRange,
+} from '../runtime/shared/types'
+import { BROWSER_EXTENSION_DENY_URLS, BROWSER_NOISE_MESSAGES } from '../runtime/shared/noise'
+
+/**
+ * Build time resolution of the Report Policy.
+ *
+ * Parse, do not validate. Everything a site writes in `nuxt.config.ts` is
+ * turned into a serialisable shape once, here, and the runtime trusts it.
+ */
+
+export type StatusInput = number | [number, number]
+
+export interface PolicyOptions {
+  dropServerStatus?: StatusInput[] | false
+  dropClientStatus?: StatusInput[] | false
+  dropTransient?: boolean
+  ignoreErrors?: Array<string | RegExp>
+  denyUrls?: RegExp[]
+  browserNoise?: boolean
+  secretKeys?: string[]
+}
+
+/**
+ * Server statuses that never produce an Error Report.
+ *
+ * 404 only, deliberately narrower than the "all 4xx" three sites use. A 401 or
+ * 403 spike is how an auth regression announces itself, and a 429 spike is how
+ * a rate limit does. Dropping the whole class hides both. A 404 is the one 4xx
+ * that a stale link or a crawler produces in normal operation.
+ */
+export const DEFAULT_SERVER_DROP_STATUS: readonly StatusInput[] = [404]
+
+/**
+ * Client statuses that never produce an Error Report.
+ *
+ * 401 and 403 are included here and not on the server. In the browser they are
+ * an expired session racing a redirect to the login page, which the app already
+ * handles. On the server the same status is a real authorisation decision.
+ */
+export const DEFAULT_CLIENT_DROP_STATUS: readonly StatusInput[] = [401, 403, 404]
+
+export function parseStatusRanges(input: readonly StatusInput[]): StatusRange[] {
+  return input.map((entry) => {
+    if (typeof entry === 'number') {
+      assertStatus(entry)
+      return { from: entry, to: entry }
+    }
+    const [from, to] = entry
+    assertStatus(from)
+    assertStatus(to)
+    if (from > to)
+      throw new TypeError(`nuxtSentry status range [${from}, ${to}] must run low to high`)
+    return { from, to }
+  })
+}
+
+function assertStatus(value: number): void {
+  if (!Number.isInteger(value) || value < 100 || value > 599)
+    throw new TypeError(`nuxtSentry status ${value} must be an integer HTTP status`)
+}
+
+export function serializePattern(pattern: RegExp): SerializedPattern {
+  // A global pattern keeps `lastIndex` between calls, so a reused instance
+  // matches every other report. Strip the flag rather than let that through.
+  return { _tag: 'pattern', source: pattern.source, flags: pattern.flags.replace(/[gy]/g, '') }
+}
+
+export function parseMessagePatterns(input: ReadonlyArray<string | RegExp>): MessagePattern[] {
+  return input.map(entry => typeof entry === 'string'
+    ? { _tag: 'literal' as const, value: entry }
+    : serializePattern(entry))
+}
+
+export interface ResolvePolicyInput {
+  scope: ReportScope
+  dataCollection: DataCollection
+  options: PolicyOptions
+}
+
+export function resolveReportPolicy(input: ResolvePolicyInput): ReportPolicy {
+  const { options, scope } = input
+  const browserNoise = options.browserNoise ?? true
+  const configured = scope === 'server' ? options.dropServerStatus : options.dropClientStatus
+  const fallback = scope === 'server' ? DEFAULT_SERVER_DROP_STATUS : DEFAULT_CLIENT_DROP_STATUS
+  const dropStatus = configured === false
+    ? []
+    : parseStatusRanges(configured ?? fallback)
+
+  return {
+    scope,
+    dataCollection: input.dataCollection,
+    dropStatus,
+    dropTransient: options.dropTransient ?? true,
+    ignoreErrors: [
+      // Browser noise applies on both scopes. A server rendered page runs the
+      // same application code, and a Nitro route can raise the same abort.
+      ...(browserNoise ? BROWSER_NOISE_MESSAGES : []),
+      ...parseMessagePatterns(options.ignoreErrors ?? []),
+    ],
+    denyUrls: [
+      ...(browserNoise ? BROWSER_EXTENSION_DENY_URLS : []),
+      ...(options.denyUrls ?? []).map(serializePattern),
+    ],
+    secretKeys: [...(options.secretKeys ?? [])],
+  }
+}

--- a/packages/nuxt-sentry/src/build/sentry-build.ts
+++ b/packages/nuxt-sentry/src/build/sentry-build.ts
@@ -1,0 +1,115 @@
+/**
+ * The `sentry` build option block handed to `@sentry/nuxt/module`.
+ *
+ * That module owns the build plugin, the source map upload and the client entry
+ * injection. This module only decides what it is configured with, so the nine
+ * sites stop holding nine copies of the same block.
+ */
+
+export interface SourceMapEnv {
+  sentryAuthToken?: string
+  /** True when a local `.env.sentry-build-plugin` exists. */
+  hasDotenvFile: boolean
+}
+
+/**
+ * Whether a build can upload a source map.
+ *
+ * A local dotenv file counts. Two sites test `process.env.SENTRY_AUTH_TOKEN`
+ * alone, so a local upload with a dotenv file silently did nothing.
+ */
+export function hasSentryAuthToken(env: SourceMapEnv): boolean {
+  return Boolean(env.sentryAuthToken?.trim()) || env.hasDotenvFile
+}
+
+export interface SentryBuildInput {
+  org: string
+  project?: string
+  release: string
+  sourceMaps: boolean
+  authToken?: string
+  hasAuthToken: boolean
+}
+
+export interface SentryBuildOptions {
+  org: string
+  project?: string
+  authToken?: string
+  release?: { name: string }
+  sourcemaps: {
+    disable: boolean
+    filesToDeleteAfterUpload: string[]
+  }
+  bundleSizeOptimizations: {
+    excludeReplayShadowDom: boolean
+    excludeReplayIframe: boolean
+    excludeReplayWorker: boolean
+  }
+  telemetry: false
+}
+
+export function resolveSentryBuildOptions(input: SentryBuildInput): SentryBuildOptions {
+  return {
+    org: input.org,
+    ...(input.project ? { project: input.project } : {}),
+    ...(input.authToken ? { authToken: input.authToken } : {}),
+    // An unnamed release cannot bind an uploaded map to the events it explains.
+    ...(input.release ? { release: { name: input.release } } : {}),
+    sourcemaps: {
+      disable: !input.sourceMaps || !input.hasAuthToken,
+      filesToDeleteAfterUpload: ['**/*.map'],
+    },
+    // Session Replay is not used anywhere in the estate, and its code is the
+    // largest single part of the browser bundle.
+    bundleSizeOptimizations: {
+      excludeReplayShadowDom: true,
+      excludeReplayIframe: true,
+      excludeReplayWorker: true,
+    },
+    telemetry: false,
+  }
+}
+
+/** A build time finding that must reach the developer before the build ships. */
+export type BuildIssue
+  = | { _tag: 'error', message: string }
+    | { _tag: 'warning', message: string }
+
+export interface BuildCheckInput {
+  sourceMaps: boolean
+  hasAuthToken: boolean
+  project?: string
+  release: string
+  gate: 'release' | 'ci' | 'always'
+  isProduction: boolean
+}
+
+/**
+ * Findings a build must surface.
+ *
+ * A missing project with an auth token present is an error: the upload would
+ * succeed against whichever project the token happens to reach, which is the
+ * exact failure one site wrote a preflight script to catch.
+ */
+export function checkSentryBuild(input: BuildCheckInput): BuildIssue[] {
+  const issues: BuildIssue[] = []
+  if (input.sourceMaps && input.hasAuthToken && !input.project) {
+    issues.push({
+      _tag: 'error',
+      message: 'A Sentry auth token is present and source map upload is on, but nuxtSentry.project is not set. Set the project slug, or set sourceMaps to false.',
+    })
+  }
+  if (input.sourceMaps && input.hasAuthToken && !input.release) {
+    issues.push({
+      _tag: 'warning',
+      message: 'Source maps upload without a release name, so they cannot bind to the reports they explain. Set SENTRY_RELEASE in the deploy workflow.',
+    })
+  }
+  if (input.isProduction && input.gate === 'release' && !input.release) {
+    issues.push({
+      _tag: 'warning',
+      message: 'This production build carries no release identity, so it sends no Error Report. Set SENTRY_RELEASE in the deploy workflow, or set nuxtSentry.gate to "always".',
+    })
+  }
+  return issues
+}

--- a/packages/nuxt-sentry/src/build/target.ts
+++ b/packages/nuxt-sentry/src/build/target.ts
@@ -1,0 +1,135 @@
+import type {
+  EnvironmentPolicy,
+  ReportTarget,
+  SampleRatePolicy,
+} from '../runtime/shared/types'
+
+/**
+ * Build time resolution of the Report Target.
+ *
+ * Every input arrives as an argument. Nothing here reads `process.env`, so the
+ * whole gate is one pure function a test can drive.
+ */
+
+/** Who may send an Error Report. */
+export type ReportGate = 'release' | 'ci' | 'always'
+
+export interface BuildEnv {
+  nodeEnv?: string
+  sentryRelease?: string
+  githubSha?: string
+  vercelGitCommitSha?: string
+  sentryEnvironment?: string
+  ci?: string
+}
+
+export interface TargetInput {
+  enabled: boolean
+  dsn: string
+  gate: ReportGate
+  environment: string | Record<string, string>
+  tracesSampleRate: number | Record<string, number>
+  app?: string
+  logs: boolean
+  workerVersionBinding: string | false
+  env: BuildEnv
+}
+
+/**
+ * GitHub Actions sets `CI=true`, other runners use `1` or `yes`.
+ *
+ * Only an explicit falsy spelling counts as "not CI", so a runner that exports
+ * an empty `CI` does not silently disable reporting.
+ */
+export function isCiBuild(ci: string | undefined): boolean {
+  if (!ci)
+    return false
+  const normalized = ci.trim().toLowerCase()
+  return normalized !== '' && normalized !== 'false' && normalized !== '0'
+}
+
+/**
+ * The release identity this build carries.
+ *
+ * `GITHUB_SHA` is a fallback, not the answer. On a `workflow_run` event it is
+ * the default branch tip rather than the commit that was built, so a deploy
+ * workflow must export `SENTRY_RELEASE` from `github.event.workflow_run.head_sha`.
+ *
+ * `VERCEL_GIT_COMMIT_SHA` covers a site built by Vercel rather than by a GitHub
+ * runner. Without it a Vercel deploy carries no release and the default gate
+ * silences the whole site.
+ */
+export function resolveRelease(env: BuildEnv): string {
+  return (env.sentryRelease || env.githubSha || env.vercelGitCommitSha || '').trim()
+}
+
+/**
+ * Parse the environment option into a policy both scopes can read.
+ *
+ * A string names every deployment. A record maps a host prefix to a name, which
+ * is how a staging deployment is split from production without a second Sentry
+ * project. The server has no hostname, so `SENTRY_ENVIRONMENT` names it there.
+ */
+export function resolveEnvironmentPolicy(
+  environment: string | Record<string, string>,
+  env: BuildEnv,
+): EnvironmentPolicy {
+  const override = env.sentryEnvironment?.trim()
+  if (typeof environment === 'string')
+    return { fallback: override || environment, hostPrefixes: [] }
+
+  const hostPrefixes = Object.entries(environment)
+    .map(([prefix, name]) => ({ prefix, name }))
+    // Longest prefix first, so `staging.api.` wins over `staging.`.
+    .toSorted((a, b) => b.prefix.length - a.prefix.length)
+  return { fallback: override || 'production', hostPrefixes }
+}
+
+export function resolveSampleRatePolicy(rate: number | Record<string, number>): SampleRatePolicy {
+  if (typeof rate === 'number') {
+    if (!Number.isFinite(rate) || rate < 0 || rate > 1)
+      throw new TypeError('nuxtSentry.tracesSampleRate must be between 0 and 1')
+    return { fallback: rate, byEnvironment: {} }
+  }
+  for (const [name, value] of Object.entries(rate)) {
+    if (!Number.isFinite(value) || value < 0 || value > 1)
+      throw new TypeError(`nuxtSentry.tracesSampleRate.${name} must be between 0 and 1`)
+  }
+  return { fallback: rate.production ?? 0, byEnvironment: { ...rate } }
+}
+
+/**
+ * Whether this build may report, and under what identity.
+ *
+ * The gates run in a fixed order, and the first failure names itself. Ordering
+ * `option` and `no-dsn` before the build shape keeps a deliberate opt out from
+ * being reported as a broken deploy.
+ */
+export function resolveReportTarget(input: TargetInput): ReportTarget {
+  if (!input.enabled)
+    return { _tag: 'disabled', reason: 'option' }
+
+  const dsn = input.dsn.trim()
+  if (!dsn)
+    return { _tag: 'disabled', reason: 'no-dsn' }
+
+  if (input.env.nodeEnv !== 'production')
+    return { _tag: 'disabled', reason: 'not-production' }
+
+  const release = resolveRelease(input.env)
+  if (input.gate === 'release' && !release)
+    return { _tag: 'disabled', reason: 'no-release' }
+  if (input.gate === 'ci' && !isCiBuild(input.env.ci))
+    return { _tag: 'disabled', reason: 'not-ci' }
+
+  return {
+    _tag: 'enabled',
+    dsn,
+    release,
+    environment: resolveEnvironmentPolicy(input.environment, input.env),
+    tracesSampleRate: resolveSampleRatePolicy(input.tracesSampleRate),
+    app: input.app?.trim() || null,
+    logs: input.logs,
+    workerVersionBinding: input.workerVersionBinding === false ? null : input.workerVersionBinding,
+  }
+}

--- a/packages/nuxt-sentry/src/module.ts
+++ b/packages/nuxt-sentry/src/module.ts
@@ -1,0 +1,217 @@
+import type { Nuxt } from '@nuxt/schema'
+import type { SentryRuntimeConfig } from './runtime/shared/types'
+import type { ModuleOptions } from './types'
+import { existsSync } from 'node:fs'
+import process from 'node:process'
+import { addPlugin, addServerPlugin, createResolver, defineNuxtModule, hasNuxtModule, useLogger } from '@nuxt/kit'
+import { resolve } from 'pathe'
+import { resolveReportPolicy } from './build/policy'
+import { checkSentryBuild, hasSentryAuthToken, resolveSentryBuildOptions } from './build/sentry-build'
+import { resolveRelease, resolveReportTarget } from './build/target'
+
+export type { ModuleOptions } from './types'
+
+const MODULE_NAME = '@harlan-zw/nuxt-sentry'
+
+/** Wide Event fields this module populates, so the allowlist stays exhaustive. */
+const WIDE_EVENT_FIELDS = ['sentry.traceId', 'sentry.spanId'] as const
+
+interface NitroConfigLike {
+  preset?: string
+  plugins?: string[]
+}
+
+/**
+ * A Cloudflare Workers preset needs `@sentry/cloudflare`, which the Node SDK
+ * cannot replace and which cannot be bundled into a Node build.
+ */
+function isCloudflarePreset(preset: string | undefined): boolean {
+  return Boolean(preset?.startsWith('cloudflare'))
+}
+
+export default defineNuxtModule<ModuleOptions>({
+  meta: {
+    // Declared so `@harlan-zw/nuxt-dx` attributes the registered plugins to
+    // this package. Today every site registers an anonymous
+    // `server/plugins/sentry.ts`, so the bundle entry has no owner and the
+    // size budget override has to be copied into each app.
+    name: MODULE_NAME,
+    configKey: 'nuxtSentry',
+    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+  },
+  defaults: {
+    enabled: true,
+    dsn: '',
+    org: 'harlan-zw',
+    // A release identity is the proof that a deploy produced this build.
+    // `nuxt preview` and `wrangler dev` both run a production build with
+    // NODE_ENV=production, so NODE_ENV alone let a laptop file issues against
+    // the live project.
+    gate: 'release',
+    environment: 'production',
+    tracesSampleRate: 0.05,
+    // Richer reports, then redaction. The Redaction Rules are what make this
+    // safe, and they run on every report under both settings.
+    dataCollection: 'scrubbed',
+    sourceMaps: true,
+    logs: false,
+    workerVersionBinding: 'CF_VERSION_METADATA',
+    wideEvents: false,
+  },
+  setup(options, nuxt) {
+    const logger = useLogger(MODULE_NAME)
+    if (options.enabled === false)
+      return
+
+    const resolver = createResolver(import.meta.url)
+    const env = {
+      nodeEnv: process.env.NODE_ENV,
+      sentryRelease: process.env.SENTRY_RELEASE,
+      githubSha: process.env.GITHUB_SHA,
+      vercelGitCommitSha: process.env.VERCEL_GIT_COMMIT_SHA,
+      sentryEnvironment: process.env.SENTRY_ENVIRONMENT,
+      ci: process.env.CI,
+    }
+
+    const target = resolveReportTarget({
+      enabled: true,
+      dsn: options.dsn ?? '',
+      gate: options.gate ?? 'release',
+      environment: options.environment ?? 'production',
+      tracesSampleRate: options.tracesSampleRate ?? 0.05,
+      app: options.app,
+      logs: options.logs ?? false,
+      workerVersionBinding: options.workerVersionBinding ?? 'CF_VERSION_METADATA',
+      env,
+    })
+
+    // Nothing to configure without a DSN, and warning about a release the site
+    // never asked for would be noise. `enabled: false` took the same road above.
+    if (target._tag === 'disabled' && target.reason === 'no-dsn') {
+      logger.info('No nuxtSentry.dsn is set, so no Error Report is sent and no Sentry build option is written.')
+      return
+    }
+
+    const dataCollection = options.dataCollection ?? 'scrubbed'
+    const runtime: SentryRuntimeConfig = {
+      target,
+      client: resolveReportPolicy({ scope: 'client', dataCollection, options: options.policy ?? {} }),
+      server: resolveReportPolicy({ scope: 'server', dataCollection, options: options.policy ?? {} }),
+    }
+
+    // Public, because the client plugin reads it. Nothing here is a secret: the
+    // DSN ships in the browser bundle by design, and the policy is a rule list.
+    const publicConfig = nuxt.options.runtimeConfig.public as Record<string, unknown>
+    publicConfig.nuxtSentry = runtime
+
+    const sourceMaps = options.sourceMaps ?? true
+    const authTokenPresent = hasSentryAuthToken({
+      sentryAuthToken: process.env.SENTRY_AUTH_TOKEN,
+      hasDotenvFile: existsSync(resolve(nuxt.options.rootDir, '.env.sentry-build-plugin')),
+    })
+    const release = resolveRelease(env)
+
+    for (const issue of checkSentryBuild({
+      sourceMaps,
+      hasAuthToken: authTokenPresent,
+      project: options.project,
+      release,
+      gate: options.gate ?? 'release',
+      isProduction: env.nodeEnv === 'production',
+    })) {
+      if (issue._tag === 'error')
+        throw new Error(`[${MODULE_NAME}] ${issue.message}`)
+      logger.warn(issue.message)
+    }
+
+    // `@sentry/nuxt/module` still owns the build plugin, the source map upload
+    // and the client entry injection. This module only decides its settings.
+    const nuxtOptions = nuxt.options as unknown as { sentry?: Record<string, unknown> }
+    nuxtOptions.sentry = {
+      ...resolveSentryBuildOptions({
+        org: options.org ?? 'harlan-zw',
+        project: options.project,
+        release,
+        sourceMaps,
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        hasAuthToken: authTokenPresent,
+      }),
+      ...nuxtOptions.sentry,
+    }
+
+    if (sourceMaps && authTokenPresent) {
+      // `hidden` emits the map and keeps the comment out of the served bundle.
+      // `sourcemap.server` is left alone: `@harlan-zw/nuxt-cloudflare` derives
+      // `upload_source_maps` from it, and turning it on here would change a
+      // Wrangler file this module does not own.
+      nuxt.options.sourcemap.client = 'hidden'
+    }
+
+    if (target._tag === 'disabled') {
+      logger.info(`No Error Report is sent from this build. ${describeReason(target.reason)}`)
+      return
+    }
+
+    addPlugin({ src: resolver.resolve('./runtime/app/plugins/sentry.client'), mode: 'client' })
+
+    const nitro = ((nuxt.options as unknown as { nitro?: NitroConfigLike }).nitro ??= {})
+    const cloudflare = isCloudflarePreset(nitro.preset)
+    if (cloudflare) {
+      addServerPlugin(resolver.resolve('./runtime/server/plugins/sentry-cloudflare'))
+    }
+    else {
+      logger.warn('The Nitro preset is not a Cloudflare one, so this module registers no server plugin. Keep the site\'s own sentry.server.config.ts and build it with createBeforeSend from @harlan-zw/nuxt-sentry/server.')
+    }
+
+    registerWideEvents(nuxt, options, resolver, cloudflare)
+  },
+})
+
+function describeReason(reason: string): string {
+  switch (reason) {
+    case 'no-dsn':
+      return 'No nuxtSentry.dsn is set.'
+    case 'not-production':
+      return 'This build is not a production build.'
+    case 'no-release':
+      return 'This build carries no release identity. Set SENTRY_RELEASE in the deploy workflow, or set nuxtSentry.gate to "always".'
+    case 'not-ci':
+      return 'This build was not produced in CI.'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Wire the two directions this module shares with `@harlan-zw/nuxt-wide-events`.
+ *
+ * Neither package imports the other. The field declaration goes through the
+ * `wide-events:fields` build hook, which never fires when that module is
+ * absent, and the drain plugin is registered only when it is present.
+ */
+function registerWideEvents(
+  nuxt: Nuxt,
+  options: ModuleOptions,
+  resolver: ReturnType<typeof createResolver>,
+  cloudflare: boolean,
+): void {
+  const declareFields = nuxt.hook as unknown as (
+    name: 'wide-events:fields',
+    callback: (registry: { add: (moduleName: string, fields: readonly string[]) => void }) => void,
+  ) => void
+  declareFields('wide-events:fields', (registry) => {
+    registry.add(MODULE_NAME, [...WIDE_EVENT_FIELDS])
+  })
+
+  // Both plugins read the Sentry trace through `@sentry/cloudflare`, so they
+  // only resolve on a Cloudflare build.
+  if (!cloudflare)
+    return
+  // `hasNuxtModule` reads `nuxt.options.modules` without checking it first.
+  if (!Array.isArray(nuxt.options.modules) || !hasNuxtModule('@harlan-zw/nuxt-wide-events', nuxt))
+    return
+
+  addServerPlugin(resolver.resolve('./runtime/server/plugins/wide-events-correlation'))
+  if (options.wideEvents)
+    addServerPlugin(resolver.resolve('./runtime/server/plugins/wide-events-drain'))
+}

--- a/packages/nuxt-sentry/src/runtime/app/plugins/sentry.client.ts
+++ b/packages/nuxt-sentry/src/runtime/app/plugins/sentry.client.ts
@@ -1,0 +1,59 @@
+import type { SentryRuntimeConfig } from '../../shared/types'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore resolved from the site's own `@sentry/nuxt`, a required peer.
+import * as Sentry from '@sentry/nuxt'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore resolved by Nuxt in the consuming application.
+import { defineNuxtPlugin, useRuntimeConfig } from '#app'
+import {
+  createBeforeSend,
+  createClientNoiseOptions,
+  createSentryDataCollection,
+  resolveClientTarget,
+  resolveEnvironment,
+  resolveTracesSampleRate,
+} from '../../shared/policy'
+
+/**
+ * Browser side Sentry.
+ *
+ * Registered by the module from inside this package, so the DSN is read from
+ * `runtimeConfig` rather than repeated as a literal. One site carried a comment
+ * saying its client DSN "must match" the one in `nuxt.config.ts`, which is a
+ * manual invariant a shared module removes.
+ *
+ * `enforce: 'pre'` runs this before the application's own plugins. An error
+ * thrown by the framework entry before any plugin runs is still missed, which
+ * is the cost of registering from a module rather than injecting an entry file.
+ */
+export default defineNuxtPlugin({
+  name: 'nuxt-sentry:client',
+  enforce: 'pre',
+  setup() {
+    const config = (useRuntimeConfig().public as Record<string, unknown>).nuxtSentry as SentryRuntimeConfig | undefined
+    if (!config)
+      return
+
+    const target = resolveClientTarget(config.target, window.location.hostname)
+    if (target._tag !== 'enabled')
+      return
+
+    const policy = config.client
+    const environment = resolveEnvironment(target.environment, window.location.hostname)
+    const noise = createClientNoiseOptions(policy)
+
+    Sentry.init({
+      dsn: target.dsn,
+      environment,
+      ...(target.release ? { release: target.release } : {}),
+      tracesSampleRate: resolveTracesSampleRate(target.tracesSampleRate, environment),
+      ...(policy.dataCollection === 'none'
+        ? { dataCollection: createSentryDataCollection() }
+        : { sendDefaultPii: true }),
+      ...(target.app ? { initialScope: { tags: { app: target.app } } } : {}),
+      ignoreErrors: noise.ignoreErrors,
+      denyUrls: noise.denyUrls,
+      beforeSend: createBeforeSend(policy),
+    })
+  },
+})

--- a/packages/nuxt-sentry/src/runtime/server/attribution.ts
+++ b/packages/nuxt-sentry/src/runtime/server/attribution.ts
@@ -1,0 +1,53 @@
+/**
+ * Cloudflare Worker version attribution.
+ *
+ * A release identity names the source commit. It does not name the Worker
+ * version that actually served the request, and a rollback or a gradual
+ * deployment makes those two different things. The `CF_VERSION_METADATA`
+ * binding carries the version, and six of the nine deployments already have it.
+ */
+
+export interface WorkerAttribution {
+  tags: {
+    worker_version: string
+    worker_version_tag?: string
+  }
+  context: {
+    id: string
+    tag: string | null
+    uploaded_at: string | null
+  }
+}
+
+interface VersionMetadataLike {
+  id?: unknown
+  tag?: unknown
+  timestamp?: unknown
+}
+
+/**
+ * Parse the binding into attribution, or return `null` when it is absent.
+ *
+ * The binding is untrusted here: it is missing on any deployment that never
+ * declared it, and `wrangler dev` supplies a placeholder. Parsing once at this
+ * boundary keeps every caller free of the checks.
+ */
+export function resolveWorkerAttribution(metadata: unknown): WorkerAttribution | null {
+  if (!metadata || typeof metadata !== 'object')
+    return null
+  const value = metadata as VersionMetadataLike
+  if (typeof value.id !== 'string' || !value.id)
+    return null
+  const tag = typeof value.tag === 'string' && value.tag ? value.tag : null
+  return {
+    tags: {
+      worker_version: value.id,
+      ...(tag ? { worker_version_tag: tag } : {}),
+    },
+    context: {
+      id: value.id,
+      tag,
+      uploaded_at: typeof value.timestamp === 'string' ? value.timestamp : null,
+    },
+  }
+}

--- a/packages/nuxt-sentry/src/runtime/server/index.ts
+++ b/packages/nuxt-sentry/src/runtime/server/index.ts
@@ -1,0 +1,61 @@
+/**
+ * The Report Policy, for code this module does not register.
+ *
+ * Two callers need it. A queue Sentry client, which `@harlan-zw/nuxt-cf-jobs`
+ * owns through `runWithQueueSentry`, must apply the same rules as the request
+ * client or a background failure is filtered differently from a foreground one.
+ * A non Cloudflare site keeps its own `sentry.server.config.ts` and builds its
+ * `beforeSend` from here.
+ */
+
+export {
+  decideReport,
+  errorChain,
+  errorStatusCode,
+  isTransientError,
+  matchesStatus,
+} from '../shared/drop'
+export {
+  applyReportPolicy,
+  createBeforeSend,
+  createClientNoiseOptions,
+  createSentryDataCollection,
+  describeDisabledTarget,
+  isLocalReportingHost,
+  resolveClientTarget,
+  resolveEnvironment,
+  resolveTracesSampleRate,
+} from '../shared/policy'
+export {
+  isSecretKey,
+  REDACTED,
+  redactErrorReport,
+  redactText,
+  redactValue,
+} from '../shared/redact'
+export type {
+  DataCollection,
+  DropRuleName,
+  EnvironmentPolicy,
+  ErrorReport,
+  ErrorReportHint,
+  MessagePattern,
+  ReportDecision,
+  ReportDisabledReason,
+  ReportPolicy,
+  ReportScope,
+  ReportTarget,
+  SampleRatePolicy,
+  SentryRuntimeConfig,
+  SerializedPattern,
+  StatusRange,
+} from '../shared/types'
+export type { WorkerAttribution } from './attribution'
+export { resolveWorkerAttribution } from './attribution'
+export type {
+  DrainedWideEvent,
+  SentryCorrelation,
+  WideEventLogDecision,
+  WideEventLogLevel,
+} from './wide-events'
+export { decideWideEventLog, parseSentryCorrelation } from './wide-events'

--- a/packages/nuxt-sentry/src/runtime/server/plugins/sentry-cloudflare.ts
+++ b/packages/nuxt-sentry/src/runtime/server/plugins/sentry-cloudflare.ts
@@ -1,0 +1,70 @@
+import type { NitroApp } from 'nitropack/types'
+import type { SentryRuntimeConfig } from '../../shared/types'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore optional peer. `@sentry/cloudflare` is only resolved on a
+// Cloudflare build, which is the only build that registers this plugin.
+import { consoleLoggingIntegration, setContext, setTags } from '@sentry/cloudflare'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore optional peer, resolved from the site's own `@sentry/nuxt`.
+import { sentryCloudflareNitroPlugin } from '@sentry/nuxt/module/plugins'
+import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
+import {
+  createBeforeSend,
+  createSentryDataCollection,
+  resolveEnvironment,
+  resolveTracesSampleRate,
+} from '../../shared/policy'
+import { resolveWorkerAttribution } from '../attribution'
+
+/**
+ * Server side Sentry on Cloudflare Workers.
+ *
+ * The default `sentry.server.config.ts` is Node based and cannot run on
+ * Workers, so this Nitro plugin, backed by `@sentry/cloudflare`, is the
+ * supported replacement. It wraps `nitroApp.localFetch` for per request
+ * isolation and hooks Nitro's `error` event to capture unhandled errors.
+ *
+ * Registered by the module from inside this package, which is what lets
+ * `@harlan-zw/nuxt-dx` attribute the bundle entry to `@harlan-zw/nuxt-sentry`.
+ * Nothing here decides policy. Every decision is a pure function in
+ * `../../shared`, and this file only calls Sentry with the result.
+ */
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  const config = (useRuntimeConfig().public as Record<string, unknown>).nuxtSentry as SentryRuntimeConfig | undefined
+  if (!config || config.target._tag !== 'enabled')
+    return
+
+  const { target, server: policy } = config
+  const environment = resolveEnvironment(target.environment)
+
+  sentryCloudflareNitroPlugin({
+    dsn: target.dsn,
+    environment,
+    ...(target.release ? { release: target.release } : {}),
+    tracesSampleRate: resolveTracesSampleRate(target.tracesSampleRate, environment),
+    ...(policy.dataCollection === 'none'
+      ? { dataCollection: createSentryDataCollection() }
+      : { sendDefaultPii: true }),
+    ...(target.logs
+      ? { enableLogs: true, integrations: [consoleLoggingIntegration({ levels: ['warn', 'error'] })] }
+      : {}),
+    ...(target.app ? { initialScope: { tags: { app: target.app } } } : {}),
+    beforeSend: createBeforeSend(policy),
+  })(nitroApp)
+
+  if (!target.workerVersionBinding)
+    return
+
+  // The isolation scope exists by the time Nitro runs request hooks, so tagging
+  // here makes every request error attributable to the exact Worker version as
+  // well as to its source release.
+  const binding = target.workerVersionBinding
+  nitroApp.hooks.hook('request', (event) => {
+    const env = (event.context as { cloudflare?: { env?: Record<string, unknown> } }).cloudflare?.env
+    const attribution = resolveWorkerAttribution(env?.[binding])
+    if (!attribution)
+      return
+    setTags(attribution.tags)
+    setContext('cloudflare_worker_version', attribution.context)
+  })
+})

--- a/packages/nuxt-sentry/src/runtime/server/plugins/wide-events-correlation.ts
+++ b/packages/nuxt-sentry/src/runtime/server/plugins/wide-events-correlation.ts
@@ -1,0 +1,32 @@
+import type { NitroApp } from 'nitropack/types'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore optional peer. Registered only on a Cloudflare build with
+// `@harlan-zw/nuxt-wide-events` installed.
+import { getTraceData } from '@sentry/cloudflare'
+import { defineNitroPlugin } from 'nitropack/runtime'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore auto import contributed by `@harlan-zw/nuxt-wide-events`.
+import { addWideEventFields } from '#imports'
+import { parseSentryCorrelation } from '../wide-events'
+
+/**
+ * Write the Sentry trace identity into the request's Wide Event.
+ *
+ * Two fields, so a Wide Event and an Error Report for the same request can be
+ * joined. Without them the two sinks hold two halves of one failure with no key
+ * between them.
+ *
+ * The single object literal is load bearing. `@harlan-zw/nuxt-wide-events`
+ * parses every server file at build time and rejects an `addWideEventFields`
+ * call whose argument is not an object literal, so every key is present on
+ * every call and `null` where the value is unavailable.
+ */
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  nitroApp.hooks.hook('request', () => {
+    const correlation = parseSentryCorrelation(getTraceData())
+    addWideEventFields({
+      'sentry.traceId': correlation['sentry.traceId'],
+      'sentry.spanId': correlation['sentry.spanId'],
+    })
+  })
+})

--- a/packages/nuxt-sentry/src/runtime/server/plugins/wide-events-drain.ts
+++ b/packages/nuxt-sentry/src/runtime/server/plugins/wide-events-drain.ts
@@ -1,0 +1,26 @@
+import type { NitroApp } from 'nitropack/types'
+import type { DrainedWideEvent } from '../wide-events'
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-ignore optional peer. Registered only on a Cloudflare build with
+// `@harlan-zw/nuxt-wide-events` installed.
+import { logger } from '@sentry/cloudflare'
+import { defineNitroPlugin } from 'nitropack/runtime'
+import { decideWideEventLog } from '../wide-events'
+
+/**
+ * Forward a failing Wide Event to Sentry Logs.
+ *
+ * A log, never an error. The Wide Event has no stack in production, so it could
+ * not make a useful Error Report, and sending one would double count a failure
+ * Sentry already captured from the same request.
+ */
+export default defineNitroPlugin((nitroApp: NitroApp) => {
+  // eslint-disable-next-line ts/ban-ts-comment
+  // @ts-ignore the hook is declared by `@harlan-zw/nuxt-wide-events`.
+  nitroApp.hooks.hook('wide-events:emit', (record: DrainedWideEvent) => {
+    const decision = decideWideEventLog(record)
+    if (decision._tag === 'skip')
+      return
+    logger[decision.level](decision.message, decision.attributes)
+  })
+})

--- a/packages/nuxt-sentry/src/runtime/server/wide-events.ts
+++ b/packages/nuxt-sentry/src/runtime/server/wide-events.ts
@@ -1,0 +1,77 @@
+/**
+ * The two directions this module shares with `@harlan-zw/nuxt-wide-events`.
+ *
+ * The two packages keep different halves of the same failure and must not
+ * duplicate each other. `nuxt-wide-events` discards the error object in
+ * production and keeps only a level, so a Sentry report cannot be built from a
+ * Wide Event. Sentry keeps the exception, the stack and the request scope.
+ *
+ * So Sentry never reads a Wide Event to build a report. It reads one to emit a
+ * LOG, which is a separate quota, and it writes the trace identity back so a
+ * Wide Event and a Sentry report can be joined.
+ */
+
+/** The Wide Event record shape this module reads. Structural, so no import is needed. */
+export interface DrainedWideEvent {
+  level?: string
+  service?: string
+  name?: string
+  [key: string]: unknown
+}
+
+export type WideEventLogLevel = 'warn' | 'error'
+
+export type WideEventLogDecision
+  = | { _tag: 'skip' }
+    | { _tag: 'log', level: WideEventLogLevel, message: string, attributes: Record<string, unknown> }
+
+/**
+ * Whether a drained Wide Event becomes a Sentry log.
+ *
+ * Only a failing record. A successful request is already a Wide Event in the
+ * site's own sink, and mirroring every one of them into Sentry Logs would spend
+ * the byte quota on records nobody reads.
+ */
+export function decideWideEventLog(record: DrainedWideEvent): WideEventLogDecision {
+  const level = record.level
+  if (level !== 'error' && level !== 'warn')
+    return { _tag: 'skip' }
+
+  const name = typeof record.name === 'string' && record.name ? record.name : 'wide-event'
+  const attributes: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'level' || key === 'name')
+      continue
+    if (value === null || ['string', 'number', 'boolean'].includes(typeof value))
+      attributes[key] = value
+  }
+  return { _tag: 'log', level, message: name, attributes }
+}
+
+/** The Wide Event fields this module populates. Must match the build hook declaration. */
+export interface SentryCorrelation {
+  'sentry.traceId': string | null
+  'sentry.spanId': string | null
+}
+
+interface TraceDataLike {
+  'sentry-trace'?: unknown
+}
+
+/**
+ * Parse `getTraceData()` into the two correlation fields.
+ *
+ * The SDK returns a `sentry-trace` header, `<traceId>-<spanId>-<sampled>`.
+ * Reading it rather than the span object keeps this a pure string parse that a
+ * test can drive without a live Sentry client.
+ */
+export function parseSentryCorrelation(traceData: unknown): SentryCorrelation {
+  const header = (traceData as TraceDataLike | undefined)?.['sentry-trace']
+  if (typeof header !== 'string')
+    return { 'sentry.traceId': null, 'sentry.spanId': null }
+  const [traceId, spanId] = header.split('-')
+  return {
+    'sentry.traceId': traceId || null,
+    'sentry.spanId': spanId || null,
+  }
+}

--- a/packages/nuxt-sentry/src/runtime/shared/drop.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/drop.ts
@@ -1,0 +1,169 @@
+import type {
+  ErrorReport,
+  MessagePattern,
+  ReportDecision,
+  ReportPolicy,
+  SerializedPattern,
+  StatusRange,
+} from './types'
+
+/**
+ * Drop Rules. Every function here is pure: it reads an Error Report and an
+ * error, and returns a decision. Nothing calls Sentry.
+ */
+
+/** A cyclic `cause` chain must not loop, and a deep one is never informative. */
+const MAX_CAUSE_DEPTH = 8
+
+interface ErrorLike {
+  name?: unknown
+  message?: unknown
+  statusCode?: unknown
+  status?: unknown
+  data?: unknown
+  response?: unknown
+  cause?: unknown
+}
+
+/**
+ * Every link of an error's `cause` chain, the error itself first.
+ *
+ * A Nitro handler wraps an upstream failure, so the status that decides the
+ * Drop Rule is often two links down. Reading only the outer error is the bug
+ * `mdream.dev` and `unlighthouse.dev` each worked around by message matching.
+ */
+export function errorChain(error: unknown): ErrorLike[] {
+  const chain: ErrorLike[] = []
+  const seen = new Set<object>()
+  let current = error
+  while (current && typeof current === 'object' && !seen.has(current) && chain.length < MAX_CAUSE_DEPTH) {
+    seen.add(current)
+    const link = current as ErrorLike
+    chain.push(link)
+    current = link.cause
+  }
+  return chain
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * The HTTP status an error carries, across every shape these sites produce:
+ * `statusCode` on an H3Error, `status` on a fetch failure, `data.statusCode` on
+ * a NuxtError serialised across the SSR boundary, and `response.status` on an
+ * ofetch error.
+ */
+export function errorStatusCode(error: unknown): number | undefined {
+  for (const link of errorChain(error)) {
+    const data = link.data as { statusCode?: unknown } | null | undefined
+    const response = link.response as { status?: unknown } | null | undefined
+    const status = numberOrUndefined(link.statusCode)
+      ?? numberOrUndefined(link.status)
+      ?? numberOrUndefined(data?.statusCode)
+      ?? numberOrUndefined(response?.status)
+    if (status !== undefined)
+      return status
+  }
+  return undefined
+}
+
+export function matchesStatus(status: number | undefined, ranges: readonly StatusRange[]): boolean {
+  if (status === undefined)
+    return false
+  return ranges.some(range => status >= range.from && status <= range.to)
+}
+
+const TRANSIENT_NAMES = new Set(['TimeoutError', 'AbortError'])
+const TRANSIENT_MESSAGE = /aborted due to timeout|operation was aborted|the user aborted a request|signal is aborted without reason|<no response>/i
+
+/**
+ * A transient upstream or network failure.
+ *
+ * The remote host was slow, unreachable, or the request was cancelled by a
+ * navigation. None of those is a defect in the site, and every one of them
+ * arrives in volume during an outage, which is exactly when the error quota
+ * matters most.
+ */
+export function isTransientError(error: unknown): boolean {
+  const chain = errorChain(error)
+  if (chain.some(link => typeof link.name === 'string' && TRANSIENT_NAMES.has(link.name)))
+    return true
+  return chain.some(link => typeof link.message === 'string' && TRANSIENT_MESSAGE.test(link.message))
+}
+
+/** Rebuild a serialised pattern. Called once per plugin start, not per report. */
+export function compilePattern(pattern: SerializedPattern): RegExp {
+  return new RegExp(pattern.source, pattern.flags)
+}
+
+export function matchesMessage(text: string, patterns: readonly MessagePattern[]): boolean {
+  return patterns.some(pattern => pattern._tag === 'literal'
+    ? text.includes(pattern.value)
+    : compilePattern(pattern).test(text))
+}
+
+/** Every free text field of a report that an ignore pattern is matched against. */
+export function reportMessages(report: ErrorReport, error: unknown): string[] {
+  const texts: string[] = []
+  if (typeof report.message === 'string')
+    texts.push(report.message)
+  for (const value of report.exception?.values ?? []) {
+    if (typeof value.type === 'string' && typeof value.value === 'string')
+      texts.push(`${value.type}: ${value.value}`)
+    else if (typeof value.value === 'string')
+      texts.push(value.value)
+    else if (typeof value.type === 'string')
+      texts.push(value.type)
+  }
+  for (const link of errorChain(error)) {
+    if (typeof link.name === 'string' && typeof link.message === 'string')
+      texts.push(`${link.name}: ${link.message}`)
+    else if (typeof link.message === 'string')
+      texts.push(link.message)
+  }
+  return texts
+}
+
+/** Every stack frame file name a deny rule is matched against. */
+export function reportSourceUrls(report: ErrorReport): string[] {
+  const urls: string[] = []
+  for (const value of report.exception?.values ?? []) {
+    for (const frame of value.stacktrace?.frames ?? []) {
+      if (typeof frame.filename === 'string')
+        urls.push(frame.filename)
+    }
+  }
+  return urls
+}
+
+/**
+ * Run every Drop Rule in order and say which one fired.
+ *
+ * The rule name is part of the result rather than a boolean, so a site can log
+ * why a report never arrived. Silently returning `null` from `beforeSend` is
+ * what made the estate's existing filters impossible to debug.
+ */
+export function decideReport(report: ErrorReport, error: unknown, policy: ReportPolicy): ReportDecision {
+  if (matchesStatus(errorStatusCode(error), policy.dropStatus))
+    return { _tag: 'drop', rule: 'status' }
+
+  if (policy.dropTransient && isTransientError(error))
+    return { _tag: 'drop', rule: 'transient' }
+
+  if (policy.ignoreErrors.length > 0) {
+    const texts = reportMessages(report, error)
+    if (texts.some(text => matchesMessage(text, policy.ignoreErrors)))
+      return { _tag: 'drop', rule: 'ignore-message' }
+  }
+
+  if (policy.denyUrls.length > 0) {
+    const patterns = policy.denyUrls.map(compilePattern)
+    const urls = reportSourceUrls(report)
+    if (urls.length > 0 && urls.every(url => patterns.some(pattern => pattern.test(url))))
+      return { _tag: 'drop', rule: 'deny-url' }
+  }
+
+  return { _tag: 'send' }
+}

--- a/packages/nuxt-sentry/src/runtime/shared/noise.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/noise.ts
@@ -1,0 +1,89 @@
+import type { LiteralPattern, MessagePattern, SerializedPattern } from './types'
+
+/**
+ * Browser noise the estate already agreed is non-actionable.
+ *
+ * Every entry here was written down by at least one site with a reason next to
+ * it. Nothing was invented for this module.
+ */
+
+function literal(value: string): LiteralPattern {
+  return { _tag: 'literal', value }
+}
+
+function pattern(source: string, flags = 'i'): SerializedPattern {
+  return { _tag: 'pattern', source, flags }
+}
+
+/**
+ * A visitor on the previous deploy asking for a hashed chunk that is gone.
+ *
+ * Exported on its own because these three are the only entries all nine sites
+ * already carried, so a site that turns the rest of the noise list off still
+ * wants them.
+ */
+export const STALE_CHUNK_MESSAGES: readonly SerializedPattern[] = [
+  pattern('Failed to fetch dynamically imported module'),
+  pattern('error loading dynamically imported module'),
+  pattern('Importing a module script failed'),
+]
+
+/**
+ * Messages that never produce an Error Report on either scope.
+ *
+ * Four groups, and each one fails for a reason outside the site.
+ *
+ * Browser extensions and injected scripts. The page did not load the code that
+ * threw, and no change to the site can stop it.
+ *
+ * Page teardown and benign browser warnings. `ResizeObserver loop` is a browser
+ * scheduling notice, not an exception.
+ *
+ * Stale chunk loads. A visitor still on the previous deploy asks for a hashed
+ * chunk that no longer exists. The reload handles it.
+ *
+ * Cancelled requests. A navigation aborts an in flight fetch, which is the
+ * expected outcome of leaving a page.
+ */
+export const BROWSER_NOISE_MESSAGES: readonly MessagePattern[] = [
+  // Browser extensions and injected scripts.
+  literal('Object Not Found Matching Id'),
+  literal('Extension context invalidated'),
+  literal('Tab not found'),
+  literal('Illegal invocation'),
+  pattern('Non-Error promise rejection captured'),
+  pattern('runtime\\.sendMessage'),
+  pattern('\\.hasAttribute is not a function'),
+  pattern('\\.getAttribute is not a function'),
+  pattern('\\.addEventListener is not a function'),
+  pattern('Cannot destructure property \'bum\''),
+  // Page teardown and benign browser warnings.
+  literal('Channel is closed'),
+  pattern('ResizeObserver loop'),
+  // Stale chunk loads after a deploy.
+  ...STALE_CHUNK_MESSAGES,
+  // Cancelled requests.
+  literal('AbortError'),
+  literal('The user aborted a request'),
+  literal('signal is aborted without reason'),
+  pattern('AsyncData request cancelled by deduplication'),
+  // Safari's generic offline or blocked request failure.
+  literal('Load failed'),
+]
+
+/**
+ * Source URLs that never produce an Error Report.
+ *
+ * A stack made entirely of extension frames is an extension defect. Reporting
+ * it files an issue against the site that no change to the site can close.
+ */
+export const BROWSER_EXTENSION_DENY_URLS: readonly SerializedPattern[] = [
+  pattern('^chrome-extension:\\/\\/', ''),
+  pattern('^moz-extension:\\/\\/', ''),
+  pattern('^safari-(web-)?extension:\\/\\/', ''),
+  pattern('^chrome:\\/\\/', ''),
+  pattern('extensions\\/', 'i'),
+  pattern('webkit-masked-url', ''),
+  // Android in app browsers inject this protocol.
+  pattern('^iabjs:\\/\\/', 'i'),
+]

--- a/packages/nuxt-sentry/src/runtime/shared/policy.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/policy.ts
@@ -1,0 +1,145 @@
+import type {
+  EnvironmentPolicy,
+  ErrorReport,
+  ErrorReportHint,
+  ReportDisabledReason,
+  ReportPolicy,
+  ReportTarget,
+  SampleRatePolicy,
+} from './types'
+import { compilePattern, decideReport } from './drop'
+import { redactErrorReport } from './redact'
+
+/**
+ * The Report Policy applied to one Error Report.
+ *
+ * Pure data in, pure data out. `beforeSend` is the only effectful edge, and it
+ * does nothing but return this function's result to Sentry.
+ */
+export function applyReportPolicy<T extends ErrorReport>(
+  report: T,
+  hint: ErrorReportHint | undefined,
+  policy: ReportPolicy,
+): T | null {
+  const decision = decideReport(report, hint?.originalException, policy)
+  if (decision._tag === 'drop')
+    return null
+  // Redaction runs on every report, under both `dataCollection` settings.
+  // Under `'none'` the request fields are absent, so only the free text rules
+  // do any work, and those still matter: ofetch quotes the failing URL into the
+  // error message, query string and all, which no data collection setting
+  // suppresses.
+  return redactErrorReport(report, policy.secretKeys)
+}
+
+/** The `beforeSend` a Sentry client is initialised with. */
+export function createBeforeSend(policy: ReportPolicy) {
+  return <T extends ErrorReport>(report: T, hint?: ErrorReportHint): T | null =>
+    applyReportPolicy(report, hint, policy)
+}
+
+/**
+ * The `ignoreErrors` and `denyUrls` the browser SDK is initialised with.
+ *
+ * The SDK matches these before `beforeSend` runs, so passing them here drops
+ * the report earlier and cheaper. The same patterns still sit in the policy, so
+ * the server, which has no such SDK option, gets the identical decision.
+ */
+export function createClientNoiseOptions(policy: ReportPolicy): {
+  ignoreErrors: Array<string | RegExp>
+  denyUrls: RegExp[]
+} {
+  return {
+    ignoreErrors: policy.ignoreErrors.map(entry => entry._tag === 'literal'
+      ? entry.value
+      : compilePattern(entry)),
+    denyUrls: policy.denyUrls.map(compilePattern),
+  }
+}
+
+/**
+ * Turn off every personal field the Sentry SDK collects by default.
+ *
+ * The exact shape the seven small sites already ship, kept byte for byte so
+ * `dataCollection: 'none'` is a true no change migration for them.
+ */
+export function createSentryDataCollection() {
+  return {
+    userInfo: false,
+    cookies: false,
+    httpHeaders: { request: false, response: false },
+    httpBodies: [],
+    urlQueryParams: false,
+    graphQL: { document: false, variables: false },
+    genAI: { inputs: false, outputs: false },
+    databaseQueryData: false,
+    stackFrameVariables: false,
+  }
+}
+
+/**
+ * The environment name for a report.
+ *
+ * `hostname` is the browser's. The server has none, so it always takes the
+ * fallback, which a deploy sets through `SENTRY_ENVIRONMENT`. That is how the
+ * two sites with a staging deployment already split the two halves.
+ */
+export function resolveEnvironment(policy: EnvironmentPolicy, hostname?: string): string {
+  if (!hostname)
+    return policy.fallback
+  const match = policy.hostPrefixes.find(entry => hostname.startsWith(entry.prefix))
+  return match ? match.name : policy.fallback
+}
+
+export function resolveTracesSampleRate(policy: SampleRatePolicy, environment: string): number {
+  const rate = policy.byEnvironment[environment]
+  return typeof rate === 'number' ? rate : policy.fallback
+}
+
+/**
+ * Hosts that are never a deployment.
+ *
+ * `nuxt preview` and `wrangler dev` both run a production build with
+ * `NODE_ENV=production`, and `import.meta.dev` is false in that bundle, so a
+ * laptop used to report into the live project. One site measured 232 events
+ * from a single local session against 223 real errors org wide in the same day.
+ *
+ * An unrecognised host still reports, so a real deployment can never be
+ * silenced by this rule.
+ */
+const LOCAL_REPORTING_HOST = /^(?:localhost|\[?::1\]?|0\.0\.0\.0|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|[^.]+\.local(?:host)?)$/i
+
+export function isLocalReportingHost(hostname: string): boolean {
+  return LOCAL_REPORTING_HOST.test(hostname)
+}
+
+/**
+ * The browser's view of the Report Target.
+ *
+ * The build time gate cannot see where the bundle is served from, so the last
+ * gate runs here. A local host downgrades an enabled target to disabled rather
+ * than throwing, so the reason stays readable in a dev tools log.
+ */
+export function resolveClientTarget(target: ReportTarget, hostname: string): ReportTarget {
+  if (target._tag === 'disabled')
+    return target
+  return isLocalReportingHost(hostname) ? { _tag: 'disabled', reason: 'local-host' } : target
+}
+
+/** One line saying why this build sends nothing. Written for a developer, not a user. */
+export function describeDisabledTarget(reason: ReportDisabledReason): string {
+  switch (reason) {
+    case 'option':
+      return 'nuxtSentry.enabled is false.'
+    case 'no-dsn':
+      return 'No nuxtSentry.dsn is set.'
+    case 'not-production':
+      return 'This build is not a production build.'
+    case 'no-release':
+      return 'This build carries no release identity, so it was not produced by a deploy. Set SENTRY_RELEASE in the deploy workflow, or set gate to "always".'
+    case 'not-ci':
+      return 'This build was not produced in CI. Set gate to "release" or "always" to report from a local production build.'
+    case 'local-host':
+      return 'This build is served from a local host, so it is not a deployment.'
+  }
+}

--- a/packages/nuxt-sentry/src/runtime/shared/redact.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/redact.ts
@@ -1,0 +1,279 @@
+import type { ErrorReport } from './types'
+
+/**
+ * Redaction Rules.
+ *
+ * `dataCollection: 'scrubbed'` is the module default, so these rules are the
+ * only thing standing between a credential and a permanent Sentry issue title.
+ * An issue title cannot be edited after the fact, so a leak here is not
+ * recoverable by deleting the event.
+ *
+ * Two independent defences, because either alone has a hole.
+ *
+ * By KEY name. Catches `apiKey: 'plain-looking-value'`, where the value has no
+ * recognisable shape at all.
+ *
+ * By VALUE shape. Catches a credential smuggled inside a free text field: an
+ * ofetch error message quotes the failing URL, query string and all, and no key
+ * name exists for it. It also catches a key nobody thought to name.
+ *
+ * Every function here is pure. None mutates its input, so a caller can hold on
+ * to the original report, and a test can assert on the return value alone.
+ */
+
+export const REDACTED = '[redacted]'
+
+/** A cyclic object must not loop, and a deep one is never informative. */
+const MAX_DEPTH = 6
+const MAX_ARRAY_ITEMS = 50
+
+/** Normalised key names that always name a secret. */
+const SECRET_KEYS: readonly string[] = [
+  'accesskey',
+  'accesstoken',
+  'apikey',
+  'apisecret',
+  'auth',
+  'authorization',
+  'bearer',
+  'clientsecret',
+  'cookie',
+  'credential',
+  'credentials',
+  'idtoken',
+  'jwt',
+  'key',
+  'passwd',
+  'password',
+  'privatekey',
+  'proxyauthorization',
+  'pwd',
+  'refreshtoken',
+  'secret',
+  'secretkey',
+  'sessionid',
+  'setcookie',
+  'signature',
+  'token',
+]
+
+/**
+ * Suffixes, so `googleApiKey`, `clientSecret` and `gscRefreshToken` are caught
+ * without a hand written list.
+ *
+ * A bare `key` suffix is deliberately absent. `cacheKey` and `sortKey` are the
+ * fields that make a report debuggable and they carry nothing secret. A real
+ * `stripeKey` that slips past the key check is still caught by its value shape.
+ */
+const SECRET_KEY_SUFFIXES: readonly string[] = [
+  'apikey',
+  'authorization',
+  'password',
+  'privatekey',
+  'secret',
+  'token',
+]
+
+/** Request headers that carry the caller identity rather than a credential. */
+const PII_REQUEST_HEADERS: ReadonlySet<string> = new Set([
+  'cf-connecting-ip',
+  'forwarded',
+  'true-client-ip',
+  'x-forwarded-for',
+  'x-real-ip',
+])
+
+function normalizeKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+/**
+ * Whether a key name always holds a secret.
+ *
+ * @param key The key name, from a header, a body field or an object property.
+ * @param extraKeys Names a site adds through `policy.secretKeys`. Matched after
+ * the same normalisation, so `X-My-Api` and `xMyApi` are one name.
+ */
+export function isSecretKey(key: string, extraKeys: readonly string[] = []): boolean {
+  const normalized = normalizeKey(key)
+  if (!normalized)
+    return false
+  if (SECRET_KEYS.includes(normalized))
+    return true
+  if (SECRET_KEY_SUFFIXES.some(suffix => normalized.endsWith(suffix)))
+    return true
+  return extraKeys.some(extra => normalizeKey(extra) === normalized)
+}
+
+/**
+ * Value shape rules, applied to every string.
+ *
+ * Ordered so a broad rule cannot eat the anchor a narrow rule needs. The query
+ * string rule runs first because it keeps the parameter name, which is the part
+ * that tells a reader which credential leaked.
+ */
+const VALUE_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // `?key=…`, `&access_token=…`, `&sig=…`. The ofetch message leak.
+  [/([?&][\w-]*(?:key|token|secret|password|auth|signature|sig|credential|session)[\w-]*=)[^&\s"'`)\]]+/gi, `$1${REDACTED}`],
+  // A credential query parameter at the start of a bare query string.
+  [/^([\w-]*(?:key|token|secret|password|auth|signature|sig|credential|session)[\w-]*=)[^&\s"'`)\]]+/i, `$1${REDACTED}`],
+  // https://user:pass@host
+  [/\/\/[^/\s:@]+:[^/\s@]+@/g, `//${REDACTED}@`],
+  // `Authorization: Bearer …` and `Basic …`
+  [/\b(bearer|basic)\s+[\w\-.~+/]+=*/gi, `$1 ${REDACTED}`],
+  // A `Cookie` or `Set-Cookie` header quoted into a message.
+  [/\b(cookie|set-cookie)\s*:\s*[^\n\r]+/gi, `$1: ${REDACTED}`],
+  // Session cookie assignments, including the names Nuxt and h3 use.
+  [/\b(nuxt-session|h3|connect\.sid|__session|session)=[^;\s"'`)\]]+/gi, `$1=${REDACTED}`],
+  // JWTs. Google id tokens and our own session tokens.
+  [/\beyJ[\w-]{8,}\.[\w-]{8,}\.[\w-]*/g, REDACTED],
+  // Google OAuth access tokens, refresh tokens and API keys.
+  [/\bya29\.[\w-]{10,}/g, REDACTED],
+  [/\b1\/\/[\w-]{20,}/g, REDACTED],
+  [/\bAIza[\w-]{20,}/g, REDACTED],
+  // GitHub
+  [/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Z0-9]{20,}/gi, REDACTED],
+  [/\bgithub_pat_\w{20,}/g, REDACTED],
+  // Stripe
+  [/\b(?:sk|rk)_(?:live|test)_[A-Z0-9]{8,}/gi, REDACTED],
+  [/\bwhsec_[A-Z0-9]{8,}/gi, REDACTED],
+  // Anthropic and OpenAI
+  [/\bsk-[\w-]{20,}/g, REDACTED],
+  // Resend
+  [/\bre_[\w-]{16,}/g, REDACTED],
+  // AWS
+  [/\b(?:AKIA|ASIA)[A-Z0-9]{16}/g, REDACTED],
+  // A Sentry DSN carries its own ingest key.
+  [/https:\/\/[a-f0-9]{16,}@[\w.-]+\/\d+/gi, REDACTED],
+]
+
+/** Strip every credential shape from a string. Returns the string unchanged when clean. */
+export function redactText(value: string): string {
+  let out = value
+  for (const [pattern, replacement] of VALUE_PATTERNS)
+    out = out.replace(pattern, replacement)
+  return out
+}
+
+/**
+ * Deep redact an arbitrary value by key name and by value shape.
+ *
+ * Returns a new value. A cycle becomes `[circular]` and depth past `MAX_DEPTH`
+ * becomes `[max depth]`, so a self referencing request body cannot hang the
+ * transport. A `BigInt` becomes a string, because Sentry's own normalisation
+ * leaves it alone and `JSON.stringify` then throws inside the transport.
+ */
+export function redactValue(value: unknown, extraKeys: readonly string[] = []): unknown {
+  return walk(value, 0, new WeakSet(), extraKeys)
+}
+
+function walk(value: unknown, depth: number, seen: WeakSet<object>, extraKeys: readonly string[]): unknown {
+  if (typeof value === 'string')
+    return redactText(value)
+  if (typeof value === 'bigint')
+    return String(value)
+  if (value === null || typeof value !== 'object')
+    return value
+  if (seen.has(value))
+    return '[circular]'
+  if (depth >= MAX_DEPTH)
+    return '[max depth]'
+  seen.add(value)
+
+  if (value instanceof Error) {
+    const cause = (value as Error & { cause?: unknown }).cause
+    return {
+      name: value.name,
+      message: redactText(value.message),
+      ...(value.stack ? { stack: redactText(value.stack) } : {}),
+      ...(cause === undefined ? {} : { cause: walk(cause, depth + 1, seen, extraKeys) }),
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const items: unknown[] = value.slice(0, MAX_ARRAY_ITEMS).map(item => walk(item, depth + 1, seen, extraKeys))
+    if (value.length > MAX_ARRAY_ITEMS)
+      items.push(`[+${value.length - MAX_ARRAY_ITEMS} more]`)
+    return items
+  }
+
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>))
+    out[key] = isSecretKey(key, extraKeys) ? REDACTED : walk(child, depth + 1, seen, extraKeys)
+  return out
+}
+
+/**
+ * Run every Redaction Rule over one Error Report.
+ *
+ * Returns a new report. The caller hands the result straight back to Sentry, so
+ * nothing that survives here can be recalled later.
+ */
+export function redactErrorReport<T extends ErrorReport>(report: T, extraKeys: readonly string[] = []): T {
+  const out: ErrorReport = { ...report }
+
+  if (typeof out.message === 'string')
+    out.message = redactText(out.message)
+
+  if (out.exception?.values) {
+    out.exception = {
+      ...out.exception,
+      values: out.exception.values.map(value => typeof value.value === 'string'
+        ? { ...value, value: redactText(value.value) }
+        : value),
+    }
+  }
+
+  if (out.breadcrumbs) {
+    out.breadcrumbs = out.breadcrumbs.map(crumb => ({
+      ...crumb,
+      ...(typeof crumb.message === 'string' ? { message: redactText(crumb.message) } : {}),
+      ...(crumb.data ? { data: redactValue(crumb.data, extraKeys) as Record<string, unknown> } : {}),
+    }))
+  }
+
+  if (out.user) {
+    // The user id stays. It is what ties a report to an account without naming
+    // the person, and it is the field that makes a signed in bug reproducible.
+    const { email: _email, username: _username, ip_address: _ip, ...rest } = out.user
+    out.user = rest
+  }
+
+  if (out.request) {
+    const request = { ...out.request }
+    // Cookies are pure credential material. A session cookie in a report is
+    // account takeover material, and nothing debuggable is lost by dropping it.
+    delete request.cookies
+    if (typeof request.url === 'string')
+      request.url = redactText(request.url)
+    // Sentry stores `query_string` without the leading `?`, so the first
+    // parameter has no anchor for the query rule. The second value pattern
+    // covers exactly that case.
+    if (typeof request.query_string === 'string' && request.query_string)
+      request.query_string = redactText(request.query_string)
+    if (request.headers) {
+      const headers: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(request.headers)) {
+        headers[key] = isSecretKey(key, extraKeys) || PII_REQUEST_HEADERS.has(key.toLowerCase())
+          ? REDACTED
+          : redactValue(value, extraKeys)
+      }
+      request.headers = headers
+    }
+    // The request body. Deep redact rather than drop: on a 500 the body is
+    // usually the whole story, and a settings endpoint posts provider
+    // credentials through the same road.
+    if (request.data != null)
+      request.data = redactValue(request.data, extraKeys)
+    out.request = request
+  }
+
+  if (out.extra)
+    out.extra = redactValue(out.extra, extraKeys) as Record<string, unknown>
+  if (out.contexts)
+    out.contexts = redactValue(out.contexts, extraKeys) as Record<string, unknown>
+  if (out.tags)
+    out.tags = redactValue(out.tags, extraKeys) as Record<string, unknown>
+
+  return out as T
+}

--- a/packages/nuxt-sentry/src/runtime/shared/types.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Types shared by the build half and the runtime half of the module.
+ *
+ * Everything here must survive `JSON.stringify`, because the resolved Report
+ * Policy travels to the client and the server through `runtimeConfig`. That
+ * rules out a live `RegExp`, so a pattern is carried as `SerializedPattern` and
+ * rebuilt once at the runtime boundary.
+ */
+
+/** A `RegExp` in a shape `runtimeConfig` can carry. */
+export interface SerializedPattern {
+  _tag: 'pattern'
+  source: string
+  flags: string
+}
+
+/** A literal message match, compared case sensitively as a substring. */
+export interface LiteralPattern {
+  _tag: 'literal'
+  value: string
+}
+
+export type MessagePattern = SerializedPattern | LiteralPattern
+
+/** An inclusive HTTP status range. A single status is `{ from: n, to: n }`. */
+export interface StatusRange {
+  from: number
+  to: number
+}
+
+/**
+ * Where an Error Report was captured. The two scopes share every rule except
+ * the status list, so the rule functions take the scope rather than being
+ * written twice.
+ */
+export type ReportScope = 'client' | 'server'
+
+/**
+ * How much of the request an Error Report carries.
+ *
+ * `none` sends no personal data at all, so no Redaction Rule can be needed.
+ * `scrubbed` sends the request and then runs every Redaction Rule over it.
+ */
+export type DataCollection = 'none' | 'scrubbed'
+
+/** The resolved Report Policy for one scope. Pure data. */
+export interface ReportPolicy {
+  scope: ReportScope
+  dataCollection: DataCollection
+  /** Statuses that never produce an Error Report. */
+  dropStatus: StatusRange[]
+  /** Drop `TimeoutError`, `AbortError` and the abort message patterns. */
+  dropTransient: boolean
+  /** Messages that never produce an Error Report. */
+  ignoreErrors: MessagePattern[]
+  /** Source URLs that never produce an Error Report. */
+  denyUrls: SerializedPattern[]
+  /** Extra key names every Redaction Rule treats as secret. */
+  secretKeys: string[]
+}
+
+/** Environment naming. The server has no hostname, so it always takes `fallback`. */
+export interface EnvironmentPolicy {
+  fallback: string
+  /** Host prefix to environment name. Checked in order. */
+  hostPrefixes: Array<{ prefix: string, name: string }>
+}
+
+/** Trace sampling. A record is keyed by resolved environment name. */
+export interface SampleRatePolicy {
+  fallback: number
+  byEnvironment: Record<string, number>
+}
+
+/** Why a build sends no Error Report. Each reason names one gate that failed. */
+export type ReportDisabledReason
+  = | 'option'
+    | 'no-dsn'
+    | 'not-production'
+    | 'no-release'
+    | 'not-ci'
+    | 'local-host'
+
+/**
+ * Whether this build may send an Error Report, and under what identity.
+ *
+ * Resolved once at build time, serialised into `runtimeConfig.nuxtSentry`, and
+ * read by both plugins. One resolution replaces the five different enable gates
+ * the sites wrote separately.
+ */
+export type ReportTarget
+  = | { _tag: 'disabled', reason: ReportDisabledReason }
+    | {
+      _tag: 'enabled'
+      dsn: string
+      release: string
+      environment: EnvironmentPolicy
+      tracesSampleRate: SampleRatePolicy
+      /** The `app` tag, or `null` when one Sentry project serves one deployment. */
+      app: string | null
+      /** Forward `console.warn` and `console.error` to Sentry Logs. */
+      logs: boolean
+      /** Cloudflare binding holding the Worker version, or `null` when off. */
+      workerVersionBinding: string | null
+    }
+
+/** The whole resolved module state, as it sits in `runtimeConfig.nuxtSentry`. */
+export interface SentryRuntimeConfig {
+  target: ReportTarget
+  client: ReportPolicy
+  server: ReportPolicy
+}
+
+/**
+ * The subset of a Sentry event this module reads or rewrites.
+ *
+ * Structural on purpose. `@sentry/cloudflare`, `@sentry/node` and the browser
+ * SDK each declare their own `Event`, and all three satisfy this shape, so the
+ * policy core couples to none of them.
+ */
+export interface ErrorReport {
+  message?: string
+  exception?: {
+    values?: Array<{
+      type?: string
+      value?: string
+      stacktrace?: { frames?: Array<{ filename?: string }> }
+    }>
+  }
+  breadcrumbs?: Array<{
+    category?: string
+    message?: string
+    data?: Record<string, unknown>
+  }> | null
+  user?: Record<string, unknown>
+  request?: {
+    url?: string
+    cookies?: unknown
+    query_string?: unknown
+    headers?: Record<string, unknown>
+    data?: unknown
+  }
+  extra?: Record<string, unknown>
+  contexts?: Record<string, unknown>
+  tags?: Record<string, unknown>
+}
+
+/** What Sentry hands `beforeSend` alongside the report. */
+export interface ErrorReportHint {
+  originalException?: unknown
+}
+
+/** The outcome of every Drop Rule, run in order. */
+export type ReportDecision
+  = | { _tag: 'send' }
+    | { _tag: 'drop', rule: DropRuleName }
+
+export type DropRuleName
+  = | 'status'
+    | 'transient'
+    | 'ignore-message'
+    | 'deny-url'

--- a/packages/nuxt-sentry/src/types.ts
+++ b/packages/nuxt-sentry/src/types.ts
@@ -1,0 +1,111 @@
+import type { PolicyOptions } from './build/policy'
+import type { ReportGate } from './build/target'
+import type { DataCollection } from './runtime/shared/types'
+
+export interface ModuleOptions {
+  /**
+   * Register anything at all. Set false to remove the module without editing
+   * the rest of the config.
+   * @default true
+   */
+  enabled?: boolean
+
+  /**
+   * The public Sentry DSN. Required. It ships in the client bundle, so it is
+   * not a secret.
+   */
+  dsn: string
+
+  /**
+   * Sentry organisation slug, used by the build plugin.
+   * @default 'harlan-zw'
+   */
+  org?: string
+
+  /** Sentry project slug, used by the build plugin. Required when `sourceMaps` is on. */
+  project?: string
+
+  /**
+   * A short label attached to every Error Report as the `app` tag. Set it when
+   * one Sentry organisation serves more than one deployment of the same
+   * codebase.
+   */
+  app?: string
+
+  /**
+   * Who may send an Error Report.
+   *
+   * `release` requires a production build that carries a release identity.
+   * `ci` requires a production build produced in CI.
+   * `always` allows any production build.
+   *
+   * @default 'release'
+   */
+  gate?: ReportGate
+
+  /**
+   * Environment name attached to every Error Report.
+   *
+   * A string is used as is. A record maps a host prefix to a name, so
+   * `{ 'staging.': 'staging' }` splits a staging deployment from production
+   * without a second project. `SENTRY_ENVIRONMENT` overrides both.
+   *
+   * @default 'production'
+   */
+  environment?: string | Record<string, string>
+
+  /**
+   * Fraction of requests traced, 0 to 1. A record keyed by environment name
+   * sets a rate per environment.
+   * @default 0.05
+   */
+  tracesSampleRate?: number | Record<string, number>
+
+  /**
+   * How much of the request an Error Report carries.
+   *
+   * `scrubbed` sends the request and then applies every Redaction Rule.
+   * `none` sends no personal data at all.
+   *
+   * @default 'scrubbed'
+   */
+  dataCollection?: DataCollection
+
+  /** Report Policy. */
+  policy?: PolicyOptions
+
+  /**
+   * Emit and upload client source maps when a Sentry auth token is present, and
+   * delete them after upload. Also strips Session Replay from the bundle.
+   * @default true
+   */
+  sourceMaps?: boolean
+
+  /**
+   * Forward `console.warn` and `console.error` to Sentry Logs.
+   *
+   * Off by default. Sentry meters logs as their own byte quota, separate from
+   * the error quota, so turning this on costs money a site must choose to spend.
+   *
+   * @default false
+   */
+  logs?: boolean
+
+  /**
+   * Attach the Cloudflare Worker version as tags and context, read from the
+   * named binding. `false` disables it. Only takes effect on a Cloudflare
+   * deployment.
+   * @default 'CF_VERSION_METADATA'
+   */
+  workerVersionBinding?: string | false
+
+  /**
+   * Forward failing Wide Events to Sentry Logs.
+   *
+   * Inert when `@harlan-zw/nuxt-wide-events` is absent or its `drain` option is
+   * off. Requires `logs` to be on, because a Wide Event is sent as a log.
+   *
+   * @default false
+   */
+  wideEvents?: boolean
+}

--- a/packages/nuxt-sentry/tests/drop.test.ts
+++ b/packages/nuxt-sentry/tests/drop.test.ts
@@ -1,0 +1,197 @@
+import type { ErrorReport, ReportPolicy } from '../src/runtime/shared/types'
+import { describe, expect, it } from 'vitest'
+import { resolveReportPolicy } from '../src/build/policy'
+import {
+  decideReport,
+  errorChain,
+  errorStatusCode,
+  isTransientError,
+  matchesStatus,
+} from '../src/runtime/shared/drop'
+
+function policy(scope: 'client' | 'server', options = {}): ReportPolicy {
+  return resolveReportPolicy({ scope, dataCollection: 'scrubbed', options })
+}
+
+const emptyReport: ErrorReport = {}
+
+describe('errorStatusCode', () => {
+  it('reads statusCode from an H3 error', () => {
+    expect(errorStatusCode({ statusCode: 404 })).toBe(404)
+  })
+
+  it('reads status from a fetch failure', () => {
+    expect(errorStatusCode({ status: 503 })).toBe(503)
+  })
+
+  it('reads data.statusCode from a serialised Nuxt error', () => {
+    expect(errorStatusCode({ data: { statusCode: 401 } })).toBe(401)
+  })
+
+  it('reads response.status from an ofetch error', () => {
+    expect(errorStatusCode({ response: { status: 429 } })).toBe(429)
+  })
+
+  it('walks the cause chain to find the status', () => {
+    expect(errorStatusCode({ message: 'wrapped', cause: { cause: { statusCode: 403 } } })).toBe(403)
+  })
+
+  it('returns undefined when no link carries a status', () => {
+    expect(errorStatusCode(new Error('boom'))).toBeUndefined()
+  })
+
+  it('stops on a cyclic cause chain', () => {
+    const error: Record<string, unknown> = { message: 'loop' }
+    error.cause = error
+    expect(errorChain(error)).toHaveLength(1)
+    expect(errorStatusCode(error)).toBeUndefined()
+  })
+})
+
+describe('matchesStatus', () => {
+  it('matches a single status and an inclusive range', () => {
+    expect(matchesStatus(404, [{ from: 404, to: 404 }])).toBe(true)
+    expect(matchesStatus(499, [{ from: 400, to: 499 }])).toBe(true)
+    expect(matchesStatus(500, [{ from: 400, to: 499 }])).toBe(false)
+  })
+
+  it('never matches when the error carries no status', () => {
+    expect(matchesStatus(undefined, [{ from: 100, to: 599 }])).toBe(false)
+  })
+})
+
+describe('isTransientError', () => {
+  it('matches TimeoutError and AbortError by name, through the cause chain', () => {
+    expect(isTransientError({ name: 'TimeoutError' })).toBe(true)
+    expect(isTransientError({ message: 'wrapped', cause: { name: 'AbortError' } })).toBe(true)
+  })
+
+  it('matches the abort message patterns', () => {
+    expect(isTransientError(new Error('The operation was aborted due to timeout'))).toBe(true)
+    expect(isTransientError(new Error('signal is aborted without reason'))).toBe(true)
+  })
+
+  it('leaves an ordinary error alone', () => {
+    expect(isTransientError(new Error('Cannot read properties of undefined'))).toBe(false)
+  })
+})
+
+describe('decideReport, server defaults', () => {
+  const server = policy('server')
+
+  it('drops a 404', () => {
+    expect(decideReport(emptyReport, { statusCode: 404 }, server)).toEqual({ _tag: 'drop', rule: 'status' })
+  })
+
+  it('keeps a 401, so an auth regression stays visible', () => {
+    expect(decideReport(emptyReport, { statusCode: 401 }, server)).toEqual({ _tag: 'send' })
+  })
+
+  it('keeps a 403', () => {
+    expect(decideReport(emptyReport, { statusCode: 403 }, server)).toEqual({ _tag: 'send' })
+  })
+
+  it('keeps a 429, so a rate limit spike stays visible', () => {
+    expect(decideReport(emptyReport, { statusCode: 429 }, server)).toEqual({ _tag: 'send' })
+  })
+
+  it('keeps a 500', () => {
+    expect(decideReport(emptyReport, { statusCode: 500 }, server)).toEqual({ _tag: 'send' })
+  })
+
+  it('drops a transient upstream timeout', () => {
+    expect(decideReport(emptyReport, { name: 'TimeoutError' }, server)).toEqual({ _tag: 'drop', rule: 'transient' })
+  })
+})
+
+describe('decideReport, client defaults', () => {
+  const client = policy('client')
+
+  it('drops 401, 403 and 404, which are an expired session racing a redirect', () => {
+    for (const status of [401, 403, 404])
+      expect(decideReport(emptyReport, { statusCode: status }, client)).toEqual({ _tag: 'drop', rule: 'status' })
+  })
+
+  it('keeps a 500', () => {
+    expect(decideReport(emptyReport, { statusCode: 500 }, client)).toEqual({ _tag: 'send' })
+  })
+
+  it('drops a stale chunk load by message', () => {
+    const report: ErrorReport = {
+      exception: { values: [{ type: 'TypeError', value: 'Failed to fetch dynamically imported module: /_nuxt/x.js' }] },
+    }
+    expect(decideReport(report, undefined, client)).toEqual({ _tag: 'drop', rule: 'ignore-message' })
+  })
+
+  it('drops a ResizeObserver loop notice', () => {
+    const report: ErrorReport = { message: 'ResizeObserver loop completed with undelivered notifications.' }
+    expect(decideReport(report, undefined, client)).toEqual({ _tag: 'drop', rule: 'ignore-message' })
+  })
+
+  it('drops a report whose every frame is a browser extension', () => {
+    const report: ErrorReport = {
+      exception: {
+        values: [{
+          type: 'TypeError',
+          value: 'x is not a function',
+          stacktrace: { frames: [{ filename: 'chrome-extension://abc/content.js' }] },
+        }],
+      },
+    }
+    expect(decideReport(report, undefined, client)).toEqual({ _tag: 'drop', rule: 'deny-url' })
+  })
+
+  it('keeps a report with one site frame among extension frames', () => {
+    const report: ErrorReport = {
+      exception: {
+        values: [{
+          type: 'TypeError',
+          value: 'x is not a function',
+          stacktrace: {
+            frames: [
+              { filename: 'chrome-extension://abc/content.js' },
+              { filename: 'https://harlanzw.com/_nuxt/app.js' },
+            ],
+          },
+        }],
+      },
+    }
+    expect(decideReport(report, undefined, client)).toEqual({ _tag: 'send' })
+  })
+
+  it('keeps a genuine application error', () => {
+    const report: ErrorReport = {
+      exception: { values: [{ type: 'TypeError', value: 'Cannot read properties of undefined (reading id)' }] },
+    }
+    expect(decideReport(report, undefined, client)).toEqual({ _tag: 'send' })
+  })
+})
+
+describe('decideReport, site rules', () => {
+  it('drops a site declared message pattern', () => {
+    const site = policy('server', { ignoreErrors: [/^Failed to (?:fetch|read) https?:\/\/\S+$/] })
+    const report: ErrorReport = { message: 'Failed to fetch https://npmjs.org/x' }
+    expect(decideReport(report, undefined, site)).toEqual({ _tag: 'drop', rule: 'ignore-message' })
+  })
+
+  it('drops a site declared status range', () => {
+    const site = policy('server', { dropServerStatus: [[400, 499]] })
+    expect(decideReport(emptyReport, { statusCode: 422 }, site)).toEqual({ _tag: 'drop', rule: 'status' })
+  })
+
+  it('reports every status when the status rule is turned off', () => {
+    const site = policy('server', { dropServerStatus: false })
+    expect(decideReport(emptyReport, { statusCode: 404 }, site)).toEqual({ _tag: 'send' })
+  })
+
+  it('reports a transient failure when the transient rule is turned off', () => {
+    const site = policy('server', { dropTransient: false })
+    expect(decideReport(emptyReport, { name: 'AbortError' }, site)).toEqual({ _tag: 'send' })
+  })
+
+  it('keeps only the site rules when browser noise is turned off', () => {
+    const site = policy('client', { browserNoise: false, ignoreErrors: ['zeroRuntime'] })
+    expect(decideReport({ message: 'ResizeObserver loop' }, undefined, site)).toEqual({ _tag: 'send' })
+    expect(decideReport({ message: 'zeroRuntime is off' }, undefined, site)).toEqual({ _tag: 'drop', rule: 'ignore-message' })
+  })
+})

--- a/packages/nuxt-sentry/tests/policy.test.ts
+++ b/packages/nuxt-sentry/tests/policy.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMessagePatterns,
+  parseStatusRanges,
+  resolveReportPolicy,
+  serializePattern,
+} from '../src/build/policy'
+import {
+  checkSentryBuild,
+  hasSentryAuthToken,
+  resolveSentryBuildOptions,
+} from '../src/build/sentry-build'
+import { resolveWorkerAttribution } from '../src/runtime/server/attribution'
+import { decideWideEventLog, parseSentryCorrelation } from '../src/runtime/server/wide-events'
+import {
+  applyReportPolicy,
+  createBeforeSend,
+  createClientNoiseOptions,
+  createSentryDataCollection,
+  describeDisabledTarget,
+  isLocalReportingHost,
+  resolveClientTarget,
+} from '../src/runtime/shared/policy'
+import { REDACTED } from '../src/runtime/shared/redact'
+
+describe('parseStatusRanges', () => {
+  it('turns a single status into a one wide range', () => {
+    expect(parseStatusRanges([404])).toEqual([{ from: 404, to: 404 }])
+  })
+
+  it('keeps an inclusive pair', () => {
+    expect(parseStatusRanges([[400, 499]])).toEqual([{ from: 400, to: 499 }])
+  })
+
+  it('rejects a value that is not an HTTP status', () => {
+    expect(() => parseStatusRanges([42])).toThrow(/HTTP status/)
+    expect(() => parseStatusRanges([[499, 400]])).toThrow(/low to high/)
+  })
+})
+
+describe('serializePattern', () => {
+  it('drops the global flag, which would carry lastIndex between reports', () => {
+    expect(serializePattern(/token=\w+/gi)).toEqual({ _tag: 'pattern', source: 'token=\\w+', flags: 'i' })
+  })
+})
+
+describe('parseMessagePatterns', () => {
+  it('keeps a string as a literal and a regexp as a pattern', () => {
+    expect(parseMessagePatterns(['AbortError', /ResizeObserver/i])).toEqual([
+      { _tag: 'literal', value: 'AbortError' },
+      { _tag: 'pattern', source: 'ResizeObserver', flags: 'i' },
+    ])
+  })
+})
+
+describe('resolveReportPolicy', () => {
+  it('gives the server 404 only, so an auth or rate limit spike stays visible', () => {
+    expect(resolveReportPolicy({ scope: 'server', dataCollection: 'scrubbed', options: {} }).dropStatus)
+      .toEqual([{ from: 404, to: 404 }])
+  })
+
+  it('gives the client 401, 403 and 404', () => {
+    expect(resolveReportPolicy({ scope: 'client', dataCollection: 'scrubbed', options: {} }).dropStatus)
+      .toEqual([{ from: 401, to: 401 }, { from: 403, to: 403 }, { from: 404, to: 404 }])
+  })
+
+  it('ships the browser noise lists by default', () => {
+    const policy = resolveReportPolicy({ scope: 'client', dataCollection: 'scrubbed', options: {} })
+    expect(policy.ignoreErrors.length).toBeGreaterThan(10)
+    expect(policy.denyUrls.length).toBeGreaterThan(5)
+  })
+})
+
+describe('createClientNoiseOptions', () => {
+  it('rebuilds every serialised pattern into a live matcher', () => {
+    const policy = resolveReportPolicy({
+      scope: 'client',
+      dataCollection: 'scrubbed',
+      options: { browserNoise: false, ignoreErrors: ['AbortError', /boom/i], denyUrls: [/^iabjs:\/\//i] },
+    })
+    const noise = createClientNoiseOptions(policy)
+    expect(noise.ignoreErrors[0]).toBe('AbortError')
+    expect((noise.ignoreErrors[1] as RegExp).test('BOOM')).toBe(true)
+    expect(noise.denyUrls[0]!.test('iabjs://x')).toBe(true)
+  })
+})
+
+describe('applyReportPolicy', () => {
+  const policy = resolveReportPolicy({ scope: 'server', dataCollection: 'scrubbed', options: {} })
+
+  it('returns null for a dropped report', () => {
+    expect(applyReportPolicy({ message: 'gone' }, { originalException: { statusCode: 404 } }, policy)).toBeNull()
+  })
+
+  it('returns a redacted report for a kept one', () => {
+    const out = applyReportPolicy({ message: 'failed ?api_key=abcdef123456' }, undefined, policy)
+    expect(out?.message).toBe(`failed ?api_key=${REDACTED}`)
+  })
+
+  it('redacts under dataCollection none too, because ofetch quotes the URL into the message', () => {
+    const none = resolveReportPolicy({ scope: 'server', dataCollection: 'none', options: {} })
+    const out = applyReportPolicy({ message: 'GET https://x.test?token=abcdef123456' }, undefined, none)
+    expect(out?.message).toBe(`GET https://x.test?token=${REDACTED}`)
+  })
+
+  it('is the same decision through createBeforeSend', () => {
+    const beforeSend = createBeforeSend(policy)
+    expect(beforeSend({ message: 'gone' }, { originalException: { statusCode: 404 } })).toBeNull()
+    expect(beforeSend({ message: 'boom' })).toEqual({ message: 'boom' })
+  })
+})
+
+describe('createSentryDataCollection', () => {
+  it('turns off every personal field the SDK collects by default', () => {
+    expect(createSentryDataCollection()).toEqual({
+      userInfo: false,
+      cookies: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      urlQueryParams: false,
+      graphQL: { document: false, variables: false },
+      genAI: { inputs: false, outputs: false },
+      databaseQueryData: false,
+      stackFrameVariables: false,
+    })
+  })
+})
+
+describe('isLocalReportingHost and resolveClientTarget', () => {
+  it('recognises every host a local production build is served from', () => {
+    for (const host of ['localhost', '127.0.0.1', '0.0.0.0', '::1', '192.168.1.10', '10.0.0.4', '172.16.3.9', 'mac.local'])
+      expect(isLocalReportingHost(host)).toBe(true)
+  })
+
+  it('lets a real deployment through', () => {
+    for (const host of ['harlanzw.com', 'staging.nuxtseo.com', 'unhead.unjs.io'])
+      expect(isLocalReportingHost(host)).toBe(false)
+  })
+
+  it('downgrades an enabled target served from a local host', () => {
+    const enabled = {
+      _tag: 'enabled' as const,
+      dsn: 'x',
+      release: 'r',
+      environment: { fallback: 'production', hostPrefixes: [] },
+      tracesSampleRate: { fallback: 0.05, byEnvironment: {} },
+      app: null,
+      logs: false,
+      workerVersionBinding: null,
+    }
+    expect(resolveClientTarget(enabled, 'localhost')).toEqual({ _tag: 'disabled', reason: 'local-host' })
+    expect(resolveClientTarget(enabled, 'harlanzw.com')).toBe(enabled)
+  })
+})
+
+describe('describeDisabledTarget', () => {
+  it('names the gate that failed and how to pass it', () => {
+    expect(describeDisabledTarget('no-release')).toContain('SENTRY_RELEASE')
+    expect(describeDisabledTarget('local-host')).toContain('local host')
+  })
+})
+
+describe('hasSentryAuthToken', () => {
+  it('accepts an environment token or a local dotenv file', () => {
+    expect(hasSentryAuthToken({ sentryAuthToken: 'tok', hasDotenvFile: false })).toBe(true)
+    expect(hasSentryAuthToken({ hasDotenvFile: true })).toBe(true)
+    expect(hasSentryAuthToken({ sentryAuthToken: '  ', hasDotenvFile: false })).toBe(false)
+  })
+})
+
+describe('resolveSentryBuildOptions', () => {
+  it('disables the upload when no auth token is present', () => {
+    const options = resolveSentryBuildOptions({ org: 'harlan-zw', project: 'zhead', release: 'r', sourceMaps: true, hasAuthToken: false })
+    expect(options.sourcemaps.disable).toBe(true)
+  })
+
+  it('names the release so an uploaded map binds to its reports', () => {
+    const options = resolveSentryBuildOptions({ org: 'harlan-zw', project: 'zhead', release: 'abc', sourceMaps: true, hasAuthToken: true })
+    expect(options).toMatchObject({
+      release: { name: 'abc' },
+      telemetry: false,
+      sourcemaps: { disable: false, filesToDeleteAfterUpload: ['**/*.map'] },
+    })
+  })
+})
+
+describe('checkSentryBuild', () => {
+  const base = { sourceMaps: true, hasAuthToken: true, release: 'abc', gate: 'release' as const, isProduction: true }
+
+  it('fails a build that would upload maps to an unnamed project', () => {
+    expect(checkSentryBuild({ ...base, project: undefined })).toEqual([
+      { _tag: 'error', message: expect.stringContaining('nuxtSentry.project') },
+    ])
+  })
+
+  it('warns when maps upload with no release name', () => {
+    expect(checkSentryBuild({ ...base, project: 'zhead', release: '' })).toEqual([
+      { _tag: 'warning', message: expect.stringContaining('release name') },
+      { _tag: 'warning', message: expect.stringContaining('no release identity') },
+    ])
+  })
+
+  it('says nothing when the build is complete', () => {
+    expect(checkSentryBuild({ ...base, project: 'zhead' })).toEqual([])
+  })
+})
+
+describe('resolveWorkerAttribution', () => {
+  it('reads the binding into tags and context', () => {
+    expect(resolveWorkerAttribution({ id: 'v1', tag: 'blue', timestamp: '2026-08-18T00:00:00Z' })).toEqual({
+      tags: { worker_version: 'v1', worker_version_tag: 'blue' },
+      context: { id: 'v1', tag: 'blue', uploaded_at: '2026-08-18T00:00:00Z' },
+    })
+  })
+
+  it('omits the tag when the deployment has none', () => {
+    expect(resolveWorkerAttribution({ id: 'v1', timestamp: 't' })?.tags).toEqual({ worker_version: 'v1' })
+  })
+
+  it('returns null when the binding is absent or malformed', () => {
+    expect(resolveWorkerAttribution(undefined)).toBeNull()
+    expect(resolveWorkerAttribution({})).toBeNull()
+    expect(resolveWorkerAttribution('CF_VERSION_METADATA')).toBeNull()
+  })
+})
+
+describe('decideWideEventLog', () => {
+  it('forwards a failing record as a log', () => {
+    expect(decideWideEventLog({ 'level': 'error', 'name': 'http.request', 'http.status': 500 })).toEqual({
+      _tag: 'log',
+      level: 'error',
+      message: 'http.request',
+      attributes: { 'http.status': 500 },
+    })
+  })
+
+  it('skips a successful record, so the log quota is spent on failures', () => {
+    expect(decideWideEventLog({ level: 'info', name: 'http.request' })).toEqual({ _tag: 'skip' })
+  })
+
+  it('drops a non primitive attribute the log transport cannot carry', () => {
+    const decision = decideWideEventLog({ level: 'warn', name: 'x', nested: { a: 1 }, ok: true })
+    expect(decision).toEqual({ _tag: 'log', level: 'warn', message: 'x', attributes: { ok: true } })
+  })
+})
+
+describe('parseSentryCorrelation', () => {
+  it('reads the trace and span from the sentry-trace header', () => {
+    expect(parseSentryCorrelation({ 'sentry-trace': 'aaaabbbbccccdddd-1111222233334444-1' })).toEqual({
+      'sentry.traceId': 'aaaabbbbccccdddd',
+      'sentry.spanId': '1111222233334444',
+    })
+  })
+
+  it('returns nulls when no trace is active', () => {
+    expect(parseSentryCorrelation(undefined)).toEqual({ 'sentry.traceId': null, 'sentry.spanId': null })
+    expect(parseSentryCorrelation({})).toEqual({ 'sentry.traceId': null, 'sentry.spanId': null })
+  })
+})

--- a/packages/nuxt-sentry/tests/redact.test.ts
+++ b/packages/nuxt-sentry/tests/redact.test.ts
@@ -1,0 +1,212 @@
+import type { ErrorReport } from '../src/runtime/shared/types'
+import { describe, expect, it } from 'vitest'
+import {
+  isSecretKey,
+  REDACTED,
+  redactErrorReport,
+  redactText,
+  redactValue,
+} from '../src/runtime/shared/redact'
+
+describe('redactText', () => {
+  it('keeps a credential query parameter name and removes its value', () => {
+    expect(redactText('Failed to fetch https://api.example.com/v1?key=AIzaSyD1234567890abcdefghijkl&site=x'))
+      .toBe(`Failed to fetch https://api.example.com/v1?key=${REDACTED}&site=x`)
+  })
+
+  it('removes a credential at the start of a bare query string', () => {
+    expect(redactText('access_token=ya29.a0AfB_verylongtokenvalue&scope=read'))
+      .toBe(`access_token=${REDACTED}&scope=read`)
+  })
+
+  it('removes a Google OAuth access token quoted into a message', () => {
+    expect(redactText('GSC call failed with ya29.A0ARrdaM9xxxxxxxxxxxxxxxxxxxx'))
+      .toBe(`GSC call failed with ${REDACTED}`)
+  })
+
+  it('removes a Google OAuth refresh token', () => {
+    expect(redactText('refresh 1//0gLongRefreshTokenValue123456 expired'))
+      .toBe(`refresh ${REDACTED} expired`)
+  })
+
+  it('removes a Google API key', () => {
+    expect(redactText('AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q')).toBe(REDACTED)
+  })
+
+  it('removes a bearer token but keeps the scheme, which names the leak', () => {
+    expect(redactText('authorization: Bearer abc.def-ghi_jkl'))
+      .toBe(`authorization: Bearer ${REDACTED}`)
+  })
+
+  it('removes a basic authorization header value', () => {
+    expect(redactText('Authorization: Basic dXNlcjpwYXNzd29yZA==').toLowerCase())
+      .toContain(REDACTED)
+  })
+
+  it('removes a whole cookie header', () => {
+    expect(redactText('cookie: nuxt-session=abc123; theme=dark'))
+      .toBe(`cookie: ${REDACTED}`)
+  })
+
+  it('removes a session cookie assignment outside a header', () => {
+    expect(redactText('set nuxt-session=abcdef123456 for the visitor'))
+      .toBe(`set nuxt-session=${REDACTED} for the visitor`)
+  })
+
+  it('removes a JWT', () => {
+    expect(redactText('token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123'))
+      .toBe(`token ${REDACTED}`)
+  })
+
+  it('removes credentials from a userinfo URL', () => {
+    expect(redactText('connect to https://admin:hunter2@db.example.com/main'))
+      .toBe(`connect to https://${REDACTED}@db.example.com/main`)
+  })
+
+  it('removes a GitHub token, a Stripe key and an OpenAI key', () => {
+    expect(redactText('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')).toBe(REDACTED)
+    expect(redactText('sk_live_ABCDEFGHIJKLMNOP')).toBe(REDACTED)
+    expect(redactText('sk-proj-ABCDEFGHIJKLMNOPQRSTUVWX')).toBe(REDACTED)
+  })
+
+  it('removes a Sentry DSN', () => {
+    expect(redactText('dsn https://5a73fdc73e42eb95936085b70f7ebd12@o1.ingest.us.sentry.io/45115'))
+      .toBe(`dsn ${REDACTED}`)
+  })
+
+  it('leaves text with no credential unchanged', () => {
+    const clean = 'Cannot read properties of undefined (reading id) at /api/sites?page=2'
+    expect(redactText(clean)).toBe(clean)
+  })
+})
+
+describe('isSecretKey', () => {
+  it('matches an exact secret name whatever its casing or punctuation', () => {
+    expect(isSecretKey('Authorization')).toBe(true)
+    expect(isSecretKey('x-api-key')).toBe(true)
+    expect(isSecretKey('refresh_token')).toBe(true)
+  })
+
+  it('matches a suffix so a prefixed name needs no list entry', () => {
+    expect(isSecretKey('googleApiKey')).toBe(true)
+    expect(isSecretKey('gscRefreshToken')).toBe(true)
+    expect(isSecretKey('clientSecret')).toBe(true)
+  })
+
+  it('keeps a debugging key that only ends in key', () => {
+    expect(isSecretKey('cacheKey')).toBe(false)
+    expect(isSecretKey('sortKey')).toBe(false)
+  })
+
+  it('matches an extra key a site declares', () => {
+    expect(isSecretKey('dataForSeoLogin')).toBe(false)
+    expect(isSecretKey('dataForSeoLogin', ['data_for_seo_login'])).toBe(true)
+  })
+})
+
+describe('redactValue', () => {
+  it('removes a secret by key name even when the value looks ordinary', () => {
+    expect(redactValue({ apiKey: 'plain-looking-value', page: 2 }))
+      .toEqual({ apiKey: REDACTED, page: 2 })
+  })
+
+  it('removes a secret nested inside an array', () => {
+    expect(redactValue({ calls: [{ url: 'https://x.test?token=abcdefgh' }] }))
+      .toEqual({ calls: [{ url: `https://x.test?token=${REDACTED}` }] })
+  })
+
+  it('reports a cycle instead of looping', () => {
+    const cyclic: Record<string, unknown> = { name: 'root' }
+    cyclic.self = cyclic
+    expect(redactValue(cyclic)).toEqual({ name: 'root', self: '[circular]' })
+  })
+
+  it('stringifies a BigInt so the transport can serialise it', () => {
+    expect(redactValue({ rows: 9007199254740993n })).toEqual({ rows: '9007199254740993' })
+  })
+
+  it('redacts an error cause chain', () => {
+    const inner = new Error('fetch https://api.test?api_key=abcdef123456 failed')
+    const outer = new Error('upstream failed', { cause: inner })
+    const result = redactValue(outer) as { cause: { message: string } }
+    expect(result.cause.message).toBe(`fetch https://api.test?api_key=${REDACTED} failed`)
+  })
+
+  it('caps a long array so one call site cannot fill the report', () => {
+    const result = redactValue(Array.from({ length: 60 }, (_, index) => index)) as unknown[]
+    expect(result).toHaveLength(51)
+    expect(result.at(-1)).toBe('[+10 more]')
+  })
+})
+
+describe('redactErrorReport', () => {
+  it('removes a token from the message, the exception and a breadcrumb', () => {
+    const report: ErrorReport = {
+      message: 'GET https://searchconsole.googleapis.com/v1?access_token=ya29.abcdefghijkl',
+      exception: { values: [{ type: 'FetchError', value: 'refused with token ya29.abcdefghijkl' }] },
+      breadcrumbs: [{ category: 'fetch', message: 'https://x.test?key=AIzaSyABCDEFGHIJKLMNOPQRSTU' }],
+    }
+    const out = redactErrorReport(report)
+    expect(out.message).toBe(`GET https://searchconsole.googleapis.com/v1?access_token=${REDACTED}`)
+    expect(out.exception?.values?.[0]?.value).toBe(`refused with token ${REDACTED}`)
+    expect(out.breadcrumbs?.[0]?.message).toBe(`https://x.test?key=${REDACTED}`)
+  })
+
+  it('drops cookies and the caller identity headers, and keeps the user id', () => {
+    const out = redactErrorReport({
+      user: { id: 'user_42', email: 'a@b.test', username: 'ab', ip_address: '1.2.3.4' },
+      request: {
+        cookies: { 'nuxt-session': 'abc' },
+        headers: {
+          'authorization': 'Bearer abcdef',
+          'cf-connecting-ip': '1.2.3.4',
+          'x-forwarded-for': '1.2.3.4',
+          'user-agent': 'Chrome',
+        },
+      },
+    })
+    expect(out.user).toEqual({ id: 'user_42' })
+    expect(out.request?.cookies).toBeUndefined()
+    expect(out.request?.headers).toEqual({
+      'authorization': REDACTED,
+      'cf-connecting-ip': REDACTED,
+      'x-forwarded-for': REDACTED,
+      'user-agent': 'Chrome',
+    })
+  })
+
+  it('redacts a query string that Sentry stores without its leading question mark', () => {
+    const out = redactErrorReport({ request: { query_string: 'token=abcdef123456&page=2' } })
+    expect(out.request?.query_string).toBe(`token=${REDACTED}&page=2`)
+  })
+
+  it('deep redacts the request body rather than dropping it', () => {
+    const out = redactErrorReport({
+      request: { data: { siteUrl: 'https://x.test', refreshToken: '1//0gSecretValue', page: 1 } },
+    })
+    expect(out.request?.data).toEqual({ siteUrl: 'https://x.test', refreshToken: REDACTED, page: 1 })
+  })
+
+  it('redacts extra, contexts and tags', () => {
+    const out = redactErrorReport({
+      extra: { authorization: 'Bearer x' },
+      contexts: { upstream: { url: 'https://x.test?secret=abcdef' } },
+      tags: { note: 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345' },
+    })
+    expect(out.extra).toEqual({ authorization: REDACTED })
+    expect(out.contexts).toEqual({ upstream: { url: `https://x.test?secret=${REDACTED}` } })
+    expect(out.tags).toEqual({ note: REDACTED })
+  })
+
+  it('does not mutate the report it was given', () => {
+    const report: ErrorReport = { message: 'key=abcdef123456', request: { cookies: { a: 'b' } } }
+    redactErrorReport(report)
+    expect(report.message).toBe('key=abcdef123456')
+    expect(report.request?.cookies).toEqual({ a: 'b' })
+  })
+
+  it('honours an extra secret key a site declares', () => {
+    const out = redactErrorReport({ extra: { dataForSeoLogin: 'harlan' } }, ['dataForSeoLogin'])
+    expect(out.extra).toEqual({ dataForSeoLogin: REDACTED })
+  })
+})

--- a/packages/nuxt-sentry/tests/target.test.ts
+++ b/packages/nuxt-sentry/tests/target.test.ts
@@ -1,0 +1,156 @@
+import type { TargetInput } from '../src/build/target'
+import { describe, expect, it } from 'vitest'
+import {
+  isCiBuild,
+  resolveEnvironmentPolicy,
+  resolveRelease,
+  resolveReportTarget,
+  resolveSampleRatePolicy,
+} from '../src/build/target'
+import { resolveEnvironment, resolveTracesSampleRate } from '../src/runtime/shared/policy'
+
+function input(overrides: Partial<TargetInput> = {}): TargetInput {
+  return {
+    enabled: true,
+    dsn: 'https://key@o1.ingest.us.sentry.io/2',
+    gate: 'release',
+    environment: 'production',
+    tracesSampleRate: 0.05,
+    logs: false,
+    workerVersionBinding: 'CF_VERSION_METADATA',
+    env: { nodeEnv: 'production', sentryRelease: 'abc123' },
+    ...overrides,
+  }
+}
+
+describe('isCiBuild', () => {
+  it('accepts the spellings a runner uses', () => {
+    expect(isCiBuild('true')).toBe(true)
+    expect(isCiBuild('1')).toBe(true)
+    expect(isCiBuild('yes')).toBe(true)
+  })
+
+  it('rejects an unset or explicitly falsy value', () => {
+    expect(isCiBuild(undefined)).toBe(false)
+    expect(isCiBuild('')).toBe(false)
+    expect(isCiBuild('false')).toBe(false)
+    expect(isCiBuild('0')).toBe(false)
+  })
+})
+
+describe('resolveRelease', () => {
+  it('prefers SENTRY_RELEASE over GITHUB_SHA', () => {
+    expect(resolveRelease({ sentryRelease: 'deployed', githubSha: 'branch-tip' })).toBe('deployed')
+  })
+
+  it('falls back to GITHUB_SHA', () => {
+    expect(resolveRelease({ githubSha: 'branch-tip' })).toBe('branch-tip')
+  })
+
+  it('falls back to VERCEL_GIT_COMMIT_SHA, so a Vercel build is not silenced', () => {
+    expect(resolveRelease({ vercelGitCommitSha: 'vercel-sha' })).toBe('vercel-sha')
+  })
+
+  it('returns an empty string when none is set', () => {
+    expect(resolveRelease({})).toBe('')
+  })
+})
+
+describe('resolveReportTarget', () => {
+  it('enables a production build that carries a release', () => {
+    const target = resolveReportTarget(input())
+    expect(target).toMatchObject({ _tag: 'enabled', release: 'abc123' })
+  })
+
+  it('disables a build that opted out', () => {
+    expect(resolveReportTarget(input({ enabled: false }))).toEqual({ _tag: 'disabled', reason: 'option' })
+  })
+
+  it('disables a build with no DSN', () => {
+    expect(resolveReportTarget(input({ dsn: '  ' }))).toEqual({ _tag: 'disabled', reason: 'no-dsn' })
+  })
+
+  it('disables a development build', () => {
+    expect(resolveReportTarget(input({ env: { nodeEnv: 'development' } })))
+      .toEqual({ _tag: 'disabled', reason: 'not-production' })
+  })
+
+  it('disables a production build with no release under the release gate', () => {
+    expect(resolveReportTarget(input({ env: { nodeEnv: 'production' } })))
+      .toEqual({ _tag: 'disabled', reason: 'no-release' })
+  })
+
+  it('enables a production build with no release under the always gate', () => {
+    expect(resolveReportTarget(input({ gate: 'always', env: { nodeEnv: 'production' } })))
+      .toMatchObject({ _tag: 'enabled', release: '' })
+  })
+
+  it('disables a local production build under the ci gate', () => {
+    expect(resolveReportTarget(input({ gate: 'ci', env: { nodeEnv: 'production', sentryRelease: 'abc' } })))
+      .toEqual({ _tag: 'disabled', reason: 'not-ci' })
+  })
+
+  it('enables a CI production build under the ci gate', () => {
+    expect(resolveReportTarget(input({ gate: 'ci', env: { nodeEnv: 'production', sentryRelease: 'abc', ci: 'true' } })))
+      .toMatchObject({ _tag: 'enabled' })
+  })
+
+  it('carries the app tag and the worker binding through', () => {
+    expect(resolveReportTarget(input({ app: 'pro', workerVersionBinding: 'CF_VERSION_METADATA' })))
+      .toMatchObject({ app: 'pro', workerVersionBinding: 'CF_VERSION_METADATA' })
+  })
+
+  it('turns a false worker binding into null', () => {
+    expect(resolveReportTarget(input({ workerVersionBinding: false })))
+      .toMatchObject({ workerVersionBinding: null })
+  })
+})
+
+describe('resolveEnvironmentPolicy and resolveEnvironment', () => {
+  it('names every deployment when the option is a string', () => {
+    const policy = resolveEnvironmentPolicy('production', {})
+    expect(resolveEnvironment(policy)).toBe('production')
+    expect(resolveEnvironment(policy, 'staging.example.com')).toBe('production')
+  })
+
+  it('splits a staging host from production', () => {
+    const policy = resolveEnvironmentPolicy({ 'staging.': 'staging' }, {})
+    expect(resolveEnvironment(policy, 'staging.example.com')).toBe('staging')
+    expect(resolveEnvironment(policy, 'example.com')).toBe('production')
+  })
+
+  it('gives the server the fallback, because it has no hostname', () => {
+    const policy = resolveEnvironmentPolicy({ 'staging.': 'staging' }, {})
+    expect(resolveEnvironment(policy)).toBe('production')
+  })
+
+  it('lets SENTRY_ENVIRONMENT name the server side deployment', () => {
+    const policy = resolveEnvironmentPolicy({ 'staging.': 'staging' }, { sentryEnvironment: 'staging' })
+    expect(resolveEnvironment(policy)).toBe('staging')
+  })
+
+  it('prefers the longest matching host prefix', () => {
+    const policy = resolveEnvironmentPolicy({ 'staging.': 'staging', 'staging.api.': 'staging-api' }, {})
+    expect(resolveEnvironment(policy, 'staging.api.example.com')).toBe('staging-api')
+  })
+})
+
+describe('resolveSampleRatePolicy and resolveTracesSampleRate', () => {
+  it('uses one rate everywhere when the option is a number', () => {
+    const policy = resolveSampleRatePolicy(0.05)
+    expect(resolveTracesSampleRate(policy, 'production')).toBe(0.05)
+    expect(resolveTracesSampleRate(policy, 'staging')).toBe(0.05)
+  })
+
+  it('uses a rate per environment', () => {
+    const policy = resolveSampleRatePolicy({ production: 0.05, staging: 1 })
+    expect(resolveTracesSampleRate(policy, 'staging')).toBe(1)
+    expect(resolveTracesSampleRate(policy, 'production')).toBe(0.05)
+    expect(resolveTracesSampleRate(policy, 'preview')).toBe(0.05)
+  })
+
+  it('rejects a rate outside 0 to 1', () => {
+    expect(() => resolveSampleRatePolicy(1.5)).toThrow(/between 0 and 1/)
+    expect(() => resolveSampleRatePolicy({ staging: -1 })).toThrow(/staging/)
+  })
+})

--- a/packages/nuxt-sentry/tsconfig.check.json
+++ b/packages/nuxt-sentry/tsconfig.check.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node", "vitest/globals"],
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "bench/**/*.ts"],
+  "exclude": ["tests/fixtures/**"]
+}

--- a/packages/nuxt-sentry/tsconfig.json
+++ b/packages/nuxt-sentry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "references": [
+    { "path": "./.nuxt/tsconfig.app.json" },
+    { "path": "./.nuxt/tsconfig.server.json" },
+    { "path": "./.nuxt/tsconfig.shared.json" },
+    { "path": "./.nuxt/tsconfig.node.json" }
+  ],
+  "files": []
+}

--- a/packages/nuxt-sentry/vitest.config.ts
+++ b/packages/nuxt-sentry/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ catalogs:
     '@sentry/cloudflare':
       specifier: ^10.70.0
       version: 10.70.0
+    '@sentry/nuxt':
+      specifier: ^10.70.0
+      version: 10.70.0
     '@types/node':
       specifier: ^26.1.1
       version: 26.2.0
@@ -457,6 +460,61 @@ importers:
       h3:
         specifier: 'catalog:'
         version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      unbuild:
+        specifier: 'catalog:'
+        version: 3.6.1(typescript@5.9.3)(vue-sfc-transformer@0.2.5(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(typescript@5.9.3)(vue@3.5.41(typescript@5.9.3)))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.41(typescript@5.9.3)
+
+  packages/nuxt-sentry:
+    dependencies:
+      '@nuxt/kit':
+        specifier: 'catalog:'
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      pathe:
+        specifier: 'catalog:'
+        version: 2.0.3
+    devDependencies:
+      '@antfu/eslint-config':
+        specifier: 'catalog:'
+        version: 9.3.0(@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3))(@typescript-eslint/utils@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      '@arethetypeswrong/cli':
+        specifier: 'catalog:'
+        version: 0.18.5
+      '@nuxt/module-builder':
+        specifier: 'catalog:'
+        version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))
+      '@nuxt/schema':
+        specifier: 'catalog:'
+        version: 4.5.2
+      '@sentry/cloudflare':
+        specifier: 'catalog:'
+        version: 10.70.0(@cloudflare/workers-types@5.20260811.1)(wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1))
+      '@sentry/nuxt':
+        specifier: 'catalog:'
+        version: 10.70.0(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0))(rollup@4.62.4)(vue@3.5.41(typescript@5.9.3))(wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.2.0
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.1(jiti@2.7.0)
+      h3:
+        specifier: 'catalog:'
+        version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      nitropack:
+        specifier: 'catalog:'
+        version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3))(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
@@ -1876,9 +1934,47 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@ota-meshi/ast-token-store@0.3.0':
     resolution: {integrity: sha512-XRO0zi2NIUKq2lUk3T1ecFSld1fMWRKE6naRFGkgkdeosx7IslyUKNv5Dcb5PJTja9tHJoFu0v/7yEpAkrkrTg==}
@@ -2240,6 +2336,78 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry/browser-utils@10.70.0':
+    resolution: {integrity: sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.70.0':
+    resolution: {integrity: sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugins@10.70.0':
+    resolution: {integrity: sha512-M+a32VOZVeTUxF+QecQ+OHYj8hb5FeppKwwWpTQ9cfS6ixgoNUK7/B7NhB2XbfxE3F1BcGvOxyS+AB+fvPfSRQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@sentry/cloudflare@10.70.0':
     resolution: {integrity: sha512-jlr9txw3lQrbc6KQn9FzlpgC1KcB36u7aIGSlUhXAZ2MB93DgwjuTnHF20qQHxmHbZylg7CtHoMq3rGiTXAgpg==}
     engines: {node: '>=18'}
@@ -2260,9 +2428,90 @@ packages:
     resolution: {integrity: sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==}
     engines: {node: '>=18'}
 
+  '@sentry/feedback@10.70.0':
+    resolution: {integrity: sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.70.0':
+    resolution: {integrity: sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.70.0':
+    resolution: {integrity: sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==}
+    engines: {node: '>=18'}
+
+  '@sentry/nuxt@10.70.0':
+    resolution: {integrity: sha512-lZ/kV5SVmww5ZOTQ2VjZshTgNrdXtkYlw49/irSk0wu9hoofS8s5r9+Mbl6/NtosCioDza44+hQYc5e+zVKU3Q==}
+    engines: {node: '>=18.19.1'}
+    peerDependencies:
+      nitro: 2.x || 3.x
+      nuxt: '>=3.7.0 || 4.x || 5.x'
+    peerDependenciesMeta:
+      nitro:
+        optional: true
+
+  '@sentry/opentelemetry@10.70.0':
+    resolution: {integrity: sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/replay-canvas@10.70.0':
+    resolution: {integrity: sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.70.0':
+    resolution: {integrity: sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==}
+    engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.4.0':
+    resolution: {integrity: sha512-NIOqb1fEj3wPEgeeuc9HAPwi9T++asNvovk22rRvsjPv9l+rBeuMk1JdZyvBSnVZU03PRM6sFKbJh/6R6M+oWw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@sentry/server-utils@10.70.0':
     resolution: {integrity: sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==}
     engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/vue@10.70.0':
+    resolution: {integrity: sha512-oopTjKv8/WvxBeRDmgh3xJtEAbP/K0qmtAkOkj9jDYAYN5mgBm33sv7cYHXdrAR4o6tE1VFVu2hWqge64dGbHw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@tanstack/vue-router': ^1.64.0
+      pinia: 2.x || 3.x || 4.x
+      vue: 2.x || 3.x
+    peerDependenciesMeta:
+      '@tanstack/vue-router':
+        optional: true
+      pinia:
+        optional: true
 
   '@simple-git/args-pathspec@1.0.3':
     resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
@@ -2657,6 +2906,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2928,6 +3181,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -4062,6 +4318,10 @@ packages:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4090,6 +4350,10 @@ packages:
 
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   impound@1.1.6:
     resolution: {integrity: sha512-ugavDQkE74SGrBjagNIwNVHNBxX14mmfQnTm4jFGzOoWwYsgihqV698BNr5xwRY9quKK4rEg8bc6ECltllMr+w==}
@@ -5345,11 +5609,18 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -5434,6 +5705,10 @@ packages:
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   reserved-identifiers@1.2.0:
     resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
@@ -8158,7 +8433,48 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@ota-meshi/ast-token-store@0.3.0': {}
 
@@ -8394,6 +8710,79 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
+  '@sentry/browser-utils@10.70.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/browser@10.70.0':
+    dependencies:
+      '@sentry/browser-utils': 10.70.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/feedback': 10.70.0
+      '@sentry/replay': 10.70.0
+      '@sentry/replay-canvas': 10.70.0
+
+  '@sentry/bundler-plugins@10.70.0(rollup@4.62.4)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.70.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.62.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@sentry/cloudflare@10.70.0(@cloudflare/workers-types@5.20260811.1)(wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -8412,6 +8801,97 @@ snapshots:
     dependencies:
       '@sentry/conventions': 0.16.0
 
+  '@sentry/feedback@10.70.0':
+    dependencies:
+      '@sentry/core': 10.70.0
+
+  '@sentry/node-core@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/node-core': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.70.0
+      import-in-the-middle: 3.3.3
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/nuxt@10.70.0(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0))(rollup@4.62.4)(vue@3.5.41(typescript@5.9.3))(wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1))':
+    dependencies:
+      '@nuxt/kit': 3.21.11(magicast@0.5.4)
+      '@sentry/browser': 10.70.0
+      '@sentry/cloudflare': 10.70.0(@cloudflare/workers-types@5.20260811.1)(wrangler@4.120.1(@cloudflare/workers-types@5.20260811.1))
+      '@sentry/core': 10.70.0
+      '@sentry/node': 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/rollup-plugin': 5.4.0(rollup@4.62.4)
+      '@sentry/server-utils': 10.70.0
+      '@sentry/vite-plugin': 5.4.0(rollup@4.62.4)
+      '@sentry/vue': 10.70.0(vue@3.5.41(typescript@5.9.3))
+      local-pkg: 1.2.1
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/instrumentation'
+      - '@opentelemetry/sdk-trace-base'
+      - '@tanstack/vue-router'
+      - encoding
+      - magicast
+      - pinia
+      - rollup
+      - supports-color
+      - vue
+      - webpack
+      - wrangler
+
+  '@sentry/opentelemetry@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/replay-canvas@10.70.0':
+    dependencies:
+      '@sentry/core': 10.70.0
+      '@sentry/replay': 10.70.0
+
+  '@sentry/replay@10.70.0':
+    dependencies:
+      '@sentry/browser-utils': 10.70.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/rollup-plugin@5.4.0(rollup@4.62.4)':
+    dependencies:
+      '@sentry/bundler-plugins': 10.70.0(rollup@4.62.4)
+    optionalDependencies:
+      rollup: 4.62.4
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+      - webpack
+
   '@sentry/server-utils@10.70.0':
     dependencies:
       '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
@@ -8421,6 +8901,22 @@ snapshots:
       meriyah: 6.1.4
     transitivePeerDependencies:
       - supports-color
+
+  '@sentry/vite-plugin@5.4.0(rollup@4.62.4)':
+    dependencies:
+      '@sentry/bundler-plugins': 10.70.0(rollup@4.62.4)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
+  '@sentry/vue@10.70.0(vue@3.5.41(typescript@5.9.3))':
+    dependencies:
+      '@sentry/browser': 10.70.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      vue: 3.5.41(typescript@5.9.3)
 
   '@simple-git/args-pathspec@1.0.3': {}
 
@@ -8912,6 +9408,12 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -9165,6 +9667,8 @@ snapshots:
   citty@0.2.2: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.2.1: {}
 
   cli-highlight@2.1.11:
     dependencies:
@@ -10203,6 +10707,13 @@ snapshots:
 
   http-shutdown@1.2.2: {}
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -10225,6 +10736,12 @@ snapshots:
   ignore@7.0.6: {}
 
   image-meta@0.2.2: {}
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
 
   impound@1.1.6(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
@@ -12111,6 +12628,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -12118,6 +12637,8 @@ snapshots:
       signal-exit: 3.0.7
 
   proto-list@1.2.4: {}
+
+  proxy-from-env@1.1.0: {}
 
   punycode.js@2.3.1: {}
 
@@ -12192,6 +12713,13 @@ snapshots:
       jsesc: 3.1.0
 
   require-directory@2.1.1: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   reserved-identifiers@1.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   '@arethetypeswrong/cli': ^0.18.5
   '@cloudflare/workers-types': ^5.20260811.1
   '@sentry/cloudflare': ^10.70.0
+  '@sentry/nuxt': ^10.70.0
   '@nuxt/kit': ^4.5.2
   '@nuxt/module-builder': ^1.0.2
   '@nuxt/schema': ^4.5.2
@@ -52,6 +53,7 @@ ignoredBuiltDependencies:
 
 allowBuilds:
   '@parcel/watcher': true
+  '@sentry/cli': true
   esbuild: true
   sharp: true
   vue-demi: true


### PR DESCRIPTION
## What this is

One Nuxt module, `@harlan-zw/nuxt-sentry`, config key `nuxtSentry`, that owns how nine sites wire Sentry. Today those nine hold two different designs that disagree on whether to collect PII at all, five separate implementations of the same enable gate, and 2,648 lines across 59 Sentry named files.

`packages/nuxt-sentry/MIGRATION.md` has the per repo plan. Nothing in the consumer repos is changed by this PR.

## What the module owns

- **Registration.** The client plugin and the Cloudflare Nitro plugin are registered from inside the package, and `meta.name` is `@harlan-zw/nuxt-sentry`. Today every site registers an anonymous `server/plugins/sentry.ts`, so `nuxt-dx` has no owner for the bundle entry and three sites copy an `overridesKb` line to work around it.
- **The enable gate.** One `ReportTarget` resolved at build time, serialised into `runtimeConfig`, read by both plugins.
- **The Report Policy.** Drop Rules, Redaction Rules, ignore lists, deny lists, sampling, environment and release naming. All pure functions over serialisable data.
- **The `sentry` build option block.** `org`, `project`, `authToken`, `release.name`, `sourcemaps`, `bundleSizeOptimizations`, `telemetry: false`, plus `sourcemap.client`. All nine repos already hold identical values for every one of those except `project`.
- **Cloudflare Worker version tags**, read from the `CF_VERSION_METADATA` binding that six deployments already have and only one uses.

## What it deliberately does not own

- **It does not wrap or re-export `@sentry/*`.** Sites keep importing `@sentry/nuxt` and `@sentry/cloudflare` directly. Both are peers, `@sentry/cloudflare` optional, following `nuxt-cf-jobs`.
- **It does not replace `@sentry/nuxt/module`.** That module still owns the build plugin, the source map upload and the client entry injection. This one configures it.
- **It does not write or edit a Wrangler file.** `@harlan-zw/nuxt-cloudflare` owns that and `upload_source_maps` with it. `sourcemap.server` is left alone on purpose, because `nuxt-cloudflare` derives `upload_source_maps` from it.
- **It does not own the queue Sentry client.** `runWithQueueSentry` stays in `@harlan-zw/nuxt-cf-jobs/sentry`. `@harlan-zw/nuxt-sentry/server` exports `createBeforeSend` so a queue wrapper applies the identical policy.
- **It does not capture per request errors twice.** It never hooks the Nitro `error` event itself. `@sentry/nuxt`'s Cloudflare plugin already does, and `nuxt-wide-events` keeps the request record.
- **It does not add Sentry Cron monitors or RPC capture.** One site each, and a billed monitor seat.
- **It does not redact application log payloads.** `nuxtseo.com`'s `redact.ts` also serves a D1 logging chokepoint. Only the Sentry half moves.

## The three defaults

### 1. `dataCollection: 'scrubbed'`

Collect the request, then run every Redaction Rule over it. Richer reports beat the safer `'none'`, which makes the redaction load bearing.

Two independent defences, because either alone has a hole. **By key name**, which catches `apiKey: 'plain-looking-value'` where the value has no recognisable shape. **By value shape**, which catches a credential smuggled into free text: ofetch quotes the failing URL, query string and all, into `err.message`, and no key name exists for that.

The rules also drop `request.cookies`, redact `request.query_string` including the leading parameter Sentry stores without a `?`, redact secret and caller identity headers, deep redact `request.data`, `extra`, `contexts` and `tags`, and remove `user.email`, `user.username` and `user.ip_address` while keeping `user.id`.

`gscdump.com` is the site this fixes. It sets `sendDefaultPii: true` on three clients, calls the Google Search Console API with OAuth tokens, and redacts nothing anywhere. 30 redaction tests cover exactly that: `ya29.` access tokens, `1//` refresh tokens, `AIza` API keys, JWTs, cookie headers, session cookie assignments, `Authorization: Bearer` and `Basic`, userinfo URLs, GitHub, Stripe and OpenAI keys, a Sentry DSN, and credentials at the start of a bare query string.

Redaction runs under **both** settings, not only `'scrubbed'`. Under `'none'` the request fields are absent, but the ofetch message leak is not, and no data collection setting suppresses it.

### 2. `gate: 'release'`

Report only when a release identity is present. A release identity is the proof that a deploy produced this build. `nuxt preview` and `wrangler dev` both run a production build with `NODE_ENV=production` and `import.meta.dev` false, so a laptop reports as production. `nuxtseo.com` measured 232 events from one local session against 223 real errors org wide in the same 24 hours.

**Correction to the brief.** This default does not silence any site. GitHub Actions always sets `GITHUB_SHA`, including on a `workflow_run` event, so the four affected sites still report; they report under the **wrong** release. I checked every workflow rather than take the count from the sweep:

| Repo | Deploy trigger | `SENTRY_RELEASE` set | Release under this default |
| --- | --- | --- | --- |
| `zhead.dev` | `workflow_run` | no | wrong, branch tip |
| `mdream.dev` | `workflow_run` | no | wrong, branch tip |
| `unlighthouse.dev` | `workflow_run` | no | wrong, branch tip |
| `request-indexing` | `workflow_run` | no | wrong, branch tip |
| `unhead.unjs.io` | `workflow_run` | **yes** | correct |
| `harlanzw.com` | `push` | no | correct, ambient SHA |
| `gscdump.com` | `push` | no | correct, ambient SHA |
| `nuxtseo.com` | `push` | no | correct, ambient SHA |
| `scripts.nuxt.com` | Vercel, no workflow | no | correct, see below |

Two things follow.

- **Four sites need a workflow fix**, not five and not because they go quiet. `zhead.dev`, `mdream.dev`, `unlighthouse.dev` and `request-indexing` must add the line `unhead.unjs.io` already has. The exact YAML is in `MIGRATION.md`. The sweep counted `nuxtseo.com` as a fifth; its `deploy-prod.yml` is a plain `push`, so its SHA is right. Its real problem is that it never passes `release` to the server client at all, which the module fixes by construction.
- **`scripts.nuxt.com` would have gone quiet**, because it builds on Vercel and has no `GITHUB_SHA`. So `resolveRelease` reads `SENTRY_RELEASE`, then `GITHUB_SHA`, then `VERCEL_GIT_COMMIT_SHA`, matching that site's existing behaviour. With it, no site goes quiet.

A production build with no release still fails loudly rather than silently: the module logs why, and `checkSentryBuild` warns at build time.

### 3. Server Drop Rule is 404 only

Three sites drop the whole 4xx class today. That hides two things worth paging on: a 401 or 403 spike is how an auth regression announces itself, and a 429 spike is how a rate limit does. A 404 is the one 4xx a stale link or a crawler produces in normal operation.

The client default is `[401, 403, 404]`. In the browser a 401 or 403 is an expired session racing a redirect to the login page, which the app already handles. `nuxtseo.com/apps/pro` identified that as the dominant client noise class, and `request-indexing` is a signed in app that drops 404 and not 401 or 403 today.

## Behaviours not carried forward

| Behaviour | Where it was | Why not |
| --- | --- | --- |
| DSN literal duplicated between `nuxt.config.ts` and `sentry.client.config.ts` | `gscdump.com` | Its own comment calls it a manual invariant. The client plugin reads `runtimeConfig`, so there is one literal. |
| Server client receives no `release` | `nuxtseo.com` | No comment explains it, and its uploaded maps bind to an unnamed release. The module always passes the resolved release. |
| `!process.env.SENTRY_AUTH_TOKEN` instead of the `hasSentryAuthToken` helper | `gscdump.com`, `nuxtseo.com` | Drift. A local upload with `.env.sentry-build-plugin` silently did nothing. `hasSentryAuthToken` is now the only road. |
| Four separate enable gate implementations | `zh`, `hz`, `un`, `ri`, `ns`, `gs` | One `ReportTarget`, resolved once. |
| Five separate copies of `SENTRY_RELEASE \|\| GITHUB_SHA` | seven repos | One `resolveRelease`. |
| Message only server filters with no status class | `mdream.dev`, `unlighthouse.dev` | A plain `createError({ statusCode: 400 })` still reported. Status is now a first class rule and the site patterns sit on top. |
| `denyUrls` absent | seven repos | Every browser extension exception reported as a site bug. The list is now a default. |
| Three `ignoreErrors` patterns only | seven repos | They missed `AbortError`, `ResizeObserver loop`, `Load failed` and `Non-Error promise rejection captured`, all of which two sites already call non-actionable. |
| `nuxt-dx` `overridesKb` for an anonymous Nitro plugin | `harlanzw.com` 326, `zhead.dev` 325, `request-indexing` 325 | The plugin now has an owner. The override stays site side until `nuxt-dx` 0.1.0 lands the owner allowance, but the key becomes one stable path inside the module. |
| Bespoke stackless manifest fetch filter | `unlighthouse.dev` | The built in stale chunk rules cover it. |
| BigInt scrub as a separate policy file | `gscdump.com` | `redactValue` stringifies a BigInt on every path, so the transport cannot throw. |

Kept per site, because each encodes a real dependency: `gscdump.com`'s D1, R2, KV and iron rules; `unlighthouse.dev`'s `EXPECTED_UPSTREAM_FAILURE` marker; `mdream.dev`'s two upstream patterns; `nuxtseo.com`'s Carbon Ads deny entries and its cron, RPC, queue and `use-query` bridges.

## Coordination with the other packages

- **`nuxt-cloudflare`** keeps `upload_source_maps` and the Wrangler config. This module reads the `CF_VERSION_METADATA` binding that `nuxt-cloudflare` injects, and never sets `sourcemap.server`, which is the value `nuxt-cloudflare` derives from.
- **`nuxt-wide-events`.** Two bridges, neither package importing the other. The Sentry trace identity is written into each request's Wide Event as `sentry.traceId` and `sentry.spanId`, declared through the `wide-events:fields` build hook so the allowlist stays exhaustive. With `wideEvents: true`, a failing Wide Event is forwarded to Sentry **Logs**, never as an error: a Wide Event carries no stack in production, and Sentry already captured the same failure.
- **`nuxt-cf-jobs`** keeps `runWithQueueSentry`. `@harlan-zw/nuxt-sentry/server` exports `createBeforeSend` so the queue client applies the same rules.

## Non Cloudflare presets

`scripts.nuxt.com` is the only non Cloudflare site. `@sentry/cloudflare` is the only SDK that runs on Workers and it cannot be bundled into a Node build, so the server plugin is registered only on a Cloudflare preset. On any other preset the module warns and the site keeps its own `sentry.server.config.ts`, building `beforeSend` from the shared policy. That site still gets the client plugin, the gate, the policy and the build block.

## Verification

Run in this branch, real numbers.

| Check | Result |
| --- | --- |
| `pnpm install` | clean, one catalog entry added for `@sentry/nuxt`, `@sentry/cli` added to `allowBuilds` |
| `pnpm --filter @harlan-zw/nuxt-sentry dev:prepare` | pass |
| `pnpm lint` (all 9 packages) | pass |
| `pnpm --filter @harlan-zw/nuxt-sentry typecheck` | pass |
| `typecheck`, other 7 published packages | pass |
| `typecheck`, `comark-content` | **fails, 259 errors, pre-existing.** Zero diff against `origin/main` for that package. |
| `pnpm test` (all 9 packages) | 1,509 tests pass, 0 fail |
| `nuxt-sentry` tests | 117 pass across 4 files, 30 of them redaction |
| `pnpm test:attw` | no problems, both export paths, node10 / node16 CJS / node16 ESM / bundler |
| `pnpm test:pack` | pass |
| `pnpm build` | 57.3 kB dist, module 11.9 kB |

## What a human still needs to answer

From the sweep, minus the three now settled.

1. Is `tracesSampleRate: 0.05` a considered value or a copied one? The module keeps it as the default. Only `gscdump.com` and `nuxtseo.com` justify their rates.
2. `gscdump.com` captures a `use-query` fetch timeout as an error and `nuxtseo.com` refuses to, citing a quota blackout. Which is the estate default? Neither bridge moved into the module.
3. Is `nuxtseo.com`'s `gate: 'ci'` still needed now that `gate: 'release'` exists? Its migration keeps `ci` for now.
4. Should the module ship the `verify-sentry-token` preflight that only `nuxtseo.com` has, as a CLI command like `nuxt-cloudflare doctor`?
5. `harlanzw.com` and `mdream.dev` set `upload_source_maps: true` while emitting no server maps. Turn on `sourcemap.server`, or remove those two lines? The module deliberately does not decide.
6. Should `zhead.dev` and `scripts.nuxt.com` move `@sentry/nuxt` to `catalog:`, or is the literal `^10.69.0` pin intentional?
7. `harlanzw.com` uses 326 kB for the `nuxt-dx` size budget override and the other two use 325. Is the difference real, or is one number stale?
8. `scripts.nuxt.com` never passes `SENTRY_AUTH_TOKEN`, so it has never uploaded a source map. Does the Vercel project need it?
