### PR TITLE
perf(comark-content): stop rebuilding unchanged content on every build

### DIFF
--- a/packages/comark-content/bench/warm-ingest/fixture.mjs
+++ b/packages/comark-content/bench/warm-ingest/fixture.mjs
@@ -1,0 +1,64 @@
+// Builds a corpus the size of the nuxtseo.com docs site: 17 collections, 389
+// Markdown files, about 14 MB of parsed documents in the ingest cache.
+// Set COMARK_BENCH_CORPUS to a colon separated list to point it elsewhere.
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+
+const DEFAULT_CORPUS = [
+  'pkg/nuxt-robots/docs/content',
+  'pkg/sitemap/docs/content',
+  'pkg/og-image/docs/content',
+  'pkg/nuxt-schema-org/docs/content',
+  'pkg/nuxt-seo-utils/docs/content',
+  'pkg/nuxt-link-checker/docs/content',
+  'pkg/nuxt-site-config/docs/content',
+  'pkg/nuxt-skew-protection/docs/content',
+  'pkg/nuxt-ai-ready/docs/content',
+  'sites/nuxtseo.com/apps/site/content',
+].map(path => resolve(homedir(), path))
+
+const COLLECTION_COUNT = 17
+const FILE_COUNT = 389
+
+function corpusRoots() {
+  const configured = process.env.COMARK_BENCH_CORPUS
+  return configured ? configured.split(':').filter(Boolean) : DEFAULT_CORPUS
+}
+
+async function walk(directory) {
+  const found = []
+  const entries = await readdir(directory, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory())
+      found.push(...await walk(path))
+    else if (entry.name.endsWith('.md'))
+      found.push(path)
+  }
+  return found
+}
+
+export async function buildFixture(root) {
+  await rm(root, { recursive: true, force: true })
+  const sources = []
+  for (const corpus of corpusRoots())
+    sources.push(...await walk(corpus))
+  if (!sources.length)
+    throw new Error(`No Markdown found. Set COMARK_BENCH_CORPUS to a colon separated list of content directories.`)
+  sources.sort()
+  const documents = await Promise.all(sources.map(path => readFile(path, 'utf8')))
+  const collections = []
+  for (let index = 0; index < COLLECTION_COUNT; index++) {
+    const name = `collection${String(index).padStart(2, '0')}`
+    await mkdir(join(root, 'content', name), { recursive: true })
+    collections.push(name)
+  }
+  for (let index = 0; index < FILE_COUNT; index++) {
+    const collection = collections[index % COLLECTION_COUNT]
+    const document = documents[index % documents.length]
+    await writeFile(join(root, 'content', collection, `doc-${String(index).padStart(4, '0')}.md`), document)
+  }
+  return collections
+}

