### PR TITLE
feat(nuxt-cloudflare): default to partial bundling in generated wrangler config

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -15,6 +15,7 @@ Every default below yields to a value you wrote. The root `wrangler.jsonc`, `wra
 - `workers_dev` disabled when a route proves the Worker remains reachable; workers without routes must choose explicitly
 - Version metadata binding at `CF_VERSION_METADATA`
 - Smart Placement enabled unless the project chooses a placement
+- Partial bundling: `find_additional_modules` plus a fallthrough `ESModule` rule for `**/*.mjs`, unless a rule already covers mjs or `no_bundle` is set
 - Workers Caching enabled with version isolation
 - Rendered HTML forced to `private, no-store`; explicit non-HTML cache policies remain intact
 - Source-map upload when the Nitro build emits maps; an authored value is preserved
@@ -66,6 +67,8 @@ Cloudflare KV requires TTLs of at least 60 seconds. The cache wrapper raises sho
 Keep server runtime secret defaults empty. Nuxt reads matching `NUXT_*` values from Worker secret bindings at runtime. The production build guard rejects secret build environment values before Nitro can include them in the bundle. Nuxt Scripts proxy signing remains allowed because that module registers its security plugin during the build.
 
 Workers Caching is separate from Nitro's KV-backed cache. The module enables version-isolated caching by default. Set `workersCache: { _tag: 'disabled' }` to opt out. Choose cross-version caching only with an explicit purge path.
+
+Partial bundling is on by default. Wrangler's default bundling inlines every lazy chunk into one module the isolate parses at startup; on the Nuxt SEO Pro Worker that was a 26.3MB bundle, and partial bundling cut `wrangler check startup` active CPU from 118ms to 81ms by deploying chunks as separate modules. The generated config gains `find_additional_modules: true` and a fallthrough `ESModule` rule for `**/*.mjs`; rules you wrote are kept, and one that already covers mjs wins. Configs with `no_bundle` inject neither key, because Wrangler already defaults `find_additional_modules` to true there and applies your rules as written. Set `partialBundles: false` to keep single-bundle deploys.
 
 The module writes a fail-closed `private, no-store` before routing, so a response nobody described is never cached. It never rewrites a policy you set on a response that is not a rendered document, so asset and API route rules are yours.
 

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -31,6 +31,7 @@ export interface ModuleOptions {
     defaultTtl?: number
   }
   logsSampleRate?: number
+  partialBundles?: boolean
   publicVarNames?: string[]
   requiredSecrets?: string[]
   sourceMaps?: boolean
@@ -164,6 +165,7 @@ export function configureNitroCloudflare(
   nitro.cloudflare.wrangler = applyCloudflareDefaults(nitro.cloudflare.wrangler ?? {}, {
     compatibilityDate: options.compatibilityDate,
     logsSampleRate: options.logsSampleRate,
+    partialBundles: options.partialBundles,
     requiredSecrets: options.requiredSecrets,
     tracesSampleRate: options.tracesSampleRate,
     uploadSourceMaps: options.sourceMaps ?? nitro.sourceMap ?? context.serverSourceMaps ?? false,
@@ -457,6 +459,7 @@ export default defineNuxtModule<ModuleOptions>({
     compatibilityMaxAgeDays: 90,
     doctor: { _tag: 'advisory' },
     logsSampleRate: 0.01,
+    partialBundles: true,
     tracesSampleRate: 0.01,
     versionMetadataBinding: 'CF_VERSION_METADATA',
     workersCache: { _tag: 'enabled', crossVersion: false },

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -20,6 +20,21 @@ export type WranglerPlacementInput
     | { hostname: string, host?: never, mode?: never, region?: never }
     | { region: string, host?: never, hostname?: never, mode?: never }
 
+export type WranglerModuleRuleType
+  = | 'CommonJS'
+    | 'CompiledWasm'
+    | 'Data'
+    | 'ESModule'
+    | 'PythonModule'
+    | 'PythonRequirement'
+    | 'Text'
+
+export interface WranglerModuleRuleInput {
+  type: WranglerModuleRuleType
+  globs: string[]
+  fallthrough?: boolean
+}
+
 export interface WranglerRemoteBindingInput extends Record<string, unknown> {
   binding?: string
   remote?: boolean
@@ -79,6 +94,7 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   compatibility_flags?: string[]
   containers?: WranglerContainerInput[]
   env?: Record<string, WranglerConfigInput>
+  find_additional_modules?: boolean
   images?: WranglerRemoteBindingInput
   keep_vars?: boolean
   limits?: {
@@ -86,6 +102,7 @@ export interface WranglerConfigInput extends Record<string, unknown> {
     subrequests?: number
   }
   mtls_certificates?: WranglerRemoteBindingInput[]
+  no_bundle?: boolean
   observability?: WranglerObservabilityInput
   placement?: WranglerPlacementInput
   preview_urls?: boolean
@@ -95,6 +112,7 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   }
   route?: string | Record<string, unknown>
   routes?: Array<string | Record<string, unknown>>
+  rules?: WranglerModuleRuleInput[]
   secrets?: {
     required?: string[]
   }
@@ -110,6 +128,7 @@ export interface WranglerConfigInput extends Record<string, unknown> {
 export interface CloudflareDefaultOptions {
   compatibilityDate?: string
   logsSampleRate?: number
+  partialBundles?: boolean
   requiredSecrets?: readonly string[]
   tracesSampleRate?: number
   uploadSourceMaps?: boolean
@@ -194,6 +213,20 @@ const SECRET_NAME_RE = /(?:^|_)(?:API_?KEY|AUTH_TOKEN|CLIENT_SECRET|CREDENTIALS?
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
 const NODEJS_COMPAT_V2_DATE = new Date('2024-09-23T00:00:00.000Z')
+const MJS_COVERING_GLOBS = new Set(['**/*.mjs', '**/*'])
+const PARTIAL_BUNDLES_MODULE_RULE: WranglerModuleRuleInput = {
+  type: 'ESModule',
+  globs: ['**/*.mjs'],
+  // Wrangler keeps only the first rule per module type unless it falls
+  // through, and Nitro's `defu` merge places generated rules before authored
+  // ones. Without this a consumer ESModule rule for other globs would be
+  // dropped as redundant.
+  fallthrough: true,
+}
+
+function moduleRuleCoversMjs(rule: WranglerModuleRuleInput): boolean {
+  return rule.type === 'ESModule' && rule.globs.some(glob => MJS_COVERING_GLOBS.has(glob))
+}
 
 function unique(values: readonly string[]): string[] {
   return [...new Set(values)]
@@ -421,6 +454,7 @@ export function applyCloudflareDefaults(
       // Named Wrangler environments inherit the authored root for the keys
       // Wrangler itself inherits, and nothing else.
       authored: resolveEnvironmentPolicy(authored, authored.env?.[name] ?? {}),
+      authoredEnvironment: authored.env?.[name] ?? {},
       inherited: root,
     })]),
   )
@@ -448,6 +482,12 @@ function withNodeCompatibilityFlags(flags: readonly string[]): string[] {
 interface CloudflareEnvironmentLayers {
   /** The root Wrangler file. Outranks every module default. */
   authored?: WranglerConfigInput
+  /**
+   * The named environment's own authored block. Wrangler replaces inherited
+   * keys wholesale, so an environment that declares `rules` never sees the
+   * root's.
+   */
+  authoredEnvironment?: WranglerConfigInput
   /** The resolved root environment, for named Wrangler environments. */
   inherited?: WranglerConfigInput
 }
@@ -507,12 +547,39 @@ function applyEnvironmentDefaults(
       ? inherited.version_metadata
       : undefined)
     ?? (localBindingNames.has(versionMetadataBinding) ? undefined : { binding: versionMetadataBinding })
+  // Wrangler's default esbuild bundling inlines every lazy chunk into one
+  // module the isolate parses at startup. Partial bundling keeps them as
+  // separate uploaded modules: `find_additional_modules` discovers them and
+  // the ESModule rule types them. `no_bundle` skips the bundler, and Wrangler
+  // already defaults `find_additional_modules` to true there, so rules the
+  // consumer wrote apply as written and the module injects nothing.
+  const partialBundles = options.partialBundles ?? true
+  const noBundle = config.no_bundle ?? authored.no_bundle ?? inherited.no_bundle
+  const findAdditionalModules = config.find_additional_modules
+    ?? authored.find_additional_modules
+    ?? inherited.find_additional_modules
+  // Rules the final environment block will carry. Nitro's `defu` merge
+  // concatenates the generated and authored arrays within one environment,
+  // so both count; anything else only reaches this environment through
+  // Wrangler's root inheritance, which applies when the block declares none.
+  const environmentRules = [...(config.rules ?? []), ...(layers.authoredEnvironment?.rules ?? [])]
+  const mjsCovered = environmentRules.length > 0
+    ? environmentRules.some(moduleRuleCoversMjs)
+    : [...(authored.rules ?? []), ...(inherited.rules ?? [])].some(moduleRuleCoversMjs)
 
   return {
     ...config,
     cache,
     ...(compatibilityDate === undefined ? {} : { compatibility_date: compatibilityDate }),
     compatibility_flags: compatibilityFlags,
+    ...(partialBundles && !noBundle
+      ? {
+          find_additional_modules: findAdditionalModules ?? true,
+          // Authored rules stay in the authored config: Nitro's `defu` merge
+          // concatenates arrays, so restating them here would duplicate them.
+          ...(!mjsCovered ? { rules: [PARTIAL_BUNDLES_MODULE_RULE, ...(config.rules ?? [])] } : {}),
+        }
+      : {}),
     observability: {
       ...inherited.observability,
       ...authored.observability,
@@ -1089,11 +1156,14 @@ function resolveEnvironmentPolicy(
     cache: environment.cache ?? root.cache,
     compatibility_date: environment.compatibility_date ?? root.compatibility_date,
     compatibility_flags: environment.compatibility_flags ?? root.compatibility_flags,
+    find_additional_modules: environment.find_additional_modules ?? root.find_additional_modules,
     ...(exports === undefined ? {} : { exports }),
     ...(migrations === undefined ? {} : { migrations }),
+    no_bundle: environment.no_bundle ?? root.no_bundle,
     observability: mergeObservability(root.observability, environment.observability),
     placement: environment.placement ?? root.placement,
     preview_urls: environment.preview_urls ?? root.preview_urls,
+    rules: environment.rules ?? root.rules,
     upload_source_maps: environment.upload_source_maps ?? root.upload_source_maps,
     workers_dev: environment.workers_dev ?? root.workers_dev,
   }

--- a/packages/nuxt-cloudflare/tests/module.test.ts
+++ b/packages/nuxt-cloudflare/tests/module.test.ts
@@ -90,6 +90,26 @@ describe('configureNitroCloudflare', () => {
     expect(nitro.cloudflare?.wrangler?.placement).toEqual({ mode: 'smart' })
   })
 
+  it('enables partial bundling by default', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, {})
+
+    expect(nitro.cloudflare?.wrangler?.find_additional_modules).toBe(true)
+    expect(nitro.cloudflare?.wrangler?.rules).toEqual([
+      { type: 'ESModule', globs: ['**/*.mjs'], fallthrough: true },
+    ])
+  })
+
+  it('supports an explicit partial bundling opt-out', () => {
+    const nitro: NitroCloudflareShape = {}
+
+    configureNitroCloudflare(nitro, { partialBundles: false })
+
+    expect(nitro.cloudflare?.wrangler?.find_additional_modules).toBeUndefined()
+    expect(nitro.cloudflare?.wrangler?.rules).toBeUndefined()
+  })
+
   it('supports version-isolated Workers Caching as an explicit policy', () => {
     const nitro: NitroCloudflareShape = {}
 

--- a/packages/nuxt-cloudflare/tests/wrangler.test.ts
+++ b/packages/nuxt-cloudflare/tests/wrangler.test.ts
@@ -128,6 +128,92 @@ describe('applyCloudflareDefaults', () => {
     })
   })
 
+  describe('partial bundling', () => {
+    it('enables find_additional_modules with a fallthrough ESModule mjs rule by default', () => {
+      expect(applyCloudflareDefaults({})).toMatchObject({
+        find_additional_modules: true,
+        rules: [{ type: 'ESModule', globs: ['**/*.mjs'], fallthrough: true }],
+      })
+    })
+
+    it('keeps an explicit find_additional_modules choice', () => {
+      expect(applyCloudflareDefaults({ find_additional_modules: false }).find_additional_modules).toBe(false)
+    })
+
+    it('keeps an authored find_additional_modules choice', () => {
+      expect(applyCloudflareDefaults({}, {}, { find_additional_modules: false }).find_additional_modules)
+        .toBe(false)
+    })
+
+    it('prepends the mjs rule to consumer rules', () => {
+      expect(applyCloudflareDefaults({
+        rules: [{ type: 'Text', globs: ['**/*.sql'] }],
+      }).rules).toEqual([
+        { type: 'ESModule', globs: ['**/*.mjs'], fallthrough: true },
+        { type: 'Text', globs: ['**/*.sql'] },
+      ])
+    })
+
+    it.each([
+      ['the exact mjs glob', ['**/*.mjs']],
+      ['mjs beside other globs', ['**/*.js', '**/*.mjs']],
+      ['a catch-all glob', ['**/*']],
+    ])('does not duplicate a consumer rule that already covers mjs via %s', (_, globs) => {
+      expect(applyCloudflareDefaults({
+        rules: [{ type: 'ESModule', globs }],
+      }).rules).toEqual([{ type: 'ESModule', globs }])
+    })
+
+    it('leaves authored rules to the authored config', () => {
+      expect(applyCloudflareDefaults({}, {}, {
+        rules: [{ type: 'ESModule', globs: ['**/*.mjs', '**/*.js'] }],
+      }).rules).toBeUndefined()
+    })
+
+    it('injects neither key when the module opts out', () => {
+      const config = applyCloudflareDefaults({}, { partialBundles: false })
+
+      expect(config.find_additional_modules).toBeUndefined()
+      expect(config.rules).toBeUndefined()
+    })
+
+    it.each([
+      ['the generated config', applyCloudflareDefaults({ no_bundle: true })],
+      ['the authored config', applyCloudflareDefaults({}, {}, { no_bundle: true })],
+    ])('injects neither key when no_bundle is set in %s', (_, config) => {
+      expect(config.find_additional_modules).toBeUndefined()
+      expect(config.rules).toBeUndefined()
+    })
+
+    it('applies partial bundling to named environments without restating the root rule', () => {
+      const config = applyCloudflareDefaults({ env: { production: {} } })
+
+      expect(config.find_additional_modules).toBe(true)
+      expect(config.rules).toEqual([{ type: 'ESModule', globs: ['**/*.mjs'], fallthrough: true }])
+      expect(config.env?.production?.find_additional_modules).toBe(true)
+      expect(config.env?.production?.rules).toBeUndefined()
+    })
+
+    it('injects into a named environment that declares its own rules', () => {
+      expect(applyCloudflareDefaults({
+        rules: [{ type: 'Text', globs: ['**/*.sql'] }],
+        env: { production: { rules: [{ type: 'Data', globs: ['**/*.bin'] }] } },
+      }).env?.production?.rules).toEqual([
+        { type: 'ESModule', globs: ['**/*.mjs'], fallthrough: true },
+        { type: 'Data', globs: ['**/*.bin'] },
+      ])
+    })
+
+    it('honours an authored root mjs rule for named environments', () => {
+      const config = applyCloudflareDefaults({ env: { production: {} } }, {}, {
+        rules: [{ type: 'ESModule', globs: ['**/*.mjs'] }],
+      })
+
+      expect(config.rules).toBeUndefined()
+      expect(config.env?.production?.rules).toBeUndefined()
+    })
+  })
+
   describe('node compatibility flags', () => {
     it('never pairs nodejs_compat with nodejs_compat_v2', () => {
       expect(applyCloudflareDefaults({ compatibility_flags: ['nodejs_compat_v2'] }).compatibility_flags)


### PR DESCRIPTION
## What

Makes partial bundling the default in the generated Wrangler config for `packages/nuxt-cloudflare`:

- `find_additional_modules: true` unless the consumer set it (theirs wins, in `nitro.cloudflare.wrangler` or the authored root file, with named-env inheritance).
- Prepends `{ type: "ESModule", globs: ["**/*.mjs"], fallthrough: true }` when no existing rule already covers mjs (exact `**/*.mjs`, or `**/*`). Consumer rules are kept; a covering rule is never duplicated; authored rules stay in the authored config because Nitro's `defu` merge concatenates arrays.
- `fallthrough: true` because Wrangler's `parseRules` keeps only the first rule per module type, and `defu` places generated rules before authored ones; without it a consumer ESModule rule for other globs would be dropped as redundant.
- `no_bundle: true` (generated or authored, inherited) injects neither key: verified in wrangler's source that `noBundleWorker` defaults find_additional_modules to true there and applies consumer rules directly.
- Opt-out: `nuxtCloudflare.partialBundles: false` (default true) injects neither key.
- `WranglerConfigInput` gains `find_additional_modules`, `no_bundle`, and `rules` typed against wrangler's `config-schema.json` (`Rule` = `{ type, globs, fallstream? }`, `ConfigModuleRuleType` enum includes `ESModule`).

Named environments: a new `authoredEnvironment` layer separates the env's own authored block from root inheritance, because Wrangler replaces (not merges) an env's `rules` with the root's only when the env declares none.

## Why (benchmark evidence, verified 2026-08-22 on wrangler 4.124.0 via `wrangler deploy --dry-run` on the nuxtseo.com pro worker)

- 26.3MB single module -> 2.5KB entry + 1.88MB static boot graph + 1699 lazy modules
- DO class export + wasm modules intact, all dynamic imports resolve
- `wrangler check startup` active CPU 118ms -> 81ms, warm TTFB parity
- Upstream: cloudflare/workers-sdk#2672, discussion #13487 (wrangler ignores JS-module rules unless `find_additional_modules` is true)

## Verification

- Package unit tests: 333 passed (8 new `applyCloudflareDefaults` cases + 2 `configureNitroCloudflare` wiring cases); red-first confirmed (6 fail with the injection disabled).
- End-to-end: `nuxt build tests/fixtures/basic` emits `.output/server/wrangler.json` with both defaults; the compiled audit's Wrangler schema validation accepts them; `doctor` on the fixture reports only pre-existing advisories.
- `pnpm run typecheck` and `pnpm run lint` clean.

## Not done

- No new doctor diagnostic (surface is large; nothing natural to extend).
- Version left at 0.2.0; releases follow the `nuxt-cloudflare-v<version>` tag convention.
- `test:fixture`'s `nuxt typecheck` gate fails on clean `origin/main` in this environment (binding-types template `NUXT_B1001`); reproduced with this branch's changes stashed, so pre-existing and untouched here.