### PR TITLE
fix(cf-jobs): retry DLQ rows after stale release

### DIFF
--- a/packages/nuxt-cf-jobs/README.md
+++ b/packages/nuxt-cf-jobs/README.md
@@ -362,6 +362,8 @@ The generated `prepareJob()` loads the full job definition, validates the payloa
 
 The module registers `cf-jobs:reconcile` by default. Every two minutes it reclaims stale reservations, re-dispatches older due rows that have no queue message, and closes orphaned batches when it has enough terminal evidence.
 
+If a transport message reaches its DLQ during a live reservation, the row becomes unpublished when durable attempts remain. Reconcile sends a replacement as soon as it releases the stale reservation. Rows with exhausted durable attempts become terminal failures instead.
+
 ```ts
 export default defineNuxtConfig({
   cfJobs: {

--- a/packages/nuxt-cf-jobs/src/runtime/server/d1.ts
+++ b/packages/nuxt-cf-jobs/src/runtime/server/d1.ts
@@ -672,7 +672,11 @@ export function createD1DurableJobRepository<Queue extends string = string>(
       const evidence = dlqArrivalEvidence(at, input.messageAttempts)
       const row = await db.prepare<{ id: string }>(`
         UPDATE ${jobsTable}
-        SET retry_reasons = ${appendFailureEvidenceSql('retry_reasons')}
+        SET published_at = CASE
+              WHEN max_attempts IS NULL OR attempts < max_attempts THEN NULL
+              ELSE published_at
+            END,
+            retry_reasons = ${appendFailureEvidenceSql('retry_reasons')}
         WHERE id = ?
           AND completed_at IS NULL
           AND failed_at IS NULL

--- a/packages/nuxt-cf-jobs/src/runtime/server/outbox.ts
+++ b/packages/nuxt-cf-jobs/src/runtime/server/outbox.ts
@@ -171,7 +171,9 @@ export type NoteDurableJobDlqArrivalResult
 export interface DurableJobFailureEvidenceRepository {
   /**
    * Record that Cloudflare exhausted a durable message while its row could not
-   * be claimed. This must not take ownership of the row.
+   * be claimed. Retriable rows become unpublished so recovery can replace the
+   * exhausted transport message after releasing its stale reservation. This
+   * must not take ownership of the row.
    */
   noteDlqArrival: (id: string, input: NoteDurableJobDlqArrivalInput) => Promise<NoteDurableJobDlqArrivalResult>
 }

--- a/packages/nuxt-cf-jobs/src/runtime/server/recovery.ts
+++ b/packages/nuxt-cf-jobs/src/runtime/server/recovery.ts
@@ -101,19 +101,32 @@ export async function recoverDurableJobs<
   // every tick (oldest candidates first) and becomes a producer instead
   // of a repair. See `DurableJobRecoveryQuery.redispatchedBefore`.
   const redispatchGraceSeconds = Math.max(0, opts.redispatchGraceSeconds ?? orphanedSeconds)