--- a/packages/comark-content/bench/warm-ingest/run.mjs
+++ b/packages/comark-content/bench/warm-ingest/run.mjs
@@ -1,0 +1,91 @@
+// Measures the all-cache-hit ingest: the work every build repeats when no
+// Markdown changed. Run with `pnpm bench:warm-ingest`.
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import process from 'node:process'
+import { createJiti } from 'jiti'
+import { buildFixture } from './fixture.mjs'
+
+const SAMPLES = Number(process.env.SAMPLES ?? 5)
+const PACKAGE_ROOT = resolve(import.meta.dirname, '../..')
+
+// Mirrors the highlight options nuxtseo.com builds with.
+const HIGHLIGHT = {
+  languages: {
+    dir: [
+      [/[|├└│]──/g, 'oper'],
+      [/\b[\w-]+\/$/gm, 'class'],
+      [/\b[\w-]+\.[a-z0-9]+$/gim, 'str'],
+    ],
+  },
+}
+
+function median(values) {
+  return [...values].sort((left, right) => left - right)[Math.floor(values.length / 2)]
+}
+
+async function main() {
+  const jiti = createJiti(import.meta.url)
+  const { ingestCollections } = await jiti.import(join(PACKAGE_ROOT, 'src/core/ingest.ts'))
+  const { createContentAssetPlan, createContentRevision, syncContentAssets } = await jiti.import(join(PACKAGE_ROOT, 'src/core/asset.ts'))
+
+  const root = join(tmpdir(), 'comark-warm-ingest')
+  const outputDir = join(root, 'generated')
+  const cacheFile = join(root, '.data/cache.json')
+  const names = await buildFixture(root)
+  const loaded = names.map(name => ({
+    name,
+    rootDir: root,
+    definition: { type: 'page', source: { include: '**/*.md', cwd: join(root, 'content', name) } },
+  }))
+
+  const buildCollections = async () => {
+    const marks = {}
+    let at = performance.now()
+    const result = await ingestCollections(loaded, { cacheFile, remoteCacheDir: join(root, '.remote'), highlight: HIGHLIGHT })
+    marks.ingest = performance.now() - at
+    if (result._tag === 'Err')
+      throw new Error(JSON.stringify(result.error))
+    at = performance.now()
+    const revision = createContentRevision(result.value.collections)
+    marks.revision = performance.now() - at
+    at = performance.now()
+    const sync = await syncContentAssets({
+      outputDir,
+      revision,
+      reuseUnchanged: true,
+      createPlan: () => createContentAssetPlan({
+        collections: result.value.collections,
+        sitemapCollections: result.value.sitemapCollections,
+      }),
+    })
+    marks.assets = performance.now() - at
+    return { result, marks, sync }
+  }
+
+  const coldStart = performance.now()
+  const cold = await buildCollections()
+  console.log(`cold: ${(performance.now() - coldStart).toFixed(1)}ms (${cold.result.value.parsedFiles} parsed, assets ${cold.sync._tag})`)
+
+  const samples = []
+  const phases = []
+  for (let index = 0; index < SAMPLES; index++) {
+    const startedAt = performance.now()
+    const { result, marks, sync } = await buildCollections()
+    samples.push(performance.now() - startedAt)
+    if (result.value.parsedFiles !== 0)
+      throw new Error(`Expected an all-cache-hit run, parsed ${result.value.parsedFiles}.`)
+    phases.push({ ...marks, sync: sync._tag })
+  }
+
+  console.log(`warm samples: ${[...samples].sort((left, right) => left - right).map(value => value.toFixed(1)).join(', ')}`)
+  console.log(`warm median: ${median(samples).toFixed(1)}ms (assets ${phases[0].sync})`)
+  for (const key of ['ingest', 'revision', 'assets'])
+    console.log(`  ${key}: ${median(phases.map(entry => entry[key])).toFixed(1)}ms`)
+}
+
+main().catch((cause) => {
+  console.error(cause)
+  process.exitCode = 1
+})

--- a/packages/comark-content/package.json
+++ b/packages/comark-content/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "bench": "node ./bench/run.mjs",
     "bench:site:harlanzw": "node ./bench/site-harlanzw/run.mjs",
+    "bench:warm-ingest": "node ./bench/warm-ingest/run.mjs",
     "build": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt-module-build build",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare",
     "lint": "eslint .",
@@ -77,6 +78,7 @@
     "@nuxt/module-builder": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
+    "jiti": "catalog:",
     "nuxt": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",

--- a/packages/comark-content/src/core/asset.ts
+++ b/packages/comark-content/src/core/asset.ts
@@ -1,5 +1,8 @@
 import type { ContentCollectionManifestEntry, ContentSearchSection, IndexedContentDocument, NavigationCollectionItem, PageCollectionItemBase } from '../runtime/types'
 import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import { createNavigationSource, createSearchSections } from '../runtime/core/navigation'
 
@@ -21,7 +24,18 @@ export interface ContentAssetPlanInput {
   sitemapCollections: readonly string[]
 }
 
+/** The asset every generated directory holds, whatever the collections are. */
+const CONTENT_MANIFEST_ASSET = 'collections.json.gz'
+
 const bodyAssetName = (id: string) => `${createHash('sha256').update(id).digest('hex').slice(0, 32)}.json.gz`
+
+function isSorted(keys: string[]) {
+  for (let index = 1; index < keys.length; index++) {
+    if (keys[index - 1]! > keys[index]!)
+      return false
+  }
+  return true
+}
 
 function canonicalContent(collections: Record<string, PageCollectionItemBase[]>) {
   return JSON.stringify(collections, (key, value) => {
@@ -29,7 +43,13 @@ function canonicalContent(collections: Record<string, PageCollectionItemBase[]>)
       return undefined
     if (!value || typeof value !== 'object' || Array.isArray(value))
       return value
-    return Object.fromEntries(Object.keys(value).sort().map(name => [name, value[name]]))
+    const keys = Object.keys(value)
+    // Most parsed nodes already carry sorted keys. Reordering them allocates a
+    // replacement object for every node in the tree, so only pay for it when the
+    // order actually differs.
+    if (isSorted(keys))
+      return value
+    return Object.fromEntries(keys.sort().map(name => [name, value[name]]))
   })
 }
 
