### PR TITLE
fix(runner): size the deploy pool from its measured peak, not a guess

### DIFF
--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -10,13 +10,20 @@
 # max   Ceiling for the pool, warm included. Reached only under burst.
 # cpus  Quota for one container, and the unit the CPU budget is spent in.
 #
+# Pool memory is sized from measured peaks, not guesses. Read them from a live
+# container with `memory.peak` in its cgroup while a job runs. Measured
+# 2026-08-19: the nuxtseo deploy build peaked at 10.7g, and the busiest CI
+# container at 7.8g. Oversizing is not free here, because a warm slot promises
+# its whole limit the moment it claims a job, and that promise is what the burst
+# budget has to subtract.
+#
 # Public repositories are absent on purpose. A self-hosted runner on a public
 # repository lets a fork pull request run code on this workstation, so
 # unhead.unjs.io, request-indexing, harlanzw.com, and unlighthouse.dev stay on
 # GitHub-hosted runners.
 
 harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|5|6|12g|14g
-harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|32g|40g
+harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|20g|24g
 harlan-zw/gscdump.com|harlan-desktop-ci|1|5|6|12g|14g
 harlan-zw/mdream.dev|harlan-desktop-ci|1|3|6|12g|14g
 harlan-zw/zhead.dev|harlan-desktop-ci|1|3|6|12g|14g


### PR DESCRIPTION
### Description

Follow-up to #77, with numbers this time.

The nuxtseo deploy pool asked for 32g. Read off a live build with `memory.peak` from its cgroup, it peaks at **10.7g**. The limit was three times the need.

That is worse than wasteful. A warm slot promises its entire limit the moment it claims a job, and the burst budget from #77 subtracts that promise. So a deploy actually using 10.7g was reserving 32g of a 36g budget and blocking every CI burst for its whole run. Most of the 42 refusals logged in the first 45 minutes are that, not real pressure.

20g keeps about 1.9x the measured peak, and leaves room for a 12g CI burst beside a deploy (20 + 12 = 32, inside the budget). The budget gets more accurate rather than just smaller.

### What I measured

Peak against limit, from `memory.peak` on live containers, 2026-08-19:

| container | peak | limit |
| --- | --- | --- |
| nuxtseo deploy | 10.7g | 32g |
| scripts CI | 7.8g | 12g |
| nuxtseo CI 1 | 4.1g | 12g |
| skilld CI | 2.0g | 12g |
| nuxtseo CI 2 | 0.9g | 12g |
| gscdump, zhead, mdream (idle) | ~45Mi | 12g |

The idle figure is worth keeping in mind: a warm listener really does cost about 45Mi, so warm slots are cheap to hold and expensive only once they claim.

### What I deliberately did not change

The CI pools stay at 12g. The busiest measured 7.8g, so 12g is already only 1.5x headroom, and trimming them would trade a host-level OOM for an in-container OOM, which is the worse of the two failures. If they ever need to come down, the peaks want sampling across a full week first; one afternoon is not a distribution.

These are per-job peaks from ephemeral containers, so they are representative rather than a proven worst case.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).