### PR TITLE
fix(nuxt-cloudflare): resolve the cache subpath under node10

### DIFF
--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -60,6 +60,9 @@
       "bindings": [
         "dist/bindings.d.mts"
       ],
+      "cache": [
+        "dist/cache.d.mts"
+      ],
       "d1": [
         "dist/d1.d.mts"
       ],


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The 0.2.0 release failed at `test:attw`:

```
│ "@harlan-zw/nuxt-cloudflare/cache" │ 💀 Resolution failed │ 🟢 (ESM) │ 🟢 (ESM) │ 🟢 │
```

node10 resolution ignores `exports` and reads `typesVersions` instead. Every other subpath has an entry there; the one added in #78 did not, so the types were unreachable for anyone on that resolution mode.

Nothing was published. The release gate caught it and stopped before `npm publish`, so npm is still on 0.1.0 and the tag can be re-cut once this lands.

Worth noting for its own sake: `attw` only runs in the Release workflow, not in `verify`, so a broken subpath export cannot be caught by PR CI today. Moving it into `verify` would have failed #78 instead of the release.

All four modes green locally after the fix.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).