@@ -70,8 +90,54 @@ export function createContentAssetPlan(input: ContentAssetPlanInput): ContentAss
   return {
     manifest,
     assets: [
-      { path: 'collections.json.gz', data: encodeCollectionAsset(manifest) },
+      { path: CONTENT_MANIFEST_ASSET, data: encodeCollectionAsset(manifest) },
       ...Object.entries(input.collections).flatMap(([name, items]) => projectCollectionAssets(name, items)),
     ],
   }
+}
+
+/** Names the file that records which revision the generated directory holds. */
+export const contentAssetStampPath = (outputDir: string): string => `${outputDir}.revision`
+
+/**
+ * The generated directory already held this revision, so no asset was rewritten.
+ * A `Written` result means the directory was cleared and rebuilt.
+ */
+export type ContentAssetSync
+  = | { _tag: 'Reused' }
+    | { _tag: 'Written', assets: number }
+
+export interface SyncContentAssetsOptions {
+  outputDir: string
+  /** Identifies the content the generated directory must hold. */
+  revision: string
+  /** Set to false to always rewrite, whatever the stamp says. */
+  reuseUnchanged: boolean
+  createPlan: () => ContentAssetPlan
+}
+
+/**
+ * Writes the generated assets unless the directory already holds this revision.
+ * The stamp is written last, so an interrupted write always rebuilds.
+ */
+export async function syncContentAssets(options: SyncContentAssetsOptions): Promise<ContentAssetSync> {
+  const stampFile = contentAssetStampPath(options.outputDir)
+  if (options.reuseUnchanged) {
+    const stamp = await readFile(stampFile, 'utf8').catch(error => error.code === 'ENOENT' ? undefined : Promise.reject(error))
+    // The stamp sits outside the generated directory, so it survives a wipe of
+    // that directory. Check the manifest as well before trusting it.
+    if (stamp === options.revision && existsSync(join(options.outputDir, CONTENT_MANIFEST_ASSET)))
+      return { _tag: 'Reused' }
+  }
+  await rm(stampFile, { force: true })
+  const plan = options.createPlan()
+  await rm(options.outputDir, { recursive: true, force: true })
+  await mkdir(options.outputDir, { recursive: true })
+  await Promise.all(plan.assets.map(async (asset) => {
+    const path = join(options.outputDir, asset.path)
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, asset.data)
+  }))
+  await writeFile(stampFile, options.revision)
+  return { _tag: 'Written', assets: plan.assets.length }
 }