-  const orphaned = await findDispatchableDurableJobs(repository, {
+  // Unpublished rows have no live transport message. This includes an outbox
+  // send failure and a retriable message whose DLQ arrival cleared its
+  // publication marker. Recover them as soon as they are due and unreserved;
+  // the orphan age and redelivery grace apply only to published rows whose
+  // original message may still arrive.
+  const unpublished = await findDispatchableDurableJobs(repository, {
     now: nowSeconds,
-    createdBefore: nowSeconds - orphanedSeconds,
-    ...(redeliveryGraceSeconds > 0 ? { staleReleasedBefore: nowSeconds - redeliveryGraceSeconds } : {}),
-    ...(redispatchGraceSeconds > 0 ? { redispatchedBefore: nowSeconds - redispatchGraceSeconds } : {}),
-    publication: 'all',
+    publication: 'unpublished',
     limit,
   })
+  const remainingLimit = Math.max(0, limit - unpublished.length)
+  const orphaned = remainingLimit > 0
+    ? await findDispatchableDurableJobs(repository, {
+        now: nowSeconds,
+        createdBefore: nowSeconds - orphanedSeconds,
+        ...(redeliveryGraceSeconds > 0 ? { staleReleasedBefore: nowSeconds - redeliveryGraceSeconds } : {}),
+        ...(redispatchGraceSeconds > 0 ? { redispatchedBefore: nowSeconds - redispatchGraceSeconds } : {}),
+        publication: 'published',
+        limit: remainingLimit,
+      })
+    : []
 
   const releasedIds = new Set(stale.slice(0, released).map(job => job.id))
   const dispatchable = uniqueJobs(redeliveryGraceSeconds > 0
-    ? orphaned.filter(job => !releasedIds.has(job.id))
-    : [...stale.slice(0, released), ...orphaned])
+    ? [...unpublished, ...orphaned.filter(job => !releasedIds.has(job.id))]
+    : [...unpublished, ...stale.slice(0, released), ...orphaned])
   const publicationRepository = repository as DurableJobRecoveryRepository<Queue, Record> & Partial<DurableJobPublicationRepository>
   const dispatchResults: Array<DispatchDurableJobBatchResult<Queue>> = publicationRepository.markJobsPublished && publicationRepository.noteJobsDispatchFailure
     ? (await publishDurableJobBatch(

--- a/packages/nuxt-cf-jobs/tests/outbox-publication.test.ts
+++ b/packages/nuxt-cf-jobs/tests/outbox-publication.test.ts
@@ -277,6 +277,52 @@ describe('durable publication state', () => {
     await expect(repository.claimJob(job.id)).resolves.toMatchObject({ id: job.id })
   })
 
+  it('re-publishes a retryable stale claim when its transport message reached the DLQ', async () => {
+    const db = createSqliteD1()
+    const repository = createD1DurableJobRepository(db)
+    await repository.migrate()
+    const job = await record('transport-exhausted')
+    expect((await stagePreparedDurableJobs(repository, [job])).status).toBe('staged')
+    await publishDurableJobBatch(repository, { sendBatch: async () => true }, [job], { now: 100 })
+    await expect(repository.claimJob(job.id)).resolves.toMatchObject({ id: job.id })
+    db._db.prepare('UPDATE jobs SET reserved_at = 100 WHERE id = ?').run(job.id)
+    await repository.noteDlqArrival(job.id, { messageAttempts: 5, at: 200 })
+    const publisher = { sendBatch: vi.fn(async () => true) }
+
+    const recovered = await recoverDurableJobs(repository, publisher, {
+      now: 1_000,
+      staleSeconds: 300,
+      orphanedSeconds: 21_600,
+      redeliveryGraceSeconds: 120,
+    })
+
+    expect(recovered).toMatchObject({ released: 1, dispatched: 1 })
+    expect(publisher.sendBatch).toHaveBeenCalledWith('events', [{ jobId: job.id, queue: 'events' }], { delaySeconds: undefined })
+    expect(db._db.prepare('SELECT published_at FROM jobs WHERE id = ?').get(job.id)).toEqual({ published_at: 1_000 })
+  })
+
+  it('terminalizes a stale claim when its durable attempts were exhausted before the DLQ', async () => {
+    const db = createSqliteD1()
+    const repository = createD1DurableJobRepository(db)
+    await repository.migrate()
+    const job = await record('durable-exhausted')
+    expect((await stagePreparedDurableJobs(repository, [job])).status).toBe('staged')
+    await publishDurableJobBatch(repository, { sendBatch: async () => true }, [job], { now: 100 })
+    db._db.prepare('UPDATE jobs SET reserved_at = 100, attempts = max_attempts WHERE id = ?').run(job.id)
+    await repository.noteDlqArrival(job.id, { messageAttempts: 5, at: 200 })
+    const publisher = { sendBatch: vi.fn(async () => true) }
+
+    const recovered = await recoverDurableJobs(repository, publisher, {
+      now: 1_000,
+      staleSeconds: 300,
+      orphanedSeconds: 21_600,
+    })
+
+    expect(recovered).toMatchObject({ released: 0, dispatched: 0 })
+    expect(publisher.sendBatch).not.toHaveBeenCalled()
+    expect(db._db.prepare('SELECT id FROM failed_jobs WHERE id = ?').get(job.id)).toEqual({ id: job.id })
+  })
+
   it('never selects already-published backlog rows for recovery', async () => {
     const db = createSqliteD1()
     const repository = createD1DurableJobRepository(db)

--- a/packages/nuxt-cf-jobs/tests/recovery.test.ts
+++ b/packages/nuxt-cf-jobs/tests/recovery.test.ts
@@ -1,3 +1,4 @@
+import type { DurableJobRecoveryQuery } from '#cf-jobs/server'
 import { describe, expect, it, vi } from 'vitest'
 import { recoverDurableJobs } from '#cf-jobs/server'
 
@@ -10,10 +11,12 @@ describe('recoverDurableJobs', () => {
         { id: 'dupe', queue: 'q' },
       ]),
       releaseStaleReservedJobs: vi.fn(async () => 2),
-      findDispatchableJobs: vi.fn(async () => [
-        { id: 'dupe', queue: 'q' },
-        { id: 'orphaned', queue: 'q' },
-      ]),
+      findDispatchableJobs: vi.fn(async (query?: DurableJobRecoveryQuery) => query?.publication === 'unpublished'
+        ? []
+        : [
+            { id: 'dupe', queue: 'q' },
+            { id: 'orphaned', queue: 'q' },
+          ]),
     }
     const publisher = {
       sendBatch: vi.fn(async (queue: string, messages: Array<{ jobId: string }>) => {
@@ -37,13 +40,18 @@ describe('recoverDurableJobs', () => {
       error: 'stale-reservation',
       limit: 10,
     })
-    expect(repository.findDispatchableJobs).toHaveBeenCalledWith({
+    expect(repository.findDispatchableJobs).toHaveBeenNthCalledWith(1, {
+      now: 1_000,
+      publication: 'unpublished',
+      limit: 10,
+    })
+    expect(repository.findDispatchableJobs).toHaveBeenNthCalledWith(2, {
       now: 1_000,
       createdBefore: 400,
       staleReleasedBefore: 880,
       // Defaults to orphanedSeconds: a row is re-sent at most once per window.
       redispatchedBefore: 400,
-      publication: 'all',
+      publication: 'published',
       limit: 10,
     })
     expect(sent).toEqual([{ queue: 'q', ids: ['orphaned'] }])
@@ -124,7 +132,7 @@ describe('recoverDurableJobs orphan re-dispatch damping', () => {
         findStaleReservedJobs: vi.fn(async () => []),
         releaseStaleReservedJobs: vi.fn(async () => 0),
         // A backlog: every row is old, due and unreserved on every tick.
-        findDispatchableJobs: vi.fn(async () => rows),
+        findDispatchableJobs: vi.fn(async (query?: DurableJobRecoveryQuery) => query?.publication === 'unpublished' ? [] : rows),
         noteOrphanRedispatch: vi.fn(async (ids: readonly string[]) => {
           noted.push([...ids])
           return ids.length


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

An in-flight Queue Job whose Cloudflare message reached the DLQ stayed marked published, so reconcile could release it after 15 minutes and still wait six hours before sending a replacement. Retriable rows now re-enter the unpublished outbox, while completed and durable-exhausted rows stay terminal.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).