### PR TITLE
fix(nuxt-wide-events): preserve console levels

### DIFF
--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -15,6 +15,7 @@ export interface DevelopmentWideEventRecord extends Record<string, string | numb
 interface DevelopmentWideEventFormatOptions {
   colors?: boolean
   target?: 'stdout' | 'stderr'
+  includeLevel?: boolean
 }
 
 interface DevelopmentValueField {
@@ -69,10 +70,9 @@ export function formatDevelopmentWideEvent(
   const tag = safeTerminalText(record.service ?? scope ?? 'Wide Event')
   const level = record.level.toUpperCase()
   const request = record.kind === 'request'
-  const header = [
-    paint(level, levelColor(record.level), colors),
-    paint(`[${tag}]`, ANSI.mauve, colors),
-  ]
+  const header = options.includeLevel === false
+    ? [paint(`[${tag}]`, ANSI.mauve, colors)]
+    : [paint(level, levelColor(record.level), colors), paint(`[${tag}]`, ANSI.mauve, colors)]
 
   if (request) {
     header.push(`${paint(safeTerminalText(record.method ?? ''), ANSI.blue, colors)} ${safeTerminalText(record.path ?? '')}`)
@@ -107,7 +107,7 @@ export function formatDevelopmentWideEvent(
 /** Write one development Wide Event through its matching Console level. */
 export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): void {
   const target: 'stdout' | 'stderr' = record.level === 'warn' || record.level === 'error' ? 'stderr' : 'stdout'
-  const output = formatDevelopmentWideEvent(record, { target })
+  const output = formatDevelopmentWideEvent(record, { includeLevel: false, target })
   switch (record.level) {
     case 'debug':
       console.debug(output)

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -103,15 +103,22 @@ export function formatDevelopmentWideEvent(
   return lines.join('\n')
 }
 
-/** Write one development Wide Event without framework console decoration. */
+/** Write one development Wide Event through its matching Console level. */
 export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): void {
   const output = formatDevelopmentWideEvent(record)
-  const stdout = runtimeProcess()?.stdout
-  if (stdout?.write) {
-    stdout.write(`${output}\n`)
-    return
+  switch (record.level) {
+    case 'debug':
+      console.debug(output)
+      return
+    case 'error':
+      console.error(output)
+      return
+    case 'info':
+      console.info(output)
+      return
+    case 'warn':
+      console.warn(output)
   }
-  console.log(output)
 }
 
 function formatField(field: DevelopmentField, last: boolean, colors: boolean): string[] {

--- a/packages/nuxt-wide-events/src/runtime/server/development.ts
+++ b/packages/nuxt-wide-events/src/runtime/server/development.ts
@@ -14,6 +14,7 @@ export interface DevelopmentWideEventRecord extends Record<string, string | numb
 
 interface DevelopmentWideEventFormatOptions {
   colors?: boolean
+  target?: 'stdout' | 'stderr'
 }
 
 interface DevelopmentValueField {
@@ -59,7 +60,7 @@ export function formatDevelopmentWideEvent(
   record: DevelopmentWideEventRecord,
   options: DevelopmentWideEventFormatOptions = {},
 ): string {
-  const colors = options.colors ?? supportsColor()
+  const colors = options.colors ?? supportsColor(options.target ?? 'stdout')
   const message = typeof record.devMessage === 'string'
     ? safeTerminalText(record.devMessage)
     : undefined
@@ -105,7 +106,8 @@ export function formatDevelopmentWideEvent(
 
 /** Write one development Wide Event through its matching Console level. */
 export function writeDevelopmentWideEvent(record: DevelopmentWideEventRecord): void {
-  const output = formatDevelopmentWideEvent(record)
+  const target: 'stdout' | 'stderr' = record.level === 'warn' || record.level === 'error' ? 'stderr' : 'stdout'
+  const output = formatDevelopmentWideEvent(record, { target })
   switch (record.level) {
     case 'debug':
       console.debug(output)
@@ -240,20 +242,22 @@ function safeTerminalText(value: string): string {
   return output
 }
 
-function supportsColor(): boolean {
+function supportsColor(target: 'stdout' | 'stderr'): boolean {
   const process = runtimeProcess()
   if (process?.env.NO_COLOR !== undefined)
     return false
-  const stdout = process?.stdout
-  return stdout?.isTTY === true || stdout?.write === undefined
+  const stream = target === 'stderr' ? process?.stderr : process?.stdout
+  return stream?.isTTY === true || stream?.write === undefined
 }
 
 function runtimeProcess(): {
   env: Record<string, string | undefined>
   stdout?: { isTTY?: boolean, write?: (output: string) => unknown }
+  stderr?: { isTTY?: boolean, write?: (output: string) => unknown }
 } | undefined {
   return Reflect.get(globalThis, 'process') as {
     env: Record<string, string | undefined>
     stdout?: { isTTY?: boolean, write?: (output: string) => unknown }
+    stderr?: { isTTY?: boolean, write?: (output: string) => unknown }
   } | undefined
 }

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -182,6 +182,66 @@ describe('formatDevelopmentWideEvent', () => {
 })
 
 describe('writeDevelopmentWideEvent', () => {
+  it('colors error output when stderr is a TTY even if stdout is not', () => {
+    vi.stubGlobal('process', {
+      env: {},
+      stdout: { isTTY: false, write: () => true },
+      stderr: { isTTY: true, write: () => true },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      writeDevelopmentWideEvent({
+        timestamp: '2026-08-14T08:28:15.225Z',
+        kind: 'request',
+        level: 'error',
+        method: 'GET',
+        path: '/api/cart',
+        status: 500,
+        durationMs: 1,
+        requestId: 'req_1',
+      })
+
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining('\u001B[38;2;243;139;168mERROR\u001B[0m'),
+      )
+    }
+    finally {
+      vi.restoreAllMocks()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('keeps error output plain when stderr is not a TTY', () => {
+    vi.stubGlobal('process', {
+      env: {},
+      stdout: { isTTY: false, write: () => true },
+      stderr: { isTTY: false, write: () => true },
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      writeDevelopmentWideEvent({
+        timestamp: '2026-08-14T08:28:15.225Z',
+        kind: 'request',
+        level: 'error',
+        method: 'GET',
+        path: '/api/cart',
+        status: 500,
+        durationMs: 1,
+        requestId: 'req_1',
+      })
+
+      expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+        expect.not.stringContaining('\u001B['),
+      )
+    }
+    finally {
+      vi.restoreAllMocks()
+      vi.unstubAllGlobals()
+    }
+  })
+
   it.each([
     ['debug', 'debug'],
     ['info', 'info'],

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent } from '../src/runtime/server/development'
+import { enrichDevelopmentWideEvent, formatDevelopmentWideEvent, writeDevelopmentWideEvent } from '../src/runtime/server/development'
 
 describe('enrichDevelopmentWideEvent', () => {
   it('adds error details only to a development record', () => {
@@ -178,5 +178,47 @@ describe('formatDevelopmentWideEvent', () => {
     }, { colors: false })).toBe([
       'INFO [Wide Event] UNKNOWN /webdav/files 405 2ms · requestId: req_3',
     ].join('\n'))
+  })
+})
+
+describe('writeDevelopmentWideEvent', () => {
+  it.each([
+    ['debug', 'debug'],
+    ['info', 'info'],
+    ['warn', 'warn'],
+    ['error', 'error'],
+  ] as const)('writes %s records through console.%s', (level, method) => {
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const consoleWrites = {
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    }
+
+    try {
+      writeDevelopmentWideEvent({
+        timestamp: '2026-08-14T08:28:15.225Z',
+        kind: 'request',
+        level,
+        method: 'GET',
+        path: '/api/cart',
+        status: 200,
+        durationMs: 1,
+        requestId: 'req_1',
+      })
+
+      expect(consoleWrites[method]).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(`${level.toUpperCase()} [Wide Event] GET /api/cart 200 1ms`),
+      )
+      expect(stdoutWrite).not.toHaveBeenCalled()
+      for (const [name, write] of Object.entries(consoleWrites)) {
+        if (name !== method)
+          expect(write).not.toHaveBeenCalled()
+      }
+    }
+    finally {
+      vi.restoreAllMocks()
+    }
   })
 })

--- a/packages/nuxt-wide-events/tests/development.test.ts
+++ b/packages/nuxt-wide-events/tests/development.test.ts
@@ -203,7 +203,7 @@ describe('writeDevelopmentWideEvent', () => {
       })
 
       expect(consoleError).toHaveBeenCalledExactlyOnceWith(
-        expect.stringContaining('\u001B[38;2;243;139;168mERROR\u001B[0m'),
+        expect.stringContaining('\u001B[38;2;243;139;168m500\u001B[0m'),
       )
     }
     finally {
@@ -261,6 +261,7 @@ describe('writeDevelopmentWideEvent', () => {
         timestamp: '2026-08-14T08:28:15.225Z',
         kind: 'request',
         level,
+        service: 'shop',
         method: 'GET',
         path: '/api/cart',
         status: 200,
@@ -269,7 +270,7 @@ describe('writeDevelopmentWideEvent', () => {
       })
 
       expect(consoleWrites[method]).toHaveBeenCalledExactlyOnceWith(
-        expect.stringContaining(`${level.toUpperCase()} [Wide Event] GET /api/cart 200 1ms`),
+        '[shop] GET /api/cart 200 1ms · requestId: req_1',
       )
       expect(stdoutWrite).not.toHaveBeenCalled()
       for (const [name, write] of Object.entries(consoleWrites)) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Development Wide Events wrote directly to stdout, so Nuxt could not retain each record's severity. After switching to Console, the formatted message repeated the level that Nuxt already adds.

Each record now uses the matching Console method. Nuxt owns the level label.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