--- a/packages/comark-content/src/core/ingest.ts
+++ b/packages/comark-content/src/core/ingest.ts
@@ -125,6 +125,7 @@ function contentHighlightFingerprint(highlight: ContentHighlight | undefined) {
 
 export async function ingestCollections(loadedCollections: LoadedCollection[], options: IngestionOptions): Promise<Result<IngestionResult>> {
   const cache = await readCache(options.cacheFile)
+  const cachedEntryCount = Object.keys(cache.entries).length
   const nextCache = { version: CACHE_VERSION, entries: {} as typeof cache.entries }
   const collections: Record<string, PageCollectionItemBase[]> = {}
   const sitemapCollections: string[] = []
@@ -224,6 +225,9 @@ export async function ingestCollections(loadedCollections: LoadedCollection[], o
     if (collection.definition.sitemap !== false)
       sitemapCollections.push(collection.name)
   }
-  await writeCache(options.cacheFile, nextCache)
+  // Every entry came back from the cache and none was dropped, so the file on
+  // disk already holds this exact content. Serialising it again writes nothing new.
+  if (parsedFiles > 0 || cachedFiles !== cachedEntryCount)
+    await writeCache(options.cacheFile, nextCache)
   return ok({ collections, sitemapCollections, parsedFiles, cachedFiles, componentTags: [...componentTags].sort() })
 }

--- a/packages/comark-content/src/module.ts
+++ b/packages/comark-content/src/module.ts
@@ -3,7 +3,7 @@ import type { ContentConfig } from './config'
 import type { LoadedCollection } from './core/ingest'
 import type { ContentHighlight } from './highlight'
 import { existsSync } from 'node:fs'
-import { mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
@@ -22,7 +22,7 @@ import {
 } from '@nuxt/kit'
 import { addUnprefixedContentAliases, contentComponentDirectories, localizeNuxtUiProseComponents, renderComponentManifest } from './components'
 import { assertCloudflareCacheModule, assertSupportedOptions, mergeCollectionSources } from './config'
-import { createContentAssetPlan, createContentRevision } from './core/asset'
+import { createContentAssetPlan, createContentRevision, syncContentAssets } from './core/asset'
 import { ingestCollections } from './core/ingest'
 import { isMarkdownWatchEvent } from './core/source'
 import { excludeNuxtContentSitemapSource } from './sitemap'
@@ -174,20 +174,22 @@ export default defineNuxtModule<ModuleOptions>({
       if (initializedCollections)
         await updateTemplates({ filter: template => template.dst === componentsTemplate.dst })
       initializedCollections = true
-      await rm(outputDir, { recursive: true, force: true })
-      await mkdir(outputDir, { recursive: true })
-      const assetPlan = createContentAssetPlan({
-        collections: result.value.collections,
-        sitemapCollections: result.value.sitemapCollections,
+      // Dev rebuilds always carry a change, so they skip the revision hash and
+      // rewrite the assets outright.
+      const revision = nuxt.options.dev ? 'dev' : createContentRevision(result.value.collections)
+      const sync = await syncContentAssets({
+        outputDir,
+        revision,
+        reuseUnchanged: !nuxt.options.dev,
+        createPlan: () => createContentAssetPlan({
+          collections: result.value.collections,
+          sitemapCollections: result.value.sitemapCollections,
+        }),
       })
-      await Promise.all(assetPlan.assets.map(async (asset) => {
-        const path = join(outputDir, asset.path)
-        await mkdir(dirname(path), { recursive: true })
-        await writeFile(path, asset.data)
-      }))
       const files = Object.values(result.value.collections).reduce((sum, items) => sum + items.length, 0)
-      logger.success(`Processed ${loaded.length} collections and ${files} files in ${(performance.now() - startedAt).toFixed(2)}ms (${result.value.cachedFiles} cached, ${result.value.parsedFiles} parsed)`)
-      return nuxt.options.dev ? 'dev' : createContentRevision(result.value.collections)
+      const assets = sync._tag === 'Reused' ? 'assets reused' : `${sync.assets} assets written`
+      logger.success(`Processed ${loaded.length} collections and ${files} files in ${(performance.now() - startedAt).toFixed(2)}ms (${result.value.cachedFiles} cached, ${result.value.parsedFiles} parsed, ${assets})`)
+      return revision
     }
 
     nuxt.hook('modules:done', async () => {

--- a/packages/comark-content/test/ingest.test.ts
+++ b/packages/comark-content/test/ingest.test.ts
@@ -1,5 +1,5 @@
 import type { MarkdownDocument } from 'comark'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -384,6 +384,50 @@ describe('markdown ingestion', () => {
     expect(parse).toHaveBeenCalledTimes(2)
     expect(cached).toMatchObject({ _tag: 'Ok', value: { parsedFiles: 0, cachedFiles: 1 } })
     expect(changed).toMatchObject({ _tag: 'Ok', value: { parsedFiles: 1, cachedFiles: 0 } })
+  })
+
+  it('leaves the cache file untouched when every file came back from it', async () => {
+    const root = await temporaryRoot()
+    const sourcePath = await writeFixture(root, 'content/page.md', '# Page')
+    const parse = vi.fn(async (): Promise<MarkdownDocument> => ({ nodes: [['h1', { id: 'page' }, 'Page']], frontmatter: {}, meta: {} }))
+    const collections = [
+      { name: 'pages', rootDir: root, definition: defineCollection({ type: 'page', source: '**/*.md' }) },
+    ]
+    const cacheFile = join(root, 'cache.json')
+    const options = { cacheFile, parse }
+
+    await ingestCollections(collections, options)
+    const written = await stat(cacheFile)
+    await ingestCollections(collections, options)
+    const reused = await stat(cacheFile)
+    await writeFixture(root, 'content/second.md', '# Second')
+    await ingestCollections(collections, options)
+    const grown = await stat(cacheFile)
+
+    expect(reused.mtimeMs).toBe(written.mtimeMs)
+    expect(grown.mtimeMs).not.toBe(written.mtimeMs)
+    expect(Object.keys(JSON.parse(await readFile(cacheFile, 'utf8')).entries)).toEqual([
+      `pages:${sourcePath}`,
+      `pages:${join(root, 'content/second.md')}`,
+    ])
+  })
+
+  it('drops a removed file from the cache file', async () => {
+    const root = await temporaryRoot()
+    const sourcePath = await writeFixture(root, 'content/page.md', '# Page')
+    await writeFixture(root, 'content/second.md', '# Second')
+    const parse = vi.fn(async (): Promise<MarkdownDocument> => ({ nodes: [], frontmatter: {}, meta: {} }))
+    const collections = [
+      { name: 'pages', rootDir: root, definition: defineCollection({ type: 'page', source: '**/*.md' }) },
+    ]
+    const cacheFile = join(root, 'cache.json')
+    const options = { cacheFile, parse }
+
+    await ingestCollections(collections, options)
+    await rm(join(root, 'content/second.md'))
+    await ingestCollections(collections, options)
+
+    expect(Object.keys(JSON.parse(await readFile(cacheFile, 'utf8')).entries)).toEqual([`pages:${sourcePath}`])
   })
 
   it('rejects the previous Rangi cache version', async () => {

--- a/packages/comark-content/test/storage.test.ts
+++ b/packages/comark-content/test/storage.test.ts
@@ -1,6 +1,9 @@
 import type { PageCollectionItemBase } from '../src/runtime/types'
-import { describe, expect, it } from 'vitest'
-import { createContentAssetPlan, createContentRevision, encodeCollectionAsset } from '../src/core/asset'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { contentAssetStampPath, createContentAssetPlan, createContentRevision, encodeCollectionAsset, syncContentAssets } from '../src/core/asset'
 import { createIndexedCollectionQuery } from '../src/runtime/core/query'
 import { decodeCollectionAsset } from '../src/runtime/server/asset'
 import { createContentStorage } from '../src/runtime/server/storage-core'
@@ -142,5 +145,96 @@ describe('generated collection storage', () => {
     await expect(storage.loadNavigationCollection('pages')).resolves.toHaveLength(2)
     await expect(storage.loadSearchSections('pages')).resolves.toHaveLength(2)
     expect(reads).toEqual(['pages/navigation.json.gz', 'pages/search.json.gz'])
+  })
+})
+
+describe('generated asset synchronisation', () => {
+  const temporaryRoots: string[] = []
+
+  const temporaryOutputDir = async () => {
+    const root = await mkdtemp(join(tmpdir(), 'comark-content-assets-'))
+    temporaryRoots.push(root)
+    return join(root, 'generated')
+  }
+
+  afterEach(async () => {
+    await Promise.all(temporaryRoots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+  })
+
+  const planFor = (items: PageCollectionItemBase[]) => () => createContentAssetPlan({ collections: { pages: items }, sitemapCollections: ['pages'] })
+
+  it('writes every asset when the generated directory holds another revision', async () => {
+    const outputDir = await temporaryOutputDir()
+    const createPlan = vi.fn(planFor(pages))
+
+    const first = await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+    const second = await syncContentAssets({ outputDir, revision: 'two', reuseUnchanged: true, createPlan })
+
+    expect(first).toEqual({ _tag: 'Written', assets: 6 })
+    expect(second).toEqual({ _tag: 'Written', assets: 6 })
+    expect(createPlan).toHaveBeenCalledTimes(2)
+    await expect(readFile(contentAssetStampPath(outputDir), 'utf8')).resolves.toBe('two')
+  })
+
+  it('skips the plan when the generated directory already holds the revision', async () => {
+    const outputDir = await temporaryOutputDir()
+    const createPlan = vi.fn(planFor(pages))
+
+    await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+    const reused = await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+
+    expect(reused).toEqual({ _tag: 'Reused' })
+    expect(createPlan).toHaveBeenCalledTimes(1)
+  })
+
+  it('rewrites when the generated directory is gone but the stamp survives', async () => {
+    const outputDir = await temporaryOutputDir()
+    const createPlan = vi.fn(planFor(pages))
+
+    await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+    await rm(outputDir, { recursive: true, force: true })
+    const rebuilt = await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+
+    expect(rebuilt).toEqual({ _tag: 'Written', assets: 6 })
+    await expect(readdir(outputDir)).resolves.toContain('collections.json.gz')
+  })
+
+  it('rewrites when the caller opts out of reuse', async () => {
+    const outputDir = await temporaryOutputDir()
+    const createPlan = vi.fn(planFor(pages))
+
+    await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan })
+    const rewritten = await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: false, createPlan })
+
+    expect(rewritten).toEqual({ _tag: 'Written', assets: 6 })
+    expect(createPlan).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves no stamp behind when the write fails part way', async () => {
+    const outputDir = await temporaryOutputDir()
+
+    await syncContentAssets({ outputDir, revision: 'one', reuseUnchanged: true, createPlan: planFor(pages) })
+    await expect(syncContentAssets({
+      outputDir,
+      revision: 'two',
+      reuseUnchanged: true,
+      createPlan: () => { throw new Error('plan failed') },
+    })).rejects.toThrow('plan failed')
+
+    await expect(readFile(contentAssetStampPath(outputDir), 'utf8')).rejects.toThrow('ENOENT')
+  })
+
+  it('drops assets of a collection the build no longer produces', async () => {
+    const outputDir = await temporaryOutputDir()
+
+    await syncContentAssets({
+      outputDir,
+      revision: 'one',
+      reuseUnchanged: true,
+      createPlan: () => createContentAssetPlan({ collections: { pages, notes: pages }, sitemapCollections: ['pages'] }),
+    })
+    await syncContentAssets({ outputDir, revision: 'two', reuseUnchanged: true, createPlan: planFor(pages) })
+
+    await expect(readdir(outputDir)).resolves.toEqual(['collections.json.gz', 'pages'])
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     happy-dom:
       specifier: ^20.11.1
       version: 20.11.2
+    jiti:
+      specifier: ^2.7.0
+      version: 2.7.0
     nitropack:
       specifier: ^2.13.4
       version: 2.13.4
@@ -158,6 +161,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 10.8.1(jiti@2.7.0)
+      jiti:
+        specifier: 'catalog:'
+        version: 2.7.0
       nuxt:
         specifier: 'catalog:'
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ catalog:
   evlog: ^2.26.0
   h3: 2.0.1-rc.25
   happy-dom: ^20.11.1
+  jiti: ^2.7.0
   nitropack: ^2.13.4
   nuxt: ^4.5.2
   pathe: ^2.0.3


### PR DESCRIPTION
### Description

Building nuxtseo.com, comark-content ingest is the first 3.5 to 5.7 seconds of the build, and it reports `389 cached, 0 parsed`. Nothing is parsed and the output is byte identical to the last build, yet it does the whole job again.

Warm ingest of 17 collections and 389 files, the shape nuxtseo.com has, about 14 MB of parsed documents in the cache:

```
before  427ms   ingest 145ms  revision 116ms  assets 203ms
after   171ms   ingest  86ms  revision  86ms  assets   0.2ms
```

`bench/warm-ingest` is the harness those numbers come from. Median of 9 warm runs, alternated before/after three times so machine load does not pick a winner. `pnpm bench:warm-ingest`.

Three things were repeated for nothing.

**The cache file was rewritten every run.** 14 MB of `JSON.stringify` plus a write, producing the file that was already there. It now writes only when a file was parsed or an entry disappeared.

**Every generated asset was re-gzipped and rewritten.** `rm -rf` on the generated directory, then gzip level 9 over every body, index, navigation and search asset. The revision hash already identifies the content exactly, so it now doubles as a stamp: `syncContentAssets` reuses the directory when it already holds that revision. The stamp lives beside the directory rather than in it, so it does not ship as a server asset, and the manifest is checked as well in case someone wiped the directory but not the stamp. It is written last, so an interrupted write always rebuilds. Dev opts out and always rewrites.

**The revision hash allocated an object per tree node.** `canonicalContent` sorted the keys of every object it walked, which for a Markdown AST is mostly small attribute bags that were already sorted. It now checks first and only reorders when the order actually differs.

The 3.5 vs 5.7 second spread between two runs was not this code. nuxtseo.com has one collection sourced from a GitHub tag, and 0.0.17 re-clones it on every build. That shallow clone alone is 1.3s here and it varies with the network. `main` already fixes it, since `RemoteCheckoutPolicy` treats a tag as immutable and reuses the checkout.

Remaining warm cost is about 170ms, split evenly between parsing the 14 MB cache file and hashing the content for the revision. Both are floors of the current cache format. Going lower means a stamp built from cheap inputs, which cannot see a schema or hook change, so I left it.

Verified end to end on a real `nuxt build`: unchanged rebuild logs `assets reused` and drops from 14.8ms to 3.0ms, a changed file rewrites, a wiped generated directory rewrites, and the built server still serves the content routes under the same revision.

### Additional context

The bench corpus is the local module docs plus the nuxtseo.com site content, same as `bench/site-harlanzw` points at a local checkout. `COMARK_BENCH_CORPUS` overrides it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).