### PR TITLE
feat(wide-events): refine development output

### DIFF
--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -16,14 +16,29 @@ interface DevelopmentWideEventFormatOptions {
   colors?: boolean
 }
 
+interface DevelopmentValueField {
+  _tag: 'Value'
+  key: string
+  value: string | number | boolean
+}
+
+interface DevelopmentGroupField {
+  _tag: 'Group'
+  key: string
+  values: Array<{ key: string, value: string | number | boolean }>
+}
+
+type DevelopmentField = DevelopmentValueField | DevelopmentGroupField
+
 const ANSI = {
-  cyan: '\u001B[36m',
-  dim: '\u001B[2m',
-  gray: '\u001B[90m',
-  green: '\u001B[32m',
-  red: '\u001B[31m',
+  blue: '\u001B[38;2;137;180;250m',
+  green: '\u001B[38;2;166;227;161m',
+  mauve: '\u001B[38;2;203;166;247m',
+  muted: '\u001B[38;2;147;153;178m',
+  peach: '\u001B[38;2;250;179;135m',
+  red: '\u001B[38;2;243;139;168m',
   reset: '\u001B[0m',
-  yellow: '\u001B[33m',
+  teal: '\u001B[38;2;148;226;213m',
 } as const
 
 export function enrichDevelopmentWideEvent(record: WideEventRecord, error: unknown): DevelopmentWideEventRecord {
@@ -54,32 +69,35 @@ export function formatDevelopmentWideEvent(
   const level = record.level.toUpperCase()
   const request = record.kind === 'request'
   const header = [
-    paint(formatTimestamp(record.timestamp), ANSI.dim, colors),
     paint(level, levelColor(record.level), colors),
-    paint(`[${tag}]`, ANSI.cyan, colors),
+    paint(`[${tag}]`, ANSI.mauve, colors),
   ]
 
   if (request) {
-    header.push(`${safeTerminalText(record.method ?? '')} ${safeTerminalText(record.path ?? '')}`)
-    header.push(paint(String(record.status), (record.status ?? 0) >= 400 ? ANSI.red : ANSI.green, colors))
-    header.push(paint(`in ${formatDuration(record.durationMs)}`, ANSI.dim, colors))
+    header.push(`${paint(safeTerminalText(record.method ?? ''), ANSI.blue, colors)} ${safeTerminalText(record.path ?? '')}`)
+    header.push(paint(String(record.status), statusColor(record.status), colors))
+    header.push(paint(formatDuration(record.durationMs), ANSI.muted, colors))
   }
   if (messageLines?.[0])
     header.push(messageLines[0])
+
+  const fields = Object.entries(record)
+    .filter(([key, value]) => value !== undefined && value !== null && !isHeaderField(key))
+    .filter(([key]) => key !== 'devMessage' && !(key === 'scope' && scope !== undefined))
+  const groupedFields = groupFields(fields.filter(([key]) => key !== 'requestId'))
+  // Cloudflare context exists on every edge request, so keep it with the request metadata.
+  const cloudflare = groupedFields.find(field => field.key === 'cf')
+  if (cloudflare)
+    header.push(formatHeadlineField(cloudflare, colors))
+  header.push(formatHeadlineField({ _tag: 'Value', key: 'requestId', value: record.requestId }, colors))
 
   const lines = [header.join(' ')]
   if (messageLines && messageLines.length > 1)
     lines.push(...indentMessageLines(messageLines.slice(1)))
 
-  const fields = Object.entries(record)
-    .filter(([key, value]) => value !== undefined && !isHeaderField(key))
-    .filter(([key]) => key !== 'devMessage' && !(key === 'scope' && scope !== undefined))
-    .sort(([left], [right]) => Number(left === 'requestId') - Number(right === 'requestId'))
-
-  for (const [index, [key, value]] of fields.entries()) {
-    if (value === undefined)
-      continue
-    lines.push(...formatField(key, value, index === fields.length - 1, colors))
+  const detailFields = groupedFields.filter(field => field.key !== 'cf')
+  for (const [index, field] of detailFields.entries()) {
+    lines.push(...formatField(field, index === detailFields.length - 1, colors))
   }
 
   return lines.join('\n')
@@ -96,18 +114,50 @@ export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): v
   console.log(output)
 }
 
-function formatField(key: string, value: string | number | boolean | null, last: boolean, colors: boolean): string[] {
+function formatField(field: DevelopmentField, last: boolean, colors: boolean): string[] {
   const branch = last ? '└─' : '├─'
   const continuation = last ? '  ' : '│ '
-  const valueLines = safeTerminalText(String(value)).split('\n')
+  const valueLines = formatFieldValue(field, colors).split('\n')
   return [
-    `  ${paint(branch, ANSI.dim, colors)} ${paint(`${safeTerminalText(key)}:`, ANSI.cyan, colors)} ${valueLines[0] ?? ''}`,
-    ...valueLines.slice(1).map(line => `  ${paint(continuation, ANSI.dim, colors)}   ${line}`),
+    `  ${paint(branch, ANSI.muted, colors)} ${paint(`${safeTerminalText(field.key)}:`, ANSI.teal, colors)} ${valueLines[0] ?? ''}`,
+    ...valueLines.slice(1).map(line => `  ${paint(continuation, ANSI.muted, colors)}   ${line}`),
   ]
 }
 
-function formatTimestamp(timestamp: string): string {
-  return timestamp.length >= 23 ? timestamp.slice(11, 23) : safeTerminalText(timestamp)
+function formatHeadlineField(field: DevelopmentField, colors: boolean): string {
+  return `${paint('·', ANSI.muted, colors)} ${paint(`${field.key}:`, ANSI.teal, colors)} ${formatFieldValue(field, colors)}`
+}
+
+function formatFieldValue(field: DevelopmentField, colors: boolean): string {
+  if (field._tag === 'Value')
+    return safeTerminalText(String(field.value))
+  return field.values
+    .map(({ key, value }) => `${paint(safeTerminalText(key), ANSI.blue, colors)}${paint('=', ANSI.muted, colors)}${safeTerminalText(String(value))}`)
+    .join(paint(', ', ANSI.muted, colors))
+}
+
+function groupFields(fields: Array<[string, string | number | boolean | null | undefined]>): DevelopmentField[] {
+  const groups = new Map<string, DevelopmentGroupField>()
+  const values: DevelopmentValueField[] = []
+
+  for (const [key, value] of fields) {
+    if (value === null || value === undefined)
+      continue
+    const separator = key.indexOf('.')
+    if (separator < 1) {
+      values.push({ _tag: 'Value', key, value })
+      continue
+    }
+    const group = key.slice(0, separator)
+    const child = key.slice(separator + 1)
+    const grouped = groups.get(group)
+    if (grouped)
+      grouped.values.push({ key: child, value })
+    else
+      groups.set(group, { _tag: 'Group', key: group, values: [{ key: child, value }] })
+  }
+
+  return [...groups.values(), ...values]
 }
 
 function formatDuration(durationMs: number): string {
@@ -145,14 +195,26 @@ function isHeaderField(field: string): boolean {
 function levelColor(level: WideEventLevel): string {
   switch (level) {
     case 'debug':
-      return ANSI.gray
+      return ANSI.muted
     case 'error':
       return ANSI.red
     case 'warn':
-      return ANSI.yellow
+      return ANSI.peach
     default:
-      return ANSI.cyan
+      return ANSI.blue
   }
+}
+
+function statusColor(status: number | undefined): string {
+  if (status === undefined)
+    return ANSI.muted
+  if (status >= 500)
+    return ANSI.red
+  if (status >= 400)
+    return ANSI.peach
+  if (status >= 300)
+    return ANSI.blue
+  return ANSI.green
 }
 
 function paint(value: string, color: string, enabled: boolean): string {

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -24,6 +24,51 @@ describe('enrichDevelopmentWideEvent', () => {
 })
 
 describe('formatDevelopmentWideEvent', () => {
+  it('uses a subtle pastel palette for request syntax', () => {
+    const blue = '\u001B[38;2;137;180;250m'
+    const green = '\u001B[38;2;166;227;161m'
+    const mauve = '\u001B[38;2;203;166;247m'
+    const muted = '\u001B[38;2;147;153;178m'
+    const reset = '\u001B[0m'
+    const teal = '\u001B[38;2;148;226;213m'
+
+    expect(formatDevelopmentWideEvent({
+      'timestamp': '2026-08-14T08:28:15.225Z',
+      'kind': 'request',
+      'level': 'info',
+      'service': 'shop',
+      'method': 'GET',
+      'path': '/cart',
+      'status': 200,
+      'durationMs': 2,
+      'requestId': 'req_1',
+      'cf.colo': 'SYD',
+    }, { colors: true })).toBe(
+      `${blue}INFO${reset} ${mauve}[shop]${reset} ${blue}GET${reset} /cart ${green}200${reset} ${muted}2ms${reset} ${muted}·${reset} ${teal}cf:${reset} ${blue}colo${reset}${muted}=${reset}SYD ${muted}·${reset} ${teal}requestId:${reset} req_1`,
+    )
+  })
+
+  it('keeps successful request output compact', () => {
+    expect(formatDevelopmentWideEvent({
+      'timestamp': '2026-08-14T08:28:15.225Z',
+      'kind': 'request',
+      'level': 'info',
+      'service': 'nuxtseo-pro',
+      'method': 'GET',
+      'path': '/**',
+      'status': 200,
+      'durationMs': 144,
+      'requestId': '7d24a411-02f4-4a8d-b5b7-353d937cd0a4',
+      'cf.colo': 'SYD',
+      'cf.country': 'AU',
+      'cf.httpProtocol': 'HTTP/1.1',
+      'd1.queries': null,
+      'd1.durationMs': null,
+    }, { colors: false })).toBe([
+      'INFO [nuxtseo-pro] GET /** 200 144ms · cf: colo=SYD, country=AU, httpProtocol=HTTP/1.1 · requestId: 7d24a411-02f4-4a8d-b5b7-353d937cd0a4',
+    ].join('\n'))
+  })
+
   it('keeps redirected output free of terminal color codes', () => {
     const isTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     const noColor = process.env.NO_COLOR
@@ -56,8 +101,7 @@ describe('formatDevelopmentWideEvent', () => {
     })()
 
     expect(output).toBe([
-      '08:28:15.225 INFO [Wide Event] GET /api/cart 200 in 1ms',
-      '  └─ requestId: req_1',
+      'INFO [Wide Event] GET /api/cart 200 1ms · requestId: req_1',
     ].join('\n'))
   })
 
@@ -71,11 +115,10 @@ describe('formatDevelopmentWideEvent', () => {
       durationMs: 0.155,
       requestId: 'req_1',
     }, { colors: false })).toBe([
-      '08:28:15.225 DEBUG [ssr] server fetch completed',
+      'DEBUG [ssr] server fetch completed · requestId: req_1',
       '  fetch   : GET /api/_auth/session',
       '  duration: 16ms',
       '  request : GET /',
-      '  └─ requestId: req_1',
     ].join('\n'))
   })
 
@@ -91,10 +134,10 @@ describe('formatDevelopmentWideEvent', () => {
       'durationMs': 16.4,
       'requestId': 'req_2',
       'cart.itemCount': 2,
+      'cart.total': 40,
     }, { colors: false })).toBe([
-      '08:28:15.225 WARN [shop] GET /api/cart 429 in 16ms',
-      '  ├─ cart.itemCount: 2',
-      '  └─ requestId: req_2',
+      'WARN [shop] GET /api/cart 429 16ms · requestId: req_2',
+      '  └─ cart: itemCount=2, total=40',
     ].join('\n'))
   })
 
@@ -109,8 +152,7 @@ describe('formatDevelopmentWideEvent', () => {
       durationMs: 2,
       requestId: 'req_3',
     }, { colors: false })).toBe([
-      '08:28:15.225 INFO [Wide Event] UNKNOWN /webdav/files 405 in 2ms',
-      '  └─ requestId: req_3',
+      'INFO [Wide Event] UNKNOWN /webdav/files 405 2ms · requestId: req_3',
     ].join('\n'))
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt already prints the local time. Each development Wide Event also added a UTC timestamp and empty D1 rows.

Request context now stays on one pastel headline. Null values disappear. Other fields group by their first key.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
