### PR TITLE
fix(nuxt-cloudflare): model placement mode 'off' in WranglerPlacementInput

### DIFF
--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -14,8 +14,12 @@ export interface WranglerWorkersCacheInput {
   cross_version_cache?: boolean
 }
 
+// `mode: 'off'` is Wrangler's explicit opt-out of Smart Placement. It exists
+// so a consumer can pin near-user execution instead of relying on the smart
+// default injected below — omitting the key entirely means smart.
 export type WranglerPlacementInput
   = | { mode: 'smart', host?: never, hostname?: never, region?: never }
+    | { mode: 'off', host?: never, hostname?: never, region?: never }
     | { host: string, hostname?: never, mode?: never, region?: never }
     | { hostname: string, host?: never, mode?: never, region?: never }
     | { region: string, host?: never, hostname?: never, mode?: never }


### PR DESCRIPTION
_Agent-authored PR (opencode)._

## What
Adds the missing \`{ mode: 'off' }\` variant to \`WranglerPlacementInput\`. Wrangler accepts \`placement.mode: "smart" | "off"\`, but the module's type only modeled \`smart\`, so consumers explicitly opting out of Smart Placement had to cast (nuxtseo.com does exactly that in apps/pro while the catalog version lags — see its \`fix(pro): disable Smart Placement explicitly\` PR).

The injected default in \`applyEnvironmentDefaults\` is unchanged: unset placement still defaults to smart. This PR only makes the explicit opt-out typeable.

## Evidence
- Package tests: 317/317 pass (18 files). Typecheck clean.

## Note
Related discovery (documented in nuxtseo.com's placement PR): the smart default silently re-enabled Smart Placement on their dashboard worker despite a config comment claiming it was off — worth considering whether the module should default placement to \`off\` or warn when unset, but that is a behavior change and deliberately not part of this type-only PR.