### PR TITLE
perf(runner): raise the CPU budget above the warm floor

### DIFF
--- a/infra/github-runner/harlan-desktop-github-runner.service
+++ b/infra/github-runner/harlan-desktop-github-runner.service
@@ -6,8 +6,11 @@ Wants=network-online.target
 [Service]
 Type=simple
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner/runners.conf
-# 24 physical cores, modestly oversubscribed; runner work is IO-heavy.
-Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=48
+# 24 physical cores. Sized from measured load, not from the quotas it sums: a
+# busy CI container holds 6 cores of quota and used about 1 percent of one, and
+# load sat near 8 with 46 cores committed. 48 was below the 58-core warm floor,
+# so bursting switched off whenever most pools were busy and the queue stalled.
+Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=72
 # 60g host. Sized from MEASURED usage, not from the container limits it sums.
 #
 # A CI container is capped at 12g but measured 0.02-4.2g resident all afternoon:


### PR DESCRIPTION
### Description

The supervisor's own startup warning was correct and unheeded:

```
Warm floor is 58 CPU against a burst threshold of 48, so bursting is off
whenever most pools are busy.
```

So bursting was structurally disabled under load. 64 jobs queued while load sat near 8 on 24 cores, and a busy CI container used about 1 percent of its 6 core quota.

Same error as the memory budget: sizing from the quota a pool reserves rather than from what it uses. 72 clears the warm floor with headroom.

Also carries forward the 80g memory budget and the nuxtseo CI ceiling of 8, which were installed live but never committed. Supersedes #82.

Worth watching: once the shared pnpm store lands its saving, these jobs stop waiting on network and become CPU bound, so load may rise sharply from here. Re-read load before raising this again.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).