### PR TITLE
chore: release nuxt-cloudflare 0.2.0

### DIFF
--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@harlan-zw/nuxt-cloudflare` 0.1.0 → 0.2.0, releasing #76 and #78.

Minor rather than patch, because it changes behaviour and adds public surface:

- `workersCache.html` (`'auto' | 'app' | 'no-store'`, default `'auto'`)
- a new `@harlan-zw/nuxt-cloudflare/cache` subpath exporting `edgeCache` and `NO_STORE`
- `render:response` no longer writes cache headers, and the fail-closed floor moves to the `request` hook

The behaviour change worth flagging for anyone upgrading: an explicit `cache-control` on a route rule is now honoured on rendered documents when a module publishes a chunk-retention guarantee, where before it was always replaced with `private, no-store`. With nothing publishing one, the outcome is unchanged.

Verified before tagging: 317 tests, lint, typecheck, build, and `test:pack` confirms `dist/cache.mjs` and `dist/cache.d.mts` ship, so the new subpath resolves for consumers.

Tag `nuxt-cloudflare-v0.2.0` follows once this merges.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).