### PR TITLE
perf(runner): share one pnpm store, and stop caching it over the network

### DIFF
--- a/.github/actions/harlan-desktop-setup/action.yml
+++ b/.github/actions/harlan-desktop-setup/action.yml
@@ -1,5 +1,5 @@
 name: Harlan Desktop setup
-description: Install pnpm, Node, and the workspace, with the store cached and lifecycle scripts off.
+description: Install pnpm, Node, and the workspace from the shared store, with lifecycle scripts off.
 
 # NOT GENERAL PURPOSE. Harlan's own sites only; the pinned versions track what
 # those sites run and change without notice.
@@ -30,13 +30,22 @@ runs:
   steps:
     - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-    # `cache: pnpm` keys the pnpm store on pnpm-lock.yaml. Without it a job
-    # re-downloads the whole dependency set; on nuxtseo.com that measured about
-    # 56s of every job.
+    # No `cache: pnpm` on purpose. This action only ever runs on the desktop
+    # pool, where every container mounts one shared pnpm store, so a job already
+    # resolves packages from local disk.
+    #
+    # Caching on top of that was not merely redundant, it was slower than no
+    # cache at all. GitHub's cache service measured 1.3-4.3 MB/s from here,
+    # because all the containers share one uplink: 66s on nuxtseo.com to replace
+    # a 14s warm install, and on gscdump.com five jobs each pulling the SAME
+    # 340 MB tarball, 1.79 GB per run and half of that repo's CI wall time. A run
+    # whose cache came back empty reinstalled from npm in 19s and beat it.
+    #
+    # A GitHub-hosted job has no shared store and should still cache. Set it up
+    # in that workflow, not here.
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
-        cache: pnpm
 
     - if: inputs.install == 'true'
       shell: bash

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -69,6 +69,21 @@ readonly burst_idle_seconds="${HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS:-300}"
 # row, so a dead registration clears after twice this long at worst.
 readonly prune_interval_seconds="${HARLAN_DESKTOP_RUNNER_PRUNE_INTERVAL_SECONDS:-300}"
 readonly container_label='com.harlanzw.desktop-runner'
+# One pnpm store shared by every container, so an ephemeral job resolves packages
+# from local disk instead of refetching them.
+#
+# Without it each job restores the store from GitHub's cache service, which
+# measured 1.3-4.3 MB/s on this host: 66s on nuxtseo to replace a 14s warm
+# install, and on gscdump five jobs pulling the SAME 340 MB tarball, 1.79 GB per
+# run and 50% of that repo's CI wall time. The cache was slower than not caching
+# at all -- a job whose cache came back empty reinstalled from npm in 19s.
+#
+# The store is content-addressed and safe for concurrent readers and writers, so
+# containers may share it. It lives on a different device from `_work`, so pnpm
+# copies where it would otherwise hardlink; that costs a few seconds against the
+# minute it saves. It grows without bound, so prune it on a timer, never during
+# a job.
+readonly pnpm_store_volume="${HARLAN_DESKTOP_RUNNER_PNPM_VOLUME:-harlan-runner-pnpm-store}"
 # Readable by the status command, unlike /tmp under this unit's PrivateTmp.
 readonly state_root="${XDG_RUNTIME_DIR:-/tmp}/harlan-desktop-github-runner"
 # Copied here at startup so the status command can size pools without reading a
@@ -219,6 +234,28 @@ count_markers() {
   printf '%s' "$total"
 }
 
+# The store volume must exist and belong to the container's `runner` user before
+# any job starts. Docker creates a named volume owned by root, and the runner is
+# uid 1001, so a fresh machine would fail every install until someone noticed.
+ensure_pnpm_store() {
+  if ! docker volume inspect "$pnpm_store_volume" >/dev/null 2>&1; then
+    docker volume create "$pnpm_store_volume" >/dev/null || {
+      log "Could not create the pnpm store volume $pnpm_store_volume; jobs will fall back to their own store"
+      return 0
+    }
+    log "Created pnpm store volume $pnpm_store_volume"
+  fi
+
+  # Cheap and idempotent, and it repairs a volume restored from a backup as the
+  # wrong owner. Failure here is not fatal: pnpm would still work, just slower.
+  # `--entrypoint` is required: the image's entrypoint expects a registration
+  # token on stdin and exits without one.
+  docker run --rm --user 0 --entrypoint chown \
+    --volume "$pnpm_store_volume:/pnpm-store" \
+    "$runner_image" --recursive 1001:1001 /pnpm-store >/dev/null 2>&1 \
+    || log "Could not set ownership on $pnpm_store_volume; check it is writable by uid 1001"
+}
+
 reserve() {
   local container_name="$1"
   local cpus="$2"
@@ -292,6 +329,8 @@ run_container() {
     --cpus "${pool_cpus[$pool_index]}" \
     --memory "${pool_memory[$pool_index]}" \
     --memory-swap "${pool_memory_swap[$pool_index]}" \
+    --volume "$pnpm_store_volume:/pnpm-store" \
+    --env npm_config_store_dir=/pnpm-store \
     --pids-limit 4096 \
     --cap-drop ALL \
     --security-opt no-new-privileges \
@@ -581,6 +620,8 @@ main() {
   if (( widest_pool_memory > memory_budget_gib )); then
     log "A pool asks for ${widest_pool_memory}g against a ${memory_budget_gib}g budget, so it can never burst. Raise HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB above it."
   fi
+
+  ensure_pnpm_store
 
   run_scaler &
   run_pruner &


### PR DESCRIPTION
### Description

Runner containers are ephemeral with no shared store, so every job restored the whole dependency set from GitHub's cache service. Measured from this host that service runs at **1.3-4.3 MB/s**, because all the containers share one uplink.

It was slower than not caching at all.

- nuxtseo.com: a **66s** restore replaced a **14s** warm install.
- gscdump.com: five jobs of one run each pulled the **same** 340 MB tarball. 1.79 GB per run, and **417s of an 829s run, half its CI wall time**.
- A run whose cache came back empty reinstalled from npm in **19s**, beating the working-cache path by ~175s.

The store cache also self-poisons: the same key served 410 MB at 08:55 and 6,824 bytes at 09:16, and once a near-empty entry lands under a lockfile hash the post step reports a hit and never re-saves.

Containers now mount one shared content-addressed store, so a job resolves from local disk. The desktop setup action drops `cache: pnpm` to match.

### Verified before shipping, not assumed

- `npm_config_store_dir=/pnpm-store` resolves the store onto the volume (`pnpm store path` -> `/pnpm-store/v10`).
- uid 1001 can write it, and an install populates it.
- The image bakes no Node, npm or pnpm, so the entrypoint needs overriding for the chown step. My first version of `ensure_pnpm_store` got this wrong and failed silently; the committed one passes `--entrypoint chown` and I ran it to confirm.
- After restart, `docker inspect` shows the mount and the env var on every live container.

The volume is created and chowned to the runner uid at startup, because Docker makes a named volume root-owned and a fresh machine would otherwise fail every install.

### Trade-offs

The store sits on a different device from `_work`, so pnpm copies where it would otherwise hardlink. That costs a few seconds against the minute it saves. Recovering hardlinks means moving `_work` onto the same volume, which needs per-container cleanup, so I have not done it.

The store grows without bound and wants pruning on a timer, never during a job. Not in this change.

A GitHub-hosted job has no shared store and should still cache. gscdump's cloud deploy sets that up in its own workflow and is untouched; the desktop action is desktop-only by name and by use.

Consumer side: harlan-zw/nuxtseo.com#346.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).