### PR TITLE
feat(observability): connect request context

### DIFF
--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-cloudflare",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Opinionated Cloudflare deployment defaults and diagnostics for Nuxt.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-cloudflare/src/runtime/server/plugins/wide-events.ts
+++ b/packages/nuxt-cloudflare/src/runtime/server/plugins/wide-events.ts
@@ -29,11 +29,10 @@ import { readD1Stats } from '../../../d1-stats'
  * module rests on — a reviewer can read the allowlist and know nothing else can
  * reach an event.
  *
- * So this cannot build its payload conditionally. Every key is present on every
- * call, `null` where the value is unavailable, and the whole thing is one
- * literal. An earlier version assembled a `Record` and passed the variable; it
- * failed the CONSUMING application's build, which is the worst place for a
- * module's mistake to surface.
+ * So this cannot build its payload conditionally. Every key is present in the
+ * source literal. The Wide Events transform removes `undefined` values at
+ * runtime. An earlier version assembled a `Record` and passed the variable; it
+ * failed the consuming application's build.
  */
 export default (nitroApp: NitroApp): void => {
   nitroApp.hooks.hook('beforeResponse', (event: H3Event) => {
@@ -47,8 +46,8 @@ interface RequestCfProperties {
   httpProtocol?: unknown
 }
 
-function stringOrNull(value: unknown): string | null {
-  return typeof value === 'string' ? value : null
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
 }
 
 export function recordCloudflareWideEventFields(event: H3Event): void {
@@ -65,14 +64,14 @@ export function recordCloudflareWideEventFields(event: H3Event): void {
     return
 
   addWideEventFields(event, {
-    'cf.colo': stringOrNull(cf?.colo),
-    'cf.country': stringOrNull(cf?.country),
-    'cf.httpProtocol': stringOrNull(cf?.httpProtocol),
-    'd1.queries': d1 ? d1.queries : null,
-    'd1.primaryQueries': d1 ? d1.primaryQueries : null,
-    'd1.recoveries': d1 ? d1.recoveries : null,
-    'd1.unrecovered': d1 ? d1.unrecovered : null,
-    'd1.durationMs': d1 ? Math.round(d1.durationMs) : null,
-    'd1.region': d1 ? d1.region : null,
+    'cf.colo': stringOrUndefined(cf?.colo),
+    'cf.country': stringOrUndefined(cf?.country),
+    'cf.httpProtocol': stringOrUndefined(cf?.httpProtocol),
+    'd1.queries': d1?.queries,
+    'd1.primaryQueries': d1?.primaryQueries,
+    'd1.recoveries': d1?.recoveries,
+    'd1.unrecovered': d1?.unrecovered,
+    'd1.durationMs': d1 ? Math.round(d1.durationMs) : undefined,
+    'd1.region': d1?.region ?? undefined,
   })
 }

--- a/packages/nuxt-cloudflare/tests/wide-events-runtime.test.ts
+++ b/packages/nuxt-cloudflare/tests/wide-events-runtime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { emitWideEvent, startWideEvent } from '../../nuxt-wide-events/src/runtime/server/index'
+
+const addFields = vi.hoisted(() => vi.fn())
+
+vi.mock('#imports', () => ({
+  addWideEventFields: addFields,
+}))
+
+describe('cloudflare Wide Event fields', () => {
+  it('omits values that the request did not provide', async () => {
+    const { addWideEventFields } = await import('../../nuxt-wide-events/src/runtime/server/index')
+    addFields.mockImplementation((event, fields) => {
+      const addCompilerOwnedFields = addWideEventFields as unknown as (
+        event: Parameters<typeof addWideEventFields>[0],
+        fields: Parameters<typeof addWideEventFields>[1],
+        owned: true,
+      ) => void
+      addCompilerOwnedFields(event, fields, true)
+    })
+    const { recordCloudflareWideEventFields } = await import('../src/runtime/server/plugins/wide-events')
+    const request = {
+      context: {
+        cloudflare: {
+          request: {
+            cf: { colo: 'SYD' },
+          },
+        },
+      },
+      method: 'GET',
+    }
+    startWideEvent(request, 'req_1', 10)
+
+    recordCloudflareWideEventFields(request as never)
+    const record = emitWideEvent(request, 200, undefined, undefined, 11, 'now')!
+
+    expect(record['cf.colo']).toBe('SYD')
+    expect(Object.values(record)).not.toContain(null)
+  })
+})

--- a/packages/nuxt-wide-events/README.md
+++ b/packages/nuxt-wide-events/README.md
@@ -67,6 +67,8 @@ export default defineEventHandler(async (event) => {
 
 A record keeps the highest level it receives. If the request handler recovers from an error, the record stays an error. A drain and a sampling rate both see the real level.
 
+`getActiveWideEventRequestId(event)` returns the request identity while the Wide Event is collecting. Use it to correlate an application logger, Sentry, or another request-scoped module. It returns `undefined` before collection starts and after emission.
+
 This code stops the build because `user.email` is not configured:
 
 ```ts

--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@harlan-zw/nuxt-wide-events",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Minimal Nuxt Wide Events with build-time field enforcement.",
   "author": {
     "name": "Harlan Wilton",

--- a/packages/nuxt-wide-events/src/module.ts
+++ b/packages/nuxt-wide-events/src/module.ts
@@ -102,6 +102,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
     addServerImports([
       { name: 'addWideEventFields', from: resolver.resolve('./runtime/server/index') },
+      { name: 'getActiveWideEventRequestId', from: resolver.resolve('./runtime/server/index') },
       { name: 'setWideEventLevel', from: resolver.resolve('./runtime/server/index') },
     ])
 

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -103,15 +103,9 @@ export function formatDevelopmentWideEvent(
   return lines.join('\n')
 }
 
-/** Write one development Wide Event without framework console decoration. */
+/** Write through the app console so Nuxt can attribute the log to its request. */
 export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): void {
-  const output = formatDevelopmentWideEvent(record)
-  const stdout = runtimeProcess()?.stdout
-  if (stdout?.write) {
-    stdout.write(`${output}\n`)
-    return
-  }
-  console.log(output)
+  console.log(formatDevelopmentWideEvent(record))
 }
 
 function formatField(field: DevelopmentField, last: boolean, colors: boolean): string[] {

--- a/packages/nuxt-wide-events/src/runtime/server/index.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/index.ts
@@ -69,6 +69,16 @@ export function startWideEvent(event: WideEventLike, requestId?: string, started
   context[STARTED_AT_KEY] = startedAt ?? performance.now()
 }
 
+/** Return the request identity while its Wide Event can still accept Fields. */
+export function getActiveWideEventRequestId(event: WideEventLike): string | undefined {
+  const context = stateContext(event)
+  const state = context[STATE_KEY] as WideEventState | undefined
+  if (state === undefined || state === EMITTED)
+    return undefined
+  const requestId = context[REQUEST_ID_KEY]
+  return typeof requestId === 'string' ? requestId : undefined
+}
+
 export function addWideEventFields(event: WideEventLike, fields: WideEventFields): void
 export function addWideEventFields(event: WideEventLike, fields: WideEventFields, owned = false): void {
   const context = stateContext(event)

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent } from '../src/runtime/server/development'
+import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent, writeDevelopmentWideEvent } from '../src/runtime/server/development'
 
 describe('enrichDevelopmentWideEvent', () => {
   it('adds error details only to a development record', () => {
@@ -178,5 +178,36 @@ describe('formatDevelopmentWideEvent', () => {
     }, { colors: false })).toBe([
       'INFO [Wide Event] UNKNOWN /webdav/files 405 2ms · requestId: req_3',
     ].join('\n'))
+  })
+})
+
+describe('writeDevelopmentWideEvent', () => {
+  it('uses the app console so Nuxt can attribute the log to its request', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    let consoleCalls = 0
+    let stdoutCalls = 0
+
+    try {
+      writeDevelopmentWideEvent({
+        timestamp: '2026-08-14T08:28:15.225Z',
+        kind: 'request',
+        level: 'info',
+        method: 'GET',
+        path: '/api/cart',
+        status: 200,
+        durationMs: 1,
+        requestId: 'req_1',
+      })
+    }
+    finally {
+      consoleCalls = consoleLog.mock.calls.length
+      stdoutCalls = stdoutWrite.mock.calls.length
+      consoleLog.mockRestore()
+      stdoutWrite.mockRestore()
+    }
+
+    expect(consoleCalls).toBe(1)
+    expect(stdoutCalls).toBe(0)
   })
 })

--- a/packages/nuxt-wide-events/tests/runtime.test.ts
+++ b/packages/nuxt-wide-events/tests/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { addWideEventFields, captureWideEventError, emitWideEvent, setWideEventLevel, startWideEvent } from '../src/runtime/server/index'
+import { addWideEventFields, captureWideEventError, emitWideEvent, getActiveWideEventRequestId, setWideEventLevel, startWideEvent } from '../src/runtime/server/index'
 
 function event() {
   return {
@@ -16,6 +16,18 @@ const addCompilerOwnedFields = addWideEventFields as unknown as (
 ) => void
 
 describe('wide Event runtime', () => {
+  it('exposes the request identity only while its Wide Event is collecting', () => {
+    const request = event()
+
+    expect(getActiveWideEventRequestId(request)).toBeUndefined()
+
+    startWideEvent(request, 'req_1', 10)
+    expect(getActiveWideEventRequestId(request)).toBe('req_1')
+
+    emitWideEvent(request, 200, undefined, undefined, 11, 'now')
+    expect(getActiveWideEventRequestId(request)).toBeUndefined()
+  })
+
   it('emits one structured record with configured fields', () => {
     const request = event()
     startWideEvent(request, 'req_1', 10)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

NuxtSEO currently creates a second request ID outside the active Wide Event, and Cloudflare fills absent fields with `null`. This exposes the active request ID for integrations and omits Cloudflare values the request did not provide.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
