### PR TITLE
fix(wide-events): preserve colours through dev workers

### DIFF
--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-wide-events",
   "type": "module",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Minimal Nuxt Wide Events with build-time field enforcement.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -235,7 +235,10 @@ function safeTerminalText(value: string): string {
 
 function supportsColor(): boolean {
   const process = runtimeProcess()
-  return process !== undefined && process.env.NO_COLOR === undefined && process.stdout?.isTTY === true
+  if (process?.env.NO_COLOR !== undefined)
+    return false
+  const stdout = process?.stdout
+  return stdout?.isTTY === true || stdout?.write === undefined
 }
 
 function runtimeProcess(): {

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent } from '../src/runtime/server/development'
 
 describe('enrichDevelopmentWideEvent', () => {
@@ -103,6 +103,30 @@ describe('formatDevelopmentWideEvent', () => {
     expect(output).toBe([
       'INFO [Wide Event] GET /api/cart 200 1ms · requestId: req_1',
     ].join('\n'))
+  })
+
+  it('keeps terminal colors through a worker console transport', () => {
+    vi.stubGlobal('process', { env: {}, stdout: undefined })
+
+    const output = (() => {
+      try {
+        return formatDevelopmentWideEvent({
+          timestamp: '2026-08-14T08:28:15.225Z',
+          kind: 'request',
+          level: 'info',
+          method: 'GET',
+          path: '/api/cart',
+          status: 200,
+          durationMs: 1,
+          requestId: 'req_1',
+        })
+      }
+      finally {
+        vi.unstubAllGlobals()
+      }
+    })()
+
+    expect(output).toContain('\u001B[38;2;137;180;250mINFO\u001B[0m')
   })
 
   it('renders a background developer message as a compact terminal block', () => {


### PR DESCRIPTION
Cloudflare dev transports console output without a Node stdout stream. That made the TTY check disable the pastel syntax colours.

This keeps colours for worker console transport while preserving plain redirected Node output.

Verified: 112 tests, lint, typecheck, package build.