### PR TITLE
perf(runner): budget memory from measured use, not from container limits

### DIFF
--- a/infra/github-runner/harlan-desktop-github-runner.service
+++ b/infra/github-runner/harlan-desktop-github-runner.service
@@ -8,9 +8,19 @@ Type=simple
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner/runners.conf
 # 24 physical cores, modestly oversubscribed; runner work is IO-heavy.
 Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=48
-# 60g host. Leaves ~24g for the desktop session, and lets the 32g deploy pool
-# run while holding CI back.
-Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=36
+# 60g host. Sized from MEASURED usage, not from the container limits it sums.
+#
+# A CI container is capped at 12g but measured 0.02-4.2g resident all afternoon:
+# eight live containers held 104g of limits against 3g of real use. Budgeting the
+# limits starved the one repository that had a backlog, because the budget is
+# global and first-come, so idle warm slots elsewhere held it while 50 jobs
+# queued. 80g of promises maps to roughly 15-25g of real memory against the ~30g
+# this host has spare.
+#
+# Re-read `memory.peak` from a busy container before moving this again. The two
+# earlier values, 36 and 52, were both derived from limits rather than
+# measurement, and both throttled the queue.
+Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=80
 ExecStart=%h/.local/lib/harlan-desktop-github-runner/supervisor
 Restart=always
 RestartSec=10

--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -22,7 +22,7 @@
 # unhead.unjs.io, request-indexing, harlanzw.com, and unlighthouse.dev stay on
 # GitHub-hosted runners.
 
-harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|5|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|8|6|12g|14g
 harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|20g|24g
 harlan-zw/gscdump.com|harlan-desktop-ci|1|5|6|12g|14g
 harlan-zw/mdream.dev|harlan-desktop-ci|1|3|6|12g|14g


### PR DESCRIPTION
### Description

Third pass at this number, and the first one derived from a measurement rather than from the limits.

The budget subtracts what a pool *promises*. A pool promises far more than it uses:

```
TOTAL use = 3g   promised = 104g
```

Per container, measured live: peaks of 4.2g, 2.1g, 2.1g, 1.2g and four at ~45Mi, each against a 12g cap.

So budgeting the limits throttled the host it was meant to protect. The budget is global and first-come, so idle warm slots in quiet repositories held it while the one repository with **50 queued jobs** was refused every burst:

```
Memory in flight 48g, budget 52g; holding nuxtseo-com-ci at 2
```

Two CI containers, on a host with 21g of RAM free and load under 6.

80g of promises maps to roughly 15-25g of real memory against the ~30g this host has spare. Also lifts the nuxtseo CI ceiling from 5 to 8 so the budget governs concurrency rather than an arbitrary pool ceiling.

### Worth saying plainly

Both earlier values were mine, and both were wrong in the same direction. 36 was set during an incident when swap was down to 73Mi, which was right for that moment and wrong once it passed. 52 was a half-step that kept the same mistake: reasoning from limits instead of reading `memory.peak`. The comment now says to measure before moving it again.

This also folds in two live-only changes that were installed but never committed, so the repo and the running host agree again: the 52 budget and the nuxtseo CI `max` of 8.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).