### PR TITLE
feat(nuxt-dx): integrate terminal diagnostics

### DIFF
--- a/packages/nuxt-dx/src/diagnostic-output.ts
+++ b/packages/nuxt-dx/src/diagnostic-output.ts
@@ -1,5 +1,5 @@
 import type { ConsolaInstance } from 'consola'
-import type { DiagnosticTerminal, DiagnosticTerminalNotice } from './terminal-bridge'
+import type { DiagnosticTerminal, DiagnosticTerminalNotice, DiagnosticTerminalPanel, DiagnosticTerminalPanelEntry } from './terminal-bridge'
 
 interface DiagnosticTaskLabels {
   start: string
@@ -8,13 +8,21 @@ interface DiagnosticTaskLabels {
 
 type SizeBudgetNoticeScope = 'client' | 'server'
 
+export interface BudgetNoticeReport {
+  message: string
+  entries: readonly DiagnosticTerminalPanelEntry[]
+}
+
 export interface DiagnosticOutput {
-  updateBudgetNotice: (scope: SizeBudgetNoticeScope, reports: readonly string[]) => void
+  updateBudgetDiagnostics: (scope: SizeBudgetNoticeScope, reports: readonly BudgetNoticeReport[]) => void
   runTask: <T>(labels: DiagnosticTaskLabels, work: () => Promise<T>) => Promise<T>
+  dispose: () => void
 }
 
 export function createDiagnosticOutput(useTerminal: () => DiagnosticTerminal, logger: ConsolaInstance): DiagnosticOutput {
   const notices = new Map<SizeBudgetNoticeScope, DiagnosticTerminalNotice>()
+  const reports = new Map<SizeBudgetNoticeScope, readonly BudgetNoticeReport[]>()
+  let panel: DiagnosticTerminalPanel | undefined
 
   const dismissNotice = (scope: SizeBudgetNoticeScope) => {
     notices.get(scope)?.dismiss()
@@ -22,19 +30,34 @@ export function createDiagnosticOutput(useTerminal: () => DiagnosticTerminal, lo
   }
 
   return {
-    updateBudgetNotice(scope, reports) {
+    updateBudgetDiagnostics(scope, nextReports) {
       const terminal = useTerminal()
+      reports.set(scope, nextReports)
       dismissNotice(scope)
-      if (!reports.length)
+      if (!panel && terminal.registerPanel) {
+        panel = terminal.registerPanel({
+          id: 'nuxt-dx:diagnostics',
+          title: 'Nuxt DX Diagnostics',
+          empty: 'No Diagnostics',
+          shortcut: { key: 'd', label: 'diagnostics', description: 'browse current Diagnostics' },
+        })
+      }
+      if (panel) {
+        for (const noticeScope of notices.keys())
+          dismissNotice(noticeScope)
+        panel.update([...reports.values()].flatMap(report => report.flatMap(entry => entry.entries)))
+        return
+      }
+      if (!nextReports.length)
         return
       if (!terminal.interactive) {
-        for (const report of reports)
-          logger.warn(report)
+        for (const report of nextReports)
+          logger.warn(report.message)
         return
       }
       notices.set(scope, terminal.notify({
         title: `Nuxt DX: ${scope} size budget`,
-        message: reports.join('\n\n'),
+        message: nextReports.map(report => report.message).join('\n\n'),
         level: 'warn',
       }))
     },
@@ -53,6 +76,13 @@ export function createDiagnosticOutput(useTerminal: () => DiagnosticTerminal, lo
           task.stop(labels.failure, 'failure')
           throw error
         })
+    },
+    dispose() {
+      for (const scope of notices.keys())
+        dismissNotice(scope)
+      panel?.dispose()
+      panel = undefined
+      reports.clear()
     },
   }
 }

--- a/packages/nuxt-dx/src/diagnostic-output.ts
+++ b/packages/nuxt-dx/src/diagnostic-output.ts
@@ -1,0 +1,42 @@
+import type { NuxtLogger, NuxtTerminal } from '@nuxt/kit'
+
+interface DiagnosticTaskLabels {
+  start: string
+  success: string
+}
+
+export interface DiagnosticOutput {
+  warn: (message: string) => void
+  runTask: <T>(labels: DiagnosticTaskLabels, work: () => Promise<T>) => Promise<T>
+}
+
+export function createDiagnosticOutput(terminal: NuxtTerminal, logger: NuxtLogger): DiagnosticOutput {
+  return {
+    warn(message) {
+      if (!terminal.interactive) {
+        logger.warn(message)
+        return
+      }
+      terminal.notify({
+        title: 'Nuxt DX diagnostic',
+        message,
+        level: 'warn',
+      })
+    },
+    runTask(labels, work) {
+      if (!terminal.interactive)
+        return Promise.resolve().then(work)
+
+      const task = terminal.startTask(labels.start)
+      return Promise.resolve()
+        .then(work)
+        .then((result) => {
+          task.stop(labels.success)
+          return result
+        }, (error) => {
+          task.stop(undefined, 'failure')
+          throw error
+        })
+    },
+  }
+}

--- a/packages/nuxt-dx/src/diagnostic-output.ts
+++ b/packages/nuxt-dx/src/diagnostic-output.ts
@@ -1,8 +1,9 @@
-import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotice } from '@nuxt/kit'
+import type { ConsolaInstance } from 'consola'
+import type { DiagnosticTerminal, DiagnosticTerminalNotice } from './terminal-bridge'
 
 interface DiagnosticTaskLabels {
   start: string
-  success: string
+  failure: string
 }
 
 type SizeBudgetNoticeScope = 'client' | 'server'
@@ -12,8 +13,8 @@ export interface DiagnosticOutput {
   runTask: <T>(labels: DiagnosticTaskLabels, work: () => Promise<T>) => Promise<T>
 }
 
-export function createDiagnosticOutput(useTerminal: () => NuxtTerminal, logger: NuxtLogger): DiagnosticOutput {
-  const notices = new Map<SizeBudgetNoticeScope, NuxtTerminalNotice>()
+export function createDiagnosticOutput(useTerminal: () => DiagnosticTerminal, logger: ConsolaInstance): DiagnosticOutput {
+  const notices = new Map<SizeBudgetNoticeScope, DiagnosticTerminalNotice>()
 
   const dismissNotice = (scope: SizeBudgetNoticeScope) => {
     notices.get(scope)?.dismiss()
@@ -46,10 +47,10 @@ export function createDiagnosticOutput(useTerminal: () => NuxtTerminal, logger: 
       return Promise.resolve()
         .then(work)
         .then((result) => {
-          task.stop(labels.success)
+          task.stop()
           return result
         }, (error) => {
-          task.stop(undefined, 'failure')
+          task.stop(labels.failure, 'failure')
           throw error
         })
     },

--- a/packages/nuxt-dx/src/diagnostic-output.ts
+++ b/packages/nuxt-dx/src/diagnostic-output.ts
@@ -1,29 +1,44 @@
-import type { NuxtLogger, NuxtTerminal } from '@nuxt/kit'
+import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotice } from '@nuxt/kit'
 
 interface DiagnosticTaskLabels {
   start: string
   success: string
 }
 
+type SizeBudgetNoticeScope = 'client' | 'server'
+
 export interface DiagnosticOutput {
-  warn: (message: string) => void
+  updateBudgetNotice: (scope: SizeBudgetNoticeScope, reports: readonly string[]) => void
   runTask: <T>(labels: DiagnosticTaskLabels, work: () => Promise<T>) => Promise<T>
 }
 
-export function createDiagnosticOutput(terminal: NuxtTerminal, logger: NuxtLogger): DiagnosticOutput {
+export function createDiagnosticOutput(useTerminal: () => NuxtTerminal, logger: NuxtLogger): DiagnosticOutput {
+  const notices = new Map<SizeBudgetNoticeScope, NuxtTerminalNotice>()
+
+  const dismissNotice = (scope: SizeBudgetNoticeScope) => {
+    notices.get(scope)?.dismiss()
+    notices.delete(scope)
+  }
+
   return {
-    warn(message) {
+    updateBudgetNotice(scope, reports) {
+      const terminal = useTerminal()
+      dismissNotice(scope)
+      if (!reports.length)
+        return
       if (!terminal.interactive) {
-        logger.warn(message)
+        for (const report of reports)
+          logger.warn(report)
         return
       }
-      terminal.notify({
-        title: 'Nuxt DX diagnostic',
-        message,
+      notices.set(scope, terminal.notify({
+        title: `Nuxt DX: ${scope} size budget`,
+        message: reports.join('\n\n'),
         level: 'warn',
-      })
+      }))
     },
     runTask(labels, work) {
+      const terminal = useTerminal()
       if (!terminal.interactive)
         return Promise.resolve().then(work)
 

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,6 +1,6 @@
 import type { Nuxt, NuxtApp } from '@nuxt/schema'
 import type { ConsolaInstance } from 'consola'
-import type { DiagnosticOutput } from './diagnostic-output'
+import type { BudgetNoticeReport, DiagnosticOutput } from './diagnostic-output'
 import type { DiagnosticIssue } from './runtime/app/report'
 import type { BudgetOverride, BudgetVerdict } from './size-budget/budget'
 import type { ModuleOwner } from './size-budget/module-owner'
@@ -16,7 +16,7 @@ import { budgetFor, smallestBudget } from './size-budget/budget'
 import { moduleOwnerOf, moduleRoot } from './size-budget/module-owner'
 import { createOverrideUsage } from './size-budget/override-usage'
 import { extractPluginName } from './size-budget/plugin-name'
-import { formatBudgetReport } from './size-budget/report'
+import { formatBudgetDiagnostics, formatBudgetReport } from './size-budget/report'
 import { sizeBudgetRollupPlugin } from './size-budget/rollup'
 import { BUDGET_SCOPES } from './size-budget/scope'
 import { kilobytesToBytes } from './size-budget/size'
@@ -175,7 +175,7 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
     const report = formatBudgetReport(scope, over, reportBaseDir(nuxt))
     if (budgets.fail)
       throw new Error(`[nuxt-dx] ${report}`)
-    return report
+    return { message: report, entries: formatBudgetDiagnostics(scope, over, reportBaseDir(nuxt)) }
   }
 }
 
@@ -274,12 +274,12 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
       return [scope, reporter(scope, defaultBytes, budgets, nuxt, scope === 'client')] as const
     }))
     return async (measured: readonly MeasuredTarget[]) => {
-      output.updateBudgetNotice(bundle, [])
+      output.updateBudgetDiagnostics(bundle, [])
       return output.runTask({
         start: `Checking ${bundle} runtime size budgets`,
         failure: `Failed to check ${bundle} runtime size budgets`,
       }, async () => {
-        const overBudget: string[] = []
+        const overBudget: BudgetNoticeReport[] = []
         for (const scope of scopes) {
           const entries = measured.filter(target => target.scope === scope)
           await writeSnapshot?.(scope, entries)
@@ -288,7 +288,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
             overBudget.push(report)
         }
         await trackOverrides(measured)
-        output.updateBudgetNotice(bundle, overBudget)
+        output.updateBudgetDiagnostics(bundle, overBudget)
       })
     }
   }
@@ -366,6 +366,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     const logger = useLogger('nuxt-dx')
     const output = createDiagnosticOutput(createTerminalAccess(logger), logger)
+    nuxt.hook('close', () => output.dispose())
     const reportPath = resolveReportPath(options.report)
     if (options.sizeBudget !== false)
       setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath, logger, output)

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,5 +1,5 @@
-import type { NuxtLogger } from '@nuxt/kit'
 import type { Nuxt, NuxtApp } from '@nuxt/schema'
+import type { ConsolaInstance } from 'consola'
 import type { DiagnosticOutput } from './diagnostic-output'
 import type { DiagnosticIssue } from './runtime/app/report'
 import type { BudgetOverride, BudgetVerdict } from './size-budget/budget'
@@ -10,7 +10,7 @@ import type { RuntimeEntry } from './size-budget/targets'
 import { realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
-import { addPlugin, addTypeTemplate, createResolver, defineNuxtModule, resolveModule, useLogger, useTerminal } from '@nuxt/kit'
+import { addPlugin, addTypeTemplate, createResolver, defineNuxtModule, resolveModule, useLogger } from '@nuxt/kit'
 import { createDiagnosticOutput } from './diagnostic-output'
 import { budgetFor, smallestBudget } from './size-budget/budget'
 import { moduleOwnerOf, moduleRoot } from './size-budget/module-owner'
@@ -22,6 +22,7 @@ import { BUDGET_SCOPES } from './size-budget/scope'
 import { kilobytesToBytes } from './size-budget/size'
 import { createSnapshotWriter, resolveReportPath } from './size-budget/snapshot'
 import { runtimeTargets } from './size-budget/targets'
+import { createTerminalAccess } from './terminal-bridge'
 
 export interface SizeBudgetOptions {
   /**
@@ -95,7 +96,7 @@ interface ResolvedBudgets {
   fail: boolean
 }
 
-function resolveBudgets(options: SizeBudgetOptions, logger: NuxtLogger): ResolvedBudgets {
+function resolveBudgets(options: SizeBudgetOptions, logger: ConsolaInstance): ResolvedBudgets {
   const resolve = (kilobytes: number | false | undefined, fallback: number, label: string) => {
     if (kilobytes === false)
       return undefined
@@ -219,7 +220,7 @@ function runtimeEntries(scope: BudgetScope, paths: readonly string[], owners: re
   return paths.map(path => ({ scope, path, owner: moduleOwnerOf(path, owners) }))
 }
 
-function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined, logger: NuxtLogger, output: DiagnosticOutput): void {
+function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined, logger: ConsolaInstance, output: DiagnosticOutput): void {
   const budgets = resolveBudgets(options, logger)
   const enabledScopes = BUDGET_SCOPES.filter(scope => budgets.byScope[scope] !== undefined)
 
@@ -276,7 +277,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
       output.updateBudgetNotice(bundle, [])
       return output.runTask({
         start: `Checking ${bundle} runtime size budgets`,
-        success: `Checked ${bundle} runtime size budgets`,
+        failure: `Failed to check ${bundle} runtime size budgets`,
       }, async () => {
         const overBudget: string[] = []
         for (const scope of scopes) {
@@ -364,7 +365,7 @@ export default defineNuxtModule<ModuleOptions>({
       return
 
     const logger = useLogger('nuxt-dx')
-    const output = createDiagnosticOutput(useTerminal, logger)
+    const output = createDiagnosticOutput(createTerminalAccess(logger), logger)
     const reportPath = resolveReportPath(options.report)
     if (options.sizeBudget !== false)
       setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath, logger, output)

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,3 +1,4 @@
+import type { NuxtLogger } from '@nuxt/kit'
 import type { Nuxt, NuxtApp } from '@nuxt/schema'
 import type { DiagnosticOutput } from './diagnostic-output'
 import type { DiagnosticIssue } from './runtime/app/report'
@@ -94,7 +95,7 @@ interface ResolvedBudgets {
   fail: boolean
 }
 
-function resolveBudgets(options: SizeBudgetOptions, output: DiagnosticOutput): ResolvedBudgets {
+function resolveBudgets(options: SizeBudgetOptions, logger: NuxtLogger): ResolvedBudgets {
   const resolve = (kilobytes: number | false | undefined, fallback: number, label: string) => {
     if (kilobytes === false)
       return undefined
@@ -102,7 +103,7 @@ function resolveBudgets(options: SizeBudgetOptions, output: DiagnosticOutput): R
       return kilobytesToBytes(fallback)
     // A negative or NaN budget would flag everything, so drop it rather than drown the build in warnings.
     if (!Number.isFinite(kilobytes) || kilobytes < 0) {
-      output.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+      logger.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
       return undefined
     }
     return kilobytesToBytes(kilobytes)
@@ -111,7 +112,7 @@ function resolveBudgets(options: SizeBudgetOptions, output: DiagnosticOutput): R
   const overrides: ResolvedBudgets['overrides'] = []
   for (const [fragment, kilobytes] of Object.entries(options.overridesKb ?? {})) {
     if (!Number.isFinite(kilobytes) || kilobytes < 0)
-      output.warn(`Ignoring \`sizeBudget.overridesKb['${fragment}']\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+      logger.warn(`Ignoring \`sizeBudget.overridesKb['${fragment}']\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
     else overrides.push({ fragment, bytes: kilobytesToBytes(kilobytes) })
   }
 
@@ -151,7 +152,7 @@ async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefin
  * Measurement only knows paths. Plugin names are reconciled here, once, for the plugins big
  * enough to be at risk, so a build where everything fits parses no plugin sources at all.
  */
-function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean, output: DiagnosticOutput) {
+function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean) {
   const threshold = smallestBudget(defaultBytes, budgets.overrides)
   return async (measured: readonly MeasuredTarget[]) => {
     const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold)
@@ -173,7 +174,7 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
     const report = formatBudgetReport(scope, over, reportBaseDir(nuxt))
     if (budgets.fail)
       throw new Error(`[nuxt-dx] ${report}`)
-    output.warn(report)
+    return report
   }
 }
 
@@ -218,12 +219,12 @@ function runtimeEntries(scope: BudgetScope, paths: readonly string[], owners: re
   return paths.map(path => ({ scope, path, owner: moduleOwnerOf(path, owners) }))
 }
 
-function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined, output: DiagnosticOutput): void {
-  const budgets = resolveBudgets(options, output)
+function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined, logger: NuxtLogger, output: DiagnosticOutput): void {
+  const budgets = resolveBudgets(options, logger)
   const enabledScopes = BUDGET_SCOPES.filter(scope => budgets.byScope[scope] !== undefined)
 
   if (reportPath !== undefined && !enabledScopes.length)
-    output.warn('`nuxtDx.report` is on, but every size budget is disabled, so there is nothing to measure.')
+    logger.warn('`nuxtDx.report` is on, but every size budget is disabled, so there is nothing to measure.')
 
   const writeSnapshot = reportPath === undefined
     ? undefined
@@ -257,7 +258,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
     if (!unused.length)
       return
     const keys = unused.map(fragment => `\`${fragment}\``).join(', ')
-    output.warn(`${unused.length} \`sizeBudget.overridesKb\` key${unused.length === 1 ? '' : 's'} matched no runtime entry: ${keys}. Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.`)
+    logger.warn(`${unused.length} \`sizeBudget.overridesKb\` key${unused.length === 1 ? '' : 's'} matched no runtime entry: ${keys}. Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.`)
   }
 
   /**
@@ -269,19 +270,26 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
     const bundle = scopes.some(scope => scope === 'client' || scope === 'client-middleware') ? 'client' : 'server'
     const reports = new Map(scopes.map((scope) => {
       const defaultBytes = budgets.byScope[scope]!
-      return [scope, reporter(scope, defaultBytes, budgets, nuxt, scope === 'client', output)] as const
+      return [scope, reporter(scope, defaultBytes, budgets, nuxt, scope === 'client')] as const
     }))
-    return async (measured: readonly MeasuredTarget[]) => output.runTask({
-      start: `Checking ${bundle} runtime size budgets`,
-      success: `Checked ${bundle} runtime size budgets`,
-    }, async () => {
-      for (const scope of scopes) {
-        const entries = measured.filter(target => target.scope === scope)
-        await writeSnapshot?.(scope, entries)
-        await reports.get(scope)!(entries)
-      }
-      await trackOverrides(measured)
-    })
+    return async (measured: readonly MeasuredTarget[]) => {
+      output.updateBudgetNotice(bundle, [])
+      return output.runTask({
+        start: `Checking ${bundle} runtime size budgets`,
+        success: `Checked ${bundle} runtime size budgets`,
+      }, async () => {
+        const overBudget: string[] = []
+        for (const scope of scopes) {
+          const entries = measured.filter(target => target.scope === scope)
+          await writeSnapshot?.(scope, entries)
+          const report = await reports.get(scope)!(entries)
+          if (report)
+            overBudget.push(report)
+        }
+        await trackOverrides(measured)
+        output.updateBudgetNotice(bundle, overBudget)
+      })
+    }
   }
 
   // `app:resolve` holds app and module registrations before the client build starts.
@@ -355,12 +363,13 @@ export default defineNuxtModule<ModuleOptions>({
     if (!options.enabled)
       return
 
-    const output = createDiagnosticOutput(useTerminal(), useLogger('nuxt-dx'))
+    const logger = useLogger('nuxt-dx')
+    const output = createDiagnosticOutput(useTerminal, logger)
     const reportPath = resolveReportPath(options.report)
     if (options.sizeBudget !== false)
-      setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath, output)
+      setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath, logger, output)
     else if (reportPath !== undefined)
-      output.warn('`nuxtDx.report` is on, but `nuxtDx.sizeBudget` is `false`, so there is nothing to measure.')
+      logger.warn('`nuxtDx.report` is on, but `nuxtDx.sizeBudget` is `false`, so there is nothing to measure.')
 
     addTypeTemplate({
       filename: 'types/nuxt-dx.d.ts',

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -1,4 +1,5 @@
 import type { Nuxt, NuxtApp } from '@nuxt/schema'
+import type { DiagnosticOutput } from './diagnostic-output'
 import type { DiagnosticIssue } from './runtime/app/report'
 import type { BudgetOverride, BudgetVerdict } from './size-budget/budget'
 import type { ModuleOwner } from './size-budget/module-owner'
@@ -8,7 +9,8 @@ import type { RuntimeEntry } from './size-budget/targets'
 import { realpathSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
-import { addPlugin, addTypeTemplate, createResolver, defineNuxtModule, resolveModule, useLogger } from '@nuxt/kit'
+import { addPlugin, addTypeTemplate, createResolver, defineNuxtModule, resolveModule, useLogger, useTerminal } from '@nuxt/kit'
+import { createDiagnosticOutput } from './diagnostic-output'
 import { budgetFor, smallestBudget } from './size-budget/budget'
 import { moduleOwnerOf, moduleRoot } from './size-budget/module-owner'
 import { createOverrideUsage } from './size-budget/override-usage'
@@ -92,9 +94,7 @@ interface ResolvedBudgets {
   fail: boolean
 }
 
-const logger = useLogger('nuxt-dx')
-
-function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
+function resolveBudgets(options: SizeBudgetOptions, output: DiagnosticOutput): ResolvedBudgets {
   const resolve = (kilobytes: number | false | undefined, fallback: number, label: string) => {
     if (kilobytes === false)
       return undefined
@@ -102,7 +102,7 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
       return kilobytesToBytes(fallback)
     // A negative or NaN budget would flag everything, so drop it rather than drown the build in warnings.
     if (!Number.isFinite(kilobytes) || kilobytes < 0) {
-      logger.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+      output.warn(`Ignoring \`sizeBudget.${label}\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
       return undefined
     }
     return kilobytesToBytes(kilobytes)
@@ -111,7 +111,7 @@ function resolveBudgets(options: SizeBudgetOptions): ResolvedBudgets {
   const overrides: ResolvedBudgets['overrides'] = []
   for (const [fragment, kilobytes] of Object.entries(options.overridesKb ?? {})) {
     if (!Number.isFinite(kilobytes) || kilobytes < 0)
-      logger.warn(`Ignoring \`sizeBudget.overridesKb['${fragment}']\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
+      output.warn(`Ignoring \`sizeBudget.overridesKb['${fragment}']\`: expected a non-negative number of kilobytes, received ${kilobytes}`)
     else overrides.push({ fragment, bytes: kilobytesToBytes(kilobytes) })
   }
 
@@ -151,7 +151,7 @@ async function readPluginName(src: string, nuxt: Nuxt): Promise<string | undefin
  * Measurement only knows paths. Plugin names are reconciled here, once, for the plugins big
  * enough to be at risk, so a build where everything fits parses no plugin sources at all.
  */
-function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean) {
+function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBudgets, nuxt: Nuxt, named: boolean, output: DiagnosticOutput) {
   const threshold = smallestBudget(defaultBytes, budgets.overrides)
   return async (measured: readonly MeasuredTarget[]) => {
     const candidates = measured.filter(entry => entry.measurement.totalBytes > threshold)
@@ -173,7 +173,7 @@ function reporter(scope: BudgetScope, defaultBytes: number, budgets: ResolvedBud
     const report = formatBudgetReport(scope, over, reportBaseDir(nuxt))
     if (budgets.fail)
       throw new Error(`[nuxt-dx] ${report}`)
-    logger.warn(report)
+    output.warn(report)
   }
 }
 
@@ -218,12 +218,12 @@ function runtimeEntries(scope: BudgetScope, paths: readonly string[], owners: re
   return paths.map(path => ({ scope, path, owner: moduleOwnerOf(path, owners) }))
 }
 
-function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined): void {
-  const budgets = resolveBudgets(options)
+function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: string | undefined, output: DiagnosticOutput): void {
+  const budgets = resolveBudgets(options, output)
   const enabledScopes = BUDGET_SCOPES.filter(scope => budgets.byScope[scope] !== undefined)
 
   if (reportPath !== undefined && !enabledScopes.length)
-    logger.warn('`nuxtDx.report` is on, but every size budget is disabled, so there is nothing to measure.')
+    output.warn('`nuxtDx.report` is on, but every size budget is disabled, so there is nothing to measure.')
 
   const writeSnapshot = reportPath === undefined
     ? undefined
@@ -257,7 +257,7 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
     if (!unused.length)
       return
     const keys = unused.map(fragment => `\`${fragment}\``).join(', ')
-    logger.warn(`${unused.length} \`sizeBudget.overridesKb\` key${unused.length === 1 ? '' : 's'} matched no runtime entry: ${keys}. Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.`)
+    output.warn(`${unused.length} \`sizeBudget.overridesKb\` key${unused.length === 1 ? '' : 's'} matched no runtime entry: ${keys}. Each key must be a plugin name, a Nuxt module name, or a fragment of an entry path.`)
   }
 
   /**
@@ -266,18 +266,22 @@ function setupSizeBudget(options: SizeBudgetOptions, nuxt: Nuxt, reportPath: str
    * still leaves the artifact behind.
    */
   const onMeasured = (scopes: readonly BudgetScope[]) => {
+    const bundle = scopes.some(scope => scope === 'client' || scope === 'client-middleware') ? 'client' : 'server'
     const reports = new Map(scopes.map((scope) => {
       const defaultBytes = budgets.byScope[scope]!
-      return [scope, reporter(scope, defaultBytes, budgets, nuxt, scope === 'client')] as const
+      return [scope, reporter(scope, defaultBytes, budgets, nuxt, scope === 'client', output)] as const
     }))
-    return async (measured: readonly MeasuredTarget[]) => {
+    return async (measured: readonly MeasuredTarget[]) => output.runTask({
+      start: `Checking ${bundle} runtime size budgets`,
+      success: `Checked ${bundle} runtime size budgets`,
+    }, async () => {
       for (const scope of scopes) {
         const entries = measured.filter(target => target.scope === scope)
         await writeSnapshot?.(scope, entries)
         await reports.get(scope)!(entries)
       }
       await trackOverrides(measured)
-    }
+    })
   }
 
   // `app:resolve` holds app and module registrations before the client build starts.
@@ -351,11 +355,12 @@ export default defineNuxtModule<ModuleOptions>({
     if (!options.enabled)
       return
 
+    const output = createDiagnosticOutput(useTerminal(), useLogger('nuxt-dx'))
     const reportPath = resolveReportPath(options.report)
     if (options.sizeBudget !== false)
-      setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath)
+      setupSizeBudget(options.sizeBudget ?? {}, nuxt, reportPath, output)
     else if (reportPath !== undefined)
-      logger.warn('`nuxtDx.report` is on, but `nuxtDx.sizeBudget` is `false`, so there is nothing to measure.')
+      output.warn('`nuxtDx.report` is on, but `nuxtDx.sizeBudget` is `false`, so there is nothing to measure.')
 
     addTypeTemplate({
       filename: 'types/nuxt-dx.d.ts',

--- a/packages/nuxt-dx/src/size-budget/report.ts
+++ b/packages/nuxt-dx/src/size-budget/report.ts
@@ -1,9 +1,17 @@
-import type { TreeItem } from 'consola/utils'
 import type { BudgetVerdict } from './budget'
 import type { BudgetScope } from './scope'
-import { colors, formatTree } from 'consola/utils'
+import { colors, formatTree, stripAnsi } from 'consola/utils'
 import { SCOPE } from './scope'
 import { formatBytes } from './size'
+
+export interface BudgetDiagnostic {
+  id: string
+  title: string
+  lines: readonly string[]
+  level: 'warn'
+  copy: string
+  file: { path: string }
+}
 
 /**
  * Rollup ids carry virtual prefixes and query suffixes that make paths unreadable in a
@@ -39,7 +47,7 @@ function overrideSnippet(over: readonly BudgetVerdict[], baseDir: string): strin
 }
 
 /** Every byte charged to the target, so the listed sizes always sum to the reported total. */
-function breakdown(scope: BudgetScope, verdict: BudgetVerdict, baseDir: string): TreeItem[] {
+function breakdown(scope: BudgetScope, verdict: BudgetVerdict, baseDir: string): Array<{ text: string }> {
   const { ownBytes, exclusiveBytes, exclusiveCount, heaviestDependencies } = verdict.measurement
   const rows: { bytes: number, label: string, muted: boolean }[] = [
     { bytes: ownBytes, label: SCOPE[scope].own, muted: true },
@@ -86,4 +94,25 @@ export function formatBudgetReport(scope: BudgetScope, over: readonly BudgetVerd
     `    ${colors.cyan(overrideSnippet(over, baseDir))}`,
   )
   return lines.join('\n')
+}
+
+export function formatBudgetDiagnostics(scope: BudgetScope, over: readonly BudgetVerdict[], baseDir: string): BudgetDiagnostic[] {
+  return over.map((verdict) => {
+    const { name, owner, path, budgetBytes, measurement } = verdict
+    const file = displayId(path, baseDir)
+    const label = name ?? file
+    const overshoot = formatBytes(measurement.totalBytes - budgetBytes)
+    return {
+      id: `${scope}:${path}`,
+      title: `${label} · ${overshoot} over budget`,
+      lines: [
+        `${formatBytes(measurement.totalBytes)} bundled · ${formatBytes(budgetBytes)} budget`,
+        ...owner ? [`Nuxt module: ${owner}`] : [],
+        ...breakdown(scope, verdict, baseDir).map(row => stripAnsi(row.text)),
+      ],
+      level: 'warn',
+      copy: overrideSnippet([verdict], baseDir),
+      file: { path },
+    }
+  })
 }

--- a/packages/nuxt-dx/src/terminal-bridge.ts
+++ b/packages/nuxt-dx/src/terminal-bridge.ts
@@ -17,10 +17,32 @@ export interface DiagnosticTerminalNotice {
   dismissed: Promise<void>
 }
 
+export interface DiagnosticTerminalPanelEntry {
+  id: string
+  title: string
+  lines?: readonly string[]
+  level?: 'info' | 'warn' | 'error'
+  copy?: string
+  file?: { path: string, line?: number, column?: number }
+}
+
+export interface DiagnosticTerminalPanelDefinition {
+  id: string
+  title: string
+  empty?: string
+  shortcut?: { key: string, label: string, description: string }
+}
+
+export interface DiagnosticTerminalPanel {
+  update: (entries: readonly DiagnosticTerminalPanelEntry[]) => void
+  dispose: () => void
+}
+
 export interface DiagnosticTerminal {
   readonly interactive: boolean
   startTask: (label: string) => DiagnosticTerminalTask
   notify: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
+  registerPanel?: (definition: DiagnosticTerminalPanelDefinition) => DiagnosticTerminalPanel
 }
 
 interface TerminalHostV1 {
@@ -28,6 +50,7 @@ interface TerminalHostV1 {
   withTerminal: <T>(work: () => Promise<T>) => Promise<T>
   startTask: (label: string) => DiagnosticTerminalTask
   notify?: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
+  registerPanel?: (definition: DiagnosticTerminalPanelDefinition) => DiagnosticTerminalPanel
 }
 
 const terminalHostKey = Symbol.for('nuxt:terminal-host')
@@ -69,6 +92,7 @@ function useCompatibleTerminal(logger: ConsolaInstance): DiagnosticTerminal {
       logger.box([notification.title, notification.message].filter(Boolean).join('\n\n'))
       return { dismiss() {}, dismissed: Promise.resolve() }
     },
+    ...host?.registerPanel ? { registerPanel: host.registerPanel.bind(host) } : {},
   }
 }
 
@@ -81,5 +105,19 @@ export function createTerminalAccess(
   logger: ConsolaInstance,
   upstream: (() => DiagnosticTerminal) | undefined = (nuxtKit as UpstreamKit).useTerminal,
 ): () => DiagnosticTerminal {
-  return upstream ?? (() => useCompatibleTerminal(logger))
+  return () => {
+    const compatible = useCompatibleTerminal(logger)
+    if (!upstream)
+      return compatible
+    const terminal = upstream()
+    return {
+      ...terminal,
+      interactive: terminal.interactive || compatible.interactive,
+      ...terminal.registerPanel
+        ? { registerPanel: terminal.registerPanel }
+        : compatible.registerPanel
+          ? { registerPanel: compatible.registerPanel }
+          : {},
+    }
+  }
 }

--- a/packages/nuxt-dx/src/terminal-bridge.ts
+++ b/packages/nuxt-dx/src/terminal-bridge.ts
@@ -1,0 +1,85 @@
+import type { ConsolaInstance } from 'consola'
+import * as nuxtKit from '@nuxt/kit'
+
+export interface DiagnosticTerminalTask {
+  update: (label: string) => void
+  stop: (message?: string, outcome?: 'success' | 'failure') => void
+}
+
+export interface DiagnosticTerminalNotification {
+  title?: string
+  message: string
+  level?: 'info' | 'warn'
+}
+
+export interface DiagnosticTerminalNotice {
+  dismiss: () => void
+  dismissed: Promise<void>
+}
+
+export interface DiagnosticTerminal {
+  readonly interactive: boolean
+  startTask: (label: string) => DiagnosticTerminalTask
+  notify: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
+}
+
+interface TerminalHostV1 {
+  version: 1
+  withTerminal: <T>(work: () => Promise<T>) => Promise<T>
+  startTask: (label: string) => DiagnosticTerminalTask
+  notify?: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
+}
+
+const terminalHostKey = Symbol.for('nuxt:terminal-host')
+const globals = globalThis as typeof globalThis & { [terminalHostKey]?: unknown }
+
+function terminalHost(): TerminalHostV1 | undefined {
+  const host = globals[terminalHostKey] as Partial<TerminalHostV1> | undefined
+  if (host?.version !== 1 || typeof host.withTerminal !== 'function' || typeof host.startTask !== 'function')
+    return undefined
+  return host as TerminalHostV1
+}
+
+function useCompatibleTerminal(logger: ConsolaInstance): DiagnosticTerminal {
+  const host = terminalHost()
+  return {
+    interactive: host !== undefined,
+    startTask(label) {
+      if (host)
+        return host.startTask(label)
+      logger.start(label)
+      let stopped = false
+      return {
+        update(nextLabel) {
+          if (!stopped)
+            logger.start(nextLabel)
+        },
+        stop(message, outcome) {
+          if (stopped)
+            return
+          stopped = true
+          if (message)
+            logger[outcome === 'failure' ? 'fail' : 'success'](message)
+        },
+      }
+    },
+    notify(notification) {
+      if (host?.notify)
+        return host.notify(notification)
+      logger.box([notification.title, notification.message].filter(Boolean).join('\n\n'))
+      return { dismiss() {}, dismissed: Promise.resolve() }
+    },
+  }
+}
+
+type UpstreamKit = typeof nuxtKit & {
+  useTerminal?: () => DiagnosticTerminal
+}
+
+/** Use Nuxt's terminal API when present, with the same host contract on Nuxt 4. */
+export function createTerminalAccess(
+  logger: ConsolaInstance,
+  upstream: (() => DiagnosticTerminal) | undefined = (nuxtKit as UpstreamKit).useTerminal,
+): () => DiagnosticTerminal {
+  return upstream ?? (() => useCompatibleTerminal(logger))
+}

--- a/packages/nuxt-dx/tests/budget-report.test.ts
+++ b/packages/nuxt-dx/tests/budget-report.test.ts
@@ -2,7 +2,7 @@ import type { BudgetVerdict } from '../src/size-budget/budget'
 import type { BudgetScope } from '../src/size-budget/scope'
 import { stripAnsi } from 'consola/utils'
 import { describe, expect, it } from 'vitest'
-import { displayId, formatBudgetReport } from '../src/size-budget/report'
+import { displayId, formatBudgetDiagnostics, formatBudgetReport } from '../src/size-budget/report'
 
 describe('displayId', () => {
   it('shortens project files to a root-relative path', () => {
@@ -119,5 +119,23 @@ describe('formatBudgetReport', () => {
 
   it('stays compact for a single offender', () => {
     expect(report([verdict]).split('\n')).toHaveLength(9)
+  })
+})
+
+describe('formatBudgetDiagnostics', () => {
+  it('returns one semantic and actionable entry per verdict', () => {
+    expect(formatBudgetDiagnostics('client', [{ ...verdict, name: 'analytics', owner: '@acme/analytics' }], '/app')).toEqual([{
+      id: 'client:/app/plugins/analytics.ts',
+      title: 'analytics · 61 kB over budget',
+      lines: [
+        '81 kB bundled · 20 kB budget',
+        'Nuxt module: @acme/analytics',
+        ' 1 kB  the plugin file',
+        '80 kB  chart/index.mjs',
+      ],
+      level: 'warn',
+      copy: 'nuxtDx.sizeBudget.overridesKb = { \'analytics\': 81 }',
+      file: { path: '/app/plugins/analytics.ts' },
+    }])
   })
 })

--- a/packages/nuxt-dx/tests/diagnostic-output.test.ts
+++ b/packages/nuxt-dx/tests/diagnostic-output.test.ts
@@ -1,0 +1,90 @@
+import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotification, NuxtTerminalTask } from '@nuxt/kit'
+import { describe, expect, it, vi } from 'vitest'
+import { createDiagnosticOutput } from '../src/diagnostic-output'
+
+function createLogger(): NuxtLogger {
+  return { warn: vi.fn() } as unknown as NuxtLogger
+}
+
+function createTerminal(options: {
+  interactive?: boolean
+  notify?: (notification: NuxtTerminalNotification) => void
+  task?: NuxtTerminalTask
+} = {}): NuxtTerminal {
+  return {
+    interactive: options.interactive ?? false,
+    withTerminal: work => work(),
+    prompt: vi.fn(),
+    notify: (notification) => {
+      options.notify?.(notification)
+      return { dismiss: vi.fn(), dismissed: Promise.resolve() }
+    },
+    startTask: () => options.task ?? { update: vi.fn(), stop: vi.fn() },
+  }
+}
+
+describe('diagnostic output', () => {
+  it('holds an interactive warning in the Nuxt terminal', () => {
+    const notifications: NuxtTerminalNotification[] = []
+    const logger = createLogger()
+    const output = createDiagnosticOutput(createTerminal({
+      interactive: true,
+      notify: notification => notifications.push(notification),
+    }), logger)
+
+    output.warn('One Nuxt plugin is over budget.')
+
+    expect(notifications).toEqual([{
+      title: 'Nuxt DX diagnostic',
+      message: 'One Nuxt plugin is over budget.',
+      level: 'warn',
+    }])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps a warning in normal Nuxt output without an interactive host', () => {
+    const logger = createLogger()
+    const output = createDiagnosticOutput(createTerminal(), logger)
+
+    output.warn('One Nuxt plugin is over budget.')
+
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith('One Nuxt plugin is over budget.')
+  })
+
+  it('reports task completion to the terminal host', async () => {
+    const task = { update: vi.fn(), stop: vi.fn() }
+    const output = createDiagnosticOutput(createTerminal({ interactive: true, task }), createLogger())
+
+    await expect(output.runTask({
+      start: 'Checking runtime size budgets',
+      success: 'Checked runtime size budgets',
+    }, async () => 'done')).resolves.toBe('done')
+
+    expect(task.stop).toHaveBeenCalledExactlyOnceWith('Checked runtime size budgets')
+  })
+
+  it('marks a failed terminal task before propagating the error', async () => {
+    const task = { update: vi.fn(), stop: vi.fn() }
+    const output = createDiagnosticOutput(createTerminal({ interactive: true, task }), createLogger())
+    const failure = new Error('budget failed')
+
+    await expect(output.runTask({
+      start: 'Checking runtime size budgets',
+      success: 'Checked runtime size budgets',
+    }, async () => { throw failure })).rejects.toBe(failure)
+
+    expect(task.stop).toHaveBeenCalledExactlyOnceWith(undefined, 'failure')
+  })
+
+  it('does not add task logs without an interactive host', async () => {
+    const task = { update: vi.fn(), stop: vi.fn() }
+    const output = createDiagnosticOutput(createTerminal({ task }), createLogger())
+
+    await output.runTask({
+      start: 'Checking runtime size budgets',
+      success: 'Checked runtime size budgets',
+    }, async () => 'done')
+
+    expect(task.stop).not.toHaveBeenCalled()
+  })
+})

--- a/packages/nuxt-dx/tests/diagnostic-output.test.ts
+++ b/packages/nuxt-dx/tests/diagnostic-output.test.ts
@@ -1,5 +1,5 @@
 import type { ConsolaInstance } from 'consola'
-import type { DiagnosticTerminal, DiagnosticTerminalNotice, DiagnosticTerminalNotification, DiagnosticTerminalTask } from '../src/terminal-bridge'
+import type { DiagnosticTerminal, DiagnosticTerminalNotice, DiagnosticTerminalNotification, DiagnosticTerminalPanel, DiagnosticTerminalPanelDefinition, DiagnosticTerminalPanelEntry, DiagnosticTerminalTask } from '../src/terminal-bridge'
 import { describe, expect, it, vi } from 'vitest'
 import { createDiagnosticOutput } from '../src/diagnostic-output'
 
@@ -11,11 +11,20 @@ function createTerminal(options: {
   interactive?: boolean
   notify?: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
   task?: DiagnosticTerminalTask
+  registerPanel?: (definition: DiagnosticTerminalPanelDefinition) => DiagnosticTerminalPanel
 } = {}): DiagnosticTerminal {
   return {
     interactive: options.interactive ?? false,
     notify: options.notify ?? (() => ({ dismiss: vi.fn(), dismissed: Promise.resolve() })),
     startTask: () => options.task ?? { update: vi.fn(), stop: vi.fn() },
+    ...options.registerPanel ? { registerPanel: options.registerPanel } : {},
+  }
+}
+
+function report(message: string, id = message) {
+  return {
+    message,
+    entries: [{ id, title: message, level: 'warn' as const }] satisfies DiagnosticTerminalPanelEntry[],
   }
 }
 
@@ -26,7 +35,7 @@ describe('diagnostic output', () => {
     let terminal = createTerminal()
     const output = createDiagnosticOutput(() => terminal, logger)
 
-    output.updateBudgetNotice('client', ['First report'])
+    output.updateBudgetDiagnostics('client', [report('First report')])
     terminal = createTerminal({
       interactive: true,
       notify: (notification) => {
@@ -34,7 +43,7 @@ describe('diagnostic output', () => {
         return { dismiss: vi.fn(), dismissed: Promise.resolve() }
       },
     })
-    output.updateBudgetNotice('client', ['Second report'])
+    output.updateBudgetDiagnostics('client', [report('Second report')])
 
     expect(logger.warn).toHaveBeenCalledExactlyOnceWith('First report')
     expect(notifications).toEqual([{
@@ -53,13 +62,13 @@ describe('diagnostic output', () => {
     })
     const output = createDiagnosticOutput(() => terminal, createLogger())
 
-    output.updateBudgetNotice('client', ['First client report'])
-    output.updateBudgetNotice('server', ['Server report'])
-    output.updateBudgetNotice('client', ['Second client report'])
+    output.updateBudgetDiagnostics('client', [report('First client report')])
+    output.updateBudgetDiagnostics('server', [report('Server report')])
+    output.updateBudgetDiagnostics('client', [report('Second client report')])
 
     expect(notices[0]!.dismiss).toHaveBeenCalledOnce()
     expect(notices[1]!.dismiss).not.toHaveBeenCalled()
-    output.updateBudgetNotice('client', [])
+    output.updateBudgetDiagnostics('client', [])
     expect(notices[2]!.dismiss).toHaveBeenCalledOnce()
     expect(notices[1]!.dismiss).not.toHaveBeenCalled()
     expect(nextNotice).toBe(3)
@@ -69,10 +78,41 @@ describe('diagnostic output', () => {
     const logger = createLogger()
     const output = createDiagnosticOutput(() => createTerminal(), logger)
 
-    output.updateBudgetNotice('client', ['Plugin report', 'Middleware report'])
+    output.updateBudgetDiagnostics('client', [report('Plugin report'), report('Middleware report')])
 
     expect(logger.warn).toHaveBeenNthCalledWith(1, 'Plugin report')
     expect(logger.warn).toHaveBeenNthCalledWith(2, 'Middleware report')
+  })
+
+  it('publishes one live Diagnostics panel and removes resolved entries', () => {
+    const definitions: DiagnosticTerminalPanelDefinition[] = []
+    const panel = { update: vi.fn(), dispose: vi.fn() }
+    const output = createDiagnosticOutput(() => createTerminal({
+      interactive: true,
+      registerPanel(definition) {
+        definitions.push(definition)
+        return panel
+      },
+    }), createLogger())
+    const client = report('Client plugin over budget', 'client')
+    const server = report('Server plugin over budget', 'server')
+
+    output.updateBudgetDiagnostics('client', [client])
+    output.updateBudgetDiagnostics('server', [server])
+    output.updateBudgetDiagnostics('client', [])
+
+    expect(definitions).toEqual([{
+      id: 'nuxt-dx:diagnostics',
+      title: 'Nuxt DX Diagnostics',
+      empty: 'No Diagnostics',
+      shortcut: { key: 'd', label: 'diagnostics', description: 'browse current Diagnostics' },
+    }])
+    expect(panel.update).toHaveBeenNthCalledWith(1, client.entries)
+    expect(panel.update).toHaveBeenNthCalledWith(2, [...client.entries, ...server.entries])
+    expect(panel.update).toHaveBeenNthCalledWith(3, server.entries)
+
+    output.dispose()
+    expect(panel.dispose).toHaveBeenCalledOnce()
   })
 
   it('removes a completed task without adding a history entry', async () => {

--- a/packages/nuxt-dx/tests/diagnostic-output.test.ts
+++ b/packages/nuxt-dx/tests/diagnostic-output.test.ts
@@ -1,4 +1,4 @@
-import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotification, NuxtTerminalTask } from '@nuxt/kit'
+import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotice, NuxtTerminalNotification, NuxtTerminalTask } from '@nuxt/kit'
 import { describe, expect, it, vi } from 'vitest'
 import { createDiagnosticOutput } from '../src/diagnostic-output'
 
@@ -8,52 +8,79 @@ function createLogger(): NuxtLogger {
 
 function createTerminal(options: {
   interactive?: boolean
-  notify?: (notification: NuxtTerminalNotification) => void
+  notify?: (notification: NuxtTerminalNotification) => NuxtTerminalNotice
   task?: NuxtTerminalTask
 } = {}): NuxtTerminal {
   return {
     interactive: options.interactive ?? false,
     withTerminal: work => work(),
     prompt: vi.fn(),
-    notify: (notification) => {
-      options.notify?.(notification)
-      return { dismiss: vi.fn(), dismissed: Promise.resolve() }
-    },
+    notify: options.notify ?? (() => ({ dismiss: vi.fn(), dismissed: Promise.resolve() })),
     startTask: () => options.task ?? { update: vi.fn(), stop: vi.fn() },
   }
 }
 
 describe('diagnostic output', () => {
-  it('holds an interactive warning in the Nuxt terminal', () => {
+  it('discovers a terminal host registered after the output was created', () => {
     const notifications: NuxtTerminalNotification[] = []
     const logger = createLogger()
-    const output = createDiagnosticOutput(createTerminal({
+    let terminal = createTerminal()
+    const output = createDiagnosticOutput(() => terminal, logger)
+
+    output.updateBudgetNotice('client', ['First report'])
+    terminal = createTerminal({
       interactive: true,
-      notify: notification => notifications.push(notification),
-    }), logger)
+      notify: (notification) => {
+        notifications.push(notification)
+        return { dismiss: vi.fn(), dismissed: Promise.resolve() }
+      },
+    })
+    output.updateBudgetNotice('client', ['Second report'])
 
-    output.warn('One Nuxt plugin is over budget.')
-
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith('First report')
     expect(notifications).toEqual([{
-      title: 'Nuxt DX diagnostic',
-      message: 'One Nuxt plugin is over budget.',
+      title: 'Nuxt DX: client size budget',
+      message: 'Second report',
       level: 'warn',
     }])
-    expect(logger.warn).not.toHaveBeenCalled()
   })
 
-  it('keeps a warning in normal Nuxt output without an interactive host', () => {
+  it('replaces and clears the prior notice for one scope', () => {
+    const notices = Array.from({ length: 3 }, () => ({ dismiss: vi.fn(), dismissed: Promise.resolve() }))
+    let nextNotice = 0
+    const terminal = createTerminal({
+      interactive: true,
+      notify: () => notices[nextNotice++]!,
+    })
+    const output = createDiagnosticOutput(() => terminal, createLogger())
+
+    output.updateBudgetNotice('client', ['First client report'])
+    output.updateBudgetNotice('server', ['Server report'])
+    output.updateBudgetNotice('client', ['Second client report'])
+
+    expect(notices[0]!.dismiss).toHaveBeenCalledOnce()
+    expect(notices[1]!.dismiss).not.toHaveBeenCalled()
+    output.updateBudgetNotice('client', [])
+    expect(notices[2]!.dismiss).toHaveBeenCalledOnce()
+    expect(notices[1]!.dismiss).not.toHaveBeenCalled()
+    expect(nextNotice).toBe(3)
+  })
+
+  it('keeps over-budget reports in normal Nuxt output without an interactive host', () => {
     const logger = createLogger()
-    const output = createDiagnosticOutput(createTerminal(), logger)
+    const output = createDiagnosticOutput(() => createTerminal(), logger)
 
-    output.warn('One Nuxt plugin is over budget.')
+    output.updateBudgetNotice('client', ['Plugin report', 'Middleware report'])
 
-    expect(logger.warn).toHaveBeenCalledExactlyOnceWith('One Nuxt plugin is over budget.')
+    expect(logger.warn).toHaveBeenNthCalledWith(1, 'Plugin report')
+    expect(logger.warn).toHaveBeenNthCalledWith(2, 'Middleware report')
   })
 
-  it('reports task completion to the terminal host', async () => {
+  it('reports task completion to a host registered late', async () => {
     const task = { update: vi.fn(), stop: vi.fn() }
-    const output = createDiagnosticOutput(createTerminal({ interactive: true, task }), createLogger())
+    let terminal = createTerminal()
+    const output = createDiagnosticOutput(() => terminal, createLogger())
+    terminal = createTerminal({ interactive: true, task })
 
     await expect(output.runTask({
       start: 'Checking runtime size budgets',
@@ -65,7 +92,10 @@ describe('diagnostic output', () => {
 
   it('marks a failed terminal task before propagating the error', async () => {
     const task = { update: vi.fn(), stop: vi.fn() }
-    const output = createDiagnosticOutput(createTerminal({ interactive: true, task }), createLogger())
+    const output = createDiagnosticOutput(
+      () => createTerminal({ interactive: true, task }),
+      createLogger(),
+    )
     const failure = new Error('budget failed')
 
     await expect(output.runTask({
@@ -78,7 +108,7 @@ describe('diagnostic output', () => {
 
   it('does not add task logs without an interactive host', async () => {
     const task = { update: vi.fn(), stop: vi.fn() }
-    const output = createDiagnosticOutput(createTerminal({ task }), createLogger())
+    const output = createDiagnosticOutput(() => createTerminal({ task }), createLogger())
 
     await output.runTask({
       start: 'Checking runtime size budgets',

--- a/packages/nuxt-dx/tests/diagnostic-output.test.ts
+++ b/packages/nuxt-dx/tests/diagnostic-output.test.ts
@@ -1,20 +1,19 @@
-import type { NuxtLogger, NuxtTerminal, NuxtTerminalNotice, NuxtTerminalNotification, NuxtTerminalTask } from '@nuxt/kit'
+import type { ConsolaInstance } from 'consola'
+import type { DiagnosticTerminal, DiagnosticTerminalNotice, DiagnosticTerminalNotification, DiagnosticTerminalTask } from '../src/terminal-bridge'
 import { describe, expect, it, vi } from 'vitest'
 import { createDiagnosticOutput } from '../src/diagnostic-output'
 
-function createLogger(): NuxtLogger {
-  return { warn: vi.fn() } as unknown as NuxtLogger
+function createLogger(): ConsolaInstance {
+  return { warn: vi.fn() } as unknown as ConsolaInstance
 }
 
 function createTerminal(options: {
   interactive?: boolean
-  notify?: (notification: NuxtTerminalNotification) => NuxtTerminalNotice
-  task?: NuxtTerminalTask
-} = {}): NuxtTerminal {
+  notify?: (notification: DiagnosticTerminalNotification) => DiagnosticTerminalNotice
+  task?: DiagnosticTerminalTask
+} = {}): DiagnosticTerminal {
   return {
     interactive: options.interactive ?? false,
-    withTerminal: work => work(),
-    prompt: vi.fn(),
     notify: options.notify ?? (() => ({ dismiss: vi.fn(), dismissed: Promise.resolve() })),
     startTask: () => options.task ?? { update: vi.fn(), stop: vi.fn() },
   }
@@ -22,7 +21,7 @@ function createTerminal(options: {
 
 describe('diagnostic output', () => {
   it('discovers a terminal host registered after the output was created', () => {
-    const notifications: NuxtTerminalNotification[] = []
+    const notifications: DiagnosticTerminalNotification[] = []
     const logger = createLogger()
     let terminal = createTerminal()
     const output = createDiagnosticOutput(() => terminal, logger)
@@ -76,7 +75,7 @@ describe('diagnostic output', () => {
     expect(logger.warn).toHaveBeenNthCalledWith(2, 'Middleware report')
   })
 
-  it('reports task completion to a host registered late', async () => {
+  it('removes a completed task without adding a history entry', async () => {
     const task = { update: vi.fn(), stop: vi.fn() }
     let terminal = createTerminal()
     const output = createDiagnosticOutput(() => terminal, createLogger())
@@ -84,10 +83,10 @@ describe('diagnostic output', () => {
 
     await expect(output.runTask({
       start: 'Checking runtime size budgets',
-      success: 'Checked runtime size budgets',
+      failure: 'Failed to check runtime size budgets',
     }, async () => 'done')).resolves.toBe('done')
 
-    expect(task.stop).toHaveBeenCalledExactlyOnceWith('Checked runtime size budgets')
+    expect(task.stop).toHaveBeenCalledExactlyOnceWith()
   })
 
   it('marks a failed terminal task before propagating the error', async () => {
@@ -100,10 +99,10 @@ describe('diagnostic output', () => {
 
     await expect(output.runTask({
       start: 'Checking runtime size budgets',
-      success: 'Checked runtime size budgets',
+      failure: 'Failed to check runtime size budgets',
     }, async () => { throw failure })).rejects.toBe(failure)
 
-    expect(task.stop).toHaveBeenCalledExactlyOnceWith(undefined, 'failure')
+    expect(task.stop).toHaveBeenCalledExactlyOnceWith('Failed to check runtime size budgets', 'failure')
   })
 
   it('does not add task logs without an interactive host', async () => {
@@ -112,7 +111,7 @@ describe('diagnostic output', () => {
 
     await output.runTask({
       start: 'Checking runtime size budgets',
-      success: 'Checked runtime size budgets',
+      failure: 'Failed to check runtime size budgets',
     }, async () => 'done')
 
     expect(task.stop).not.toHaveBeenCalled()

--- a/packages/nuxt-dx/tests/fixtures/terminal-host.mjs
+++ b/packages/nuxt-dx/tests/fixtures/terminal-host.mjs
@@ -1,0 +1,32 @@
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import process from 'node:process'
+
+const output = process.env.NUXT_DX_TERMINAL_EVENTS
+
+function record(event) {
+  if (!output)
+    return
+  mkdirSync(dirname(output), { recursive: true })
+  appendFileSync(output, `${JSON.stringify(event)}\n`)
+}
+
+globalThis[Symbol.for('nuxt:terminal-host')] = {
+  version: 1,
+  withTerminal: work => work(),
+  notify(notification) {
+    record({ type: 'notification', ...notification })
+    return { dismiss() {}, dismissed: Promise.resolve() }
+  },
+  startTask(label) {
+    record({ type: 'task:start', label })
+    return {
+      update(nextLabel) {
+        record({ type: 'task:update', label: nextLabel })
+      },
+      stop(message, outcome) {
+        record({ type: 'task:stop', message, outcome })
+      },
+    }
+  },
+}

--- a/packages/nuxt-dx/tests/runtime-entries.test.ts
+++ b/packages/nuxt-dx/tests/runtime-entries.test.ts
@@ -51,9 +51,9 @@ describe('runtime entry budgets', () => {
         message: expect.stringMatching(/Nitro plugins? over budget[\s\S]+Nitro middleware over budget/),
       }),
     ])
-    expect(terminal.filter(event => event.type === 'task:stop')).toEqual(expect.arrayContaining([
-      { type: 'task:stop', message: 'Checked client runtime size budgets' },
-      { type: 'task:stop', message: 'Checked server runtime size budgets' },
-    ]))
+    expect(terminal.filter(event => event.type === 'task:stop')).toEqual([
+      { type: 'task:stop' },
+      { type: 'task:stop' },
+    ])
   }, 60_000)
 })

--- a/packages/nuxt-dx/tests/runtime-entries.test.ts
+++ b/packages/nuxt-dx/tests/runtime-entries.test.ts
@@ -1,21 +1,30 @@
 import { execFile } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
+import { readFile, rm } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
 
 const execFileAsync = promisify(execFile)
 const packageRoot = new URL('..', import.meta.url)
 const fixture = 'tests/fixtures/runtime-entries'
+const terminalEvents = new URL(`${fixture}/.nuxt/dx/terminal-events.jsonl`, packageRoot)
+const terminalHost = new URL('fixtures/terminal-host.mjs', import.meta.url)
 
 describe('runtime entry budgets', () => {
   it('measures plugins and middleware registered by the app and Nuxt modules', async () => {
-    const result = await execFileAsync('pnpm', ['exec', 'nuxt', 'build', fixture], {
+    await rm(terminalEvents, { force: true })
+    await execFileAsync('pnpm', ['exec', 'nuxt', 'build', fixture], {
       cwd: packageRoot,
-      env: { ...process.env, NO_COLOR: '1' },
+      env: {
+        ...process.env,
+        NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${terminalHost.href}`].filter(Boolean).join(' '),
+        NUXT_DX_TERMINAL_EVENTS: fileURLToPath(terminalEvents),
+        NO_COLOR: '1',
+      },
       maxBuffer: 20 * 1024 * 1024,
     })
-    const output = `${result.stdout}\n${result.stderr}`
     const report = JSON.parse(await readFile(new URL(`${fixture}/.nuxt/dx/size-budget.json`, packageRoot), 'utf8'))
+    const terminal = (await readFile(terminalEvents, 'utf8')).trim().split('\n').map(line => JSON.parse(line))
     const owned = report.entries.filter((entry: { owner?: string }) => entry.owner === 'fixture-runtime-module')
 
     expect(new Set(report.entries.map((entry: { scope: string }) => entry.scope))).toEqual(new Set([
@@ -30,9 +39,15 @@ describe('runtime entry budgets', () => {
       'nitro',
       'nitro-middleware',
     ]))
-    expect(output).toMatch(/Nuxt plugins? over budget/)
-    expect(output).toContain('Nuxt middleware over budget')
-    expect(output).toMatch(/Nitro plugins? over budget/)
-    expect(output).toContain('Nitro middleware over budget')
+    expect(terminal.filter(event => event.type === 'notification')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringMatching(/Nuxt plugins? over budget/) }),
+      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringContaining('Nuxt middleware over budget') }),
+      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringMatching(/Nitro plugins? over budget/) }),
+      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringContaining('Nitro middleware over budget') }),
+    ]))
+    expect(terminal.filter(event => event.type === 'task:stop')).toEqual(expect.arrayContaining([
+      { type: 'task:stop', message: 'Checked client runtime size budgets' },
+      { type: 'task:stop', message: 'Checked server runtime size budgets' },
+    ]))
   }, 60_000)
 })

--- a/packages/nuxt-dx/tests/runtime-entries.test.ts
+++ b/packages/nuxt-dx/tests/runtime-entries.test.ts
@@ -39,12 +39,18 @@ describe('runtime entry budgets', () => {
       'nitro',
       'nitro-middleware',
     ]))
-    expect(terminal.filter(event => event.type === 'notification')).toEqual(expect.arrayContaining([
-      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringMatching(/Nuxt plugins? over budget/) }),
-      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringContaining('Nuxt middleware over budget') }),
-      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringMatching(/Nitro plugins? over budget/) }),
-      expect.objectContaining({ level: 'warn', title: 'Nuxt DX diagnostic', message: expect.stringContaining('Nitro middleware over budget') }),
-    ]))
+    expect(terminal.filter(event => event.type === 'notification')).toEqual([
+      expect.objectContaining({
+        level: 'warn',
+        title: 'Nuxt DX: client size budget',
+        message: expect.stringMatching(/Nuxt plugins? over budget[\s\S]+Nuxt middleware over budget/),
+      }),
+      expect.objectContaining({
+        level: 'warn',
+        title: 'Nuxt DX: server size budget',
+        message: expect.stringMatching(/Nitro plugins? over budget[\s\S]+Nitro middleware over budget/),
+      }),
+    ])
     expect(terminal.filter(event => event.type === 'task:stop')).toEqual(expect.arrayContaining([
       { type: 'task:stop', message: 'Checked client runtime size budgets' },
       { type: 'task:stop', message: 'Checked server runtime size budgets' },

--- a/packages/nuxt-dx/tests/terminal-bridge.test.ts
+++ b/packages/nuxt-dx/tests/terminal-bridge.test.ts
@@ -1,0 +1,75 @@
+import type { ConsolaInstance } from 'consola'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDiagnosticOutput } from '../src/diagnostic-output'
+import { createTerminalAccess } from '../src/terminal-bridge'
+
+const terminalHostKey = Symbol.for('nuxt:terminal-host')
+const globals = globalThis as typeof globalThis & { [terminalHostKey]?: unknown }
+
+afterEach(() => {
+  delete globals[terminalHostKey]
+})
+
+function createLogger(): ConsolaInstance {
+  return {
+    box: vi.fn(),
+    fail: vi.fn(),
+    start: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as ConsolaInstance
+}
+
+describe('terminal bridge', () => {
+  it('prefers Nuxt useTerminal when the installed Kit provides it', async () => {
+    const logger = createLogger()
+    const stop = vi.fn()
+    const upstream = vi.fn(() => ({
+      interactive: true,
+      notify: vi.fn(),
+      startTask: () => ({ update: vi.fn(), stop }),
+    }))
+    const output = createDiagnosticOutput(createTerminalAccess(logger, upstream), logger)
+
+    await output.runTask({
+      start: 'Checking server runtime size budgets',
+      failure: 'Failed to check server runtime size budgets',
+    }, async () => {})
+
+    expect(upstream).toHaveBeenCalledOnce()
+    expect(stop).toHaveBeenCalledExactlyOnceWith()
+  })
+
+  it('uses a host registered between initial work and a rebuild', async () => {
+    const events: string[] = []
+    const logger = createLogger()
+    const output = createDiagnosticOutput(createTerminalAccess(logger), logger)
+    const labels = {
+      start: 'Checking server runtime size budgets',
+      failure: 'Failed to check server runtime size budgets',
+    }
+
+    await output.runTask(labels, async () => {})
+    globals[terminalHostKey] = {
+      version: 1,
+      withTerminal: async (work: () => Promise<unknown>) => work(),
+      startTask(label: string) {
+        events.push(`start:${label}`)
+        return {
+          update() {},
+          stop(message?: string) {
+            events.push(`stop:${message ?? ''}`)
+          },
+        }
+      },
+    }
+    await output.runTask(labels, async () => {})
+    delete globals[terminalHostKey]
+    await output.runTask(labels, async () => {})
+
+    expect(events).toEqual([
+      'start:Checking server runtime size budgets',
+      'stop:',
+    ])
+  })
+})

--- a/packages/nuxt-dx/tests/terminal-bridge.test.ts
+++ b/packages/nuxt-dx/tests/terminal-bridge.test.ts
@@ -72,4 +72,25 @@ describe('terminal bridge', () => {
       'stop:',
     ])
   })
+
+  it('adds the raw lightweight panel bridge when Kit does not expose it yet', () => {
+    const logger = createLogger()
+    const registerPanel = vi.fn(() => ({ update: vi.fn(), dispose: vi.fn() }))
+    globals[terminalHostKey] = {
+      version: 1,
+      withTerminal: async (work: () => Promise<unknown>) => work(),
+      startTask: () => ({ update: vi.fn(), stop: vi.fn() }),
+      registerPanel,
+    }
+    const upstream = vi.fn(() => ({
+      interactive: true,
+      notify: vi.fn(),
+      startTask: () => ({ update: vi.fn(), stop: vi.fn() }),
+    }))
+
+    const terminal = createTerminalAccess(logger, upstream)()
+    terminal.registerPanel!({ id: 'nuxt-dx:diagnostics', title: 'Nuxt DX Diagnostics' })
+
+    expect(registerPanel).toHaveBeenCalledOnce()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^5.20260811.1
       version: 5.20260811.1
     '@nuxt/kit':
-      specifier: https://pkg.pr.new/@nuxt/kit@36162
-      version: 5.0.0-0
+      specifier: ^4.5.2
+      version: 4.5.2
     '@nuxt/module-builder':
       specifier: ^1.0.2
       version: 1.0.3
@@ -141,7 +141,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       comark:
         specifier: 'catalog:'
         version: 0.6.2(rangi@2.2.0)
@@ -187,7 +187,7 @@ importers:
         version: link:../nuxt-cloudflare
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/schema':
         specifier: 'catalog:'
         version: 4.5.2
@@ -269,7 +269,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       citty:
         specifier: 'catalog:'
         version: 0.2.2
@@ -336,7 +336,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -379,7 +379,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.4.0(vue@3.5.41(typescript@5.9.3))
@@ -437,7 +437,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       nitropack:
         specifier: 'catalog:'
         version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3))(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -486,7 +486,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -541,7 +541,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.4.0(vue@3.5.41(typescript@5.9.3))
@@ -611,7 +611,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -636,7 +636,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)
       evlog:
         specifier: 'catalog:'
-        version: 2.26.0(@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.26.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       h3:
         specifier: 'catalog:'
         version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
@@ -1842,34 +1842,6 @@ packages:
   '@nuxt/kit@4.5.2':
     resolution: {integrity: sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==}
     engines: {node: '>=18.12.0'}
-
-  '@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162':
-    resolution: {tarball: https://pkg.pr.new/@nuxt/kit@36162}
-    version: 5.0.0-0
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      confbox: ^0.2.4
-      dotenv: ^17.4.2
-      giget: ^3.3.1
-      jiti: ^2.7.0
-      mlly: ^1.8.2
-      oxc-parser: '>=0.56.0'
-      rolldown: '>=1.0.0'
-    peerDependenciesMeta:
-      confbox:
-        optional: true
-      dotenv:
-        optional: true
-      giget:
-        optional: true
-      jiti:
-        optional: true
-      mlly:
-        optional: true
-      oxc-parser:
-        optional: true
-      rolldown:
-        optional: true
 
   '@nuxt/module-builder@1.0.3':
     resolution: {integrity: sha512-3VApg9j6MUc6G2p5hwUZmYCBHnFPg+18ye1uXpywDQGzS12HM9d1ktsCovBEImeLOLw2PlPOms/gMFkaqxRcuw==}
@@ -4039,7 +4011,6 @@ packages:
 
   evlog@2.26.0:
     resolution: {integrity: sha512-5/UrfWGJEIuPdOk2m2lBqxJcDoH+71bejl/D1U4q42A/+UPPZ11h35GvVdzn6HTMfnkfbBiRIfLBR5C8Osg47g==}
-    version: 2.26.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@nestjs/common': '>=11.1.28'
@@ -4827,9 +4798,6 @@ packages:
   meriyah@6.1.4:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
-
-  microdiff@1.6.0:
-    resolution: {integrity: sha512-w7JWt8Bno6I8h0rEqlxr4lNG4UbT1FVtWo42wWosIiaJ+rP3pXh7shCYDnyqBrYx36LJ1CZ64p8A62aVp0sJpQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6455,10 +6423,6 @@ packages:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
     engines: {node: '>=18.12.0'}
 
-  verkit@0.4.0:
-    resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
-    engines: {node: '>=18.12.0'}
-
   vite-dev-rpc@2.0.0:
     resolution: {integrity: sha512-yKwbTwdHKSD2k/aGqyWpPHepo45OQc8lH3/6IfT4ZqeKE26ooKvi4WIEKzqWav8v+9Is8u1k8q54hvOmqASazA==}
     peerDependencies:
@@ -7934,7 +7898,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      unctx: 3.0.1(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       untyped: 2.0.0
       verkit: 0.3.2
     transitivePeerDependencies:
@@ -7942,36 +7906,6 @@ snapshots:
       - magicast
       - oxc-parser
       - rolldown
-      - unplugin
-
-  '@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))':
-    dependencies:
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      klona: 2.0.6
-      microdiff: 1.6.0
-      nostics: 1.2.0
-      nypm: 0.6.9
-      pathe: 2.0.3
-      rc9: 3.0.1
-      scule: 1.3.0
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      unctx: 3.0.1(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      verkit: 0.4.0
-    optionalDependencies:
-      confbox: 0.2.4
-      dotenv: 17.4.2
-      giget: 3.3.1
-      jiti: 2.7.0
-      mlly: 1.8.2
-      rolldown: 1.2.3
-    transitivePeerDependencies:
-      - magic-string
       - unplugin
 
   '@nuxt/module-builder@1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))':
@@ -10537,9 +10471,9 @@ snapshots:
 
   events@3.3.0: {}
 
-  evlog@2.26.0(@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
+  evlog@2.26.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     optionalDependencies:
-      '@nuxt/kit': https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3))(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       ofetch: 1.5.1
@@ -11337,8 +11271,6 @@ snapshots:
   merge2@1.4.1: {}
 
   meriyah@6.1.4: {}
-
-  microdiff@1.6.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -13528,8 +13460,6 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   verkit@0.3.2: {}
-
-  verkit@0.4.0: {}
 
   vite-dev-rpc@2.0.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^5.20260811.1
       version: 5.20260811.1
     '@nuxt/kit':
-      specifier: ^4.5.2
-      version: 4.5.2
+      specifier: https://pkg.pr.new/@nuxt/kit@36162
+      version: 5.0.0-0
     '@nuxt/module-builder':
       specifier: ^1.0.2
       version: 1.0.3
@@ -141,7 +141,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       comark:
         specifier: 'catalog:'
         version: 0.6.2(rangi@2.2.0)
@@ -187,7 +187,7 @@ importers:
         version: link:../nuxt-cloudflare
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxt/schema':
         specifier: 'catalog:'
         version: 4.5.2
@@ -269,7 +269,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       citty:
         specifier: 'catalog:'
         version: 0.2.2
@@ -336,7 +336,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -379,7 +379,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.4.0(vue@3.5.41(typescript@5.9.3))
@@ -437,7 +437,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       nitropack:
         specifier: 'catalog:'
         version: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3))(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
@@ -486,7 +486,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -541,7 +541,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.4.0(vue@3.5.41(typescript@5.9.3))
@@ -611,7 +611,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: 'catalog:'
-        version: 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+        version: https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       pathe:
         specifier: 'catalog:'
         version: 2.0.3
@@ -636,7 +636,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)
       evlog:
         specifier: 'catalog:'
-        version: 2.26.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+        version: 2.26.0(@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       h3:
         specifier: 'catalog:'
         version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
@@ -1842,6 +1842,34 @@ packages:
   '@nuxt/kit@4.5.2':
     resolution: {integrity: sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==}
     engines: {node: '>=18.12.0'}
+
+  '@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162':
+    resolution: {tarball: https://pkg.pr.new/@nuxt/kit@36162}
+    version: 5.0.0-0
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      confbox: ^0.2.4
+      dotenv: ^17.4.2
+      giget: ^3.3.1
+      jiti: ^2.7.0
+      mlly: ^1.8.2
+      oxc-parser: '>=0.56.0'
+      rolldown: '>=1.0.0'
+    peerDependenciesMeta:
+      confbox:
+        optional: true
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      mlly:
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
 
   '@nuxt/module-builder@1.0.3':
     resolution: {integrity: sha512-3VApg9j6MUc6G2p5hwUZmYCBHnFPg+18ye1uXpywDQGzS12HM9d1ktsCovBEImeLOLw2PlPOms/gMFkaqxRcuw==}
@@ -4011,6 +4039,7 @@ packages:
 
   evlog@2.26.0:
     resolution: {integrity: sha512-5/UrfWGJEIuPdOk2m2lBqxJcDoH+71bejl/D1U4q42A/+UPPZ11h35GvVdzn6HTMfnkfbBiRIfLBR5C8Osg47g==}
+    version: 2.26.0
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@nestjs/common': '>=11.1.28'
@@ -4798,6 +4827,9 @@ packages:
   meriyah@6.1.4:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
+
+  microdiff@1.6.0:
+    resolution: {integrity: sha512-w7JWt8Bno6I8h0rEqlxr4lNG4UbT1FVtWo42wWosIiaJ+rP3pXh7shCYDnyqBrYx36LJ1CZ64p8A62aVp0sJpQ==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6205,6 +6237,23 @@ packages:
       unplugin:
         optional: true
 
+  unctx@3.0.1:
+    resolution: {integrity: sha512-5RAt2etv7g362RXyd33R82gm9u/kbtQlpoaOs9Bgm4E32GRMJ0xjbZyvdxUTmiuHk3V1IQb1aUNrp5IWY+JaWw==}
+    peerDependencies:
+      magic-string: '>=0.30.21'
+      oxc-parser: '>=0.140.0'
+      rolldown: ^1.1.5
+      unplugin: ^3.3.0
+    peerDependenciesMeta:
+      magic-string:
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+      unplugin:
+        optional: true
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -6404,6 +6453,10 @@ packages:
 
   verkit@0.3.2:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
+    engines: {node: '>=18.12.0'}
+
+  verkit@0.4.0:
+    resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
     engines: {node: '>=18.12.0'}
 
   vite-dev-rpc@2.0.0:
@@ -7889,6 +7942,36 @@ snapshots:
       - magicast
       - oxc-parser
       - rolldown
+      - unplugin
+
+  '@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))':
+    dependencies:
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.2
+      exsolve: 1.1.1
+      ignore: 7.0.6
+      klona: 2.0.6
+      microdiff: 1.6.0
+      nostics: 1.2.0
+      nypm: 0.6.9
+      pathe: 2.0.3
+      rc9: 3.0.1
+      scule: 1.3.0
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      unctx: 3.0.1(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      verkit: 0.4.0
+    optionalDependencies:
+      confbox: 0.2.4
+      dotenv: 17.4.2
+      giget: 3.3.1
+      jiti: 2.7.0
+      mlly: 1.8.2
+      rolldown: 1.2.3
+    transitivePeerDependencies:
+      - magic-string
       - unplugin
 
   '@nuxt/module-builder@1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4))(@volar/typescript@2.4.28)(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(typescript@5.9.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@5.9.3))(vue@3.5.41(typescript@5.9.3))':
@@ -10454,9 +10537,9 @@ snapshots:
 
   events@3.3.0: {}
 
-  evlog@2.26.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
+  evlog@2.26.0(@nuxt/kit@https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(nitropack@2.13.4(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(ofetch@1.5.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     optionalDependencies:
-      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
+      '@nuxt/kit': https://pkg.pr.new/@nuxt/kit@36162(confbox@0.2.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       h3: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
       nitropack: 2.13.4(drizzle-orm@1.0.0-rc.4(@cloudflare/workers-types@5.20260811.1)(@opentelemetry/api@1.9.1)(zod@4.4.3))(rolldown@1.2.3)(srvx@0.11.22)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       ofetch: 1.5.1
@@ -11254,6 +11337,8 @@ snapshots:
   merge2@1.4.1: {}
 
   meriyah@6.1.4: {}
+
+  microdiff@1.6.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -13275,6 +13360,12 @@ snapshots:
       rolldown: 1.2.3
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
 
+  unctx@3.0.1(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))):
+    optionalDependencies:
+      magic-string: 1.1.0
+      rolldown: 1.2.3
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+
   undici-types@8.3.0: {}
 
   undici@7.29.0: {}
@@ -13437,6 +13528,8 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   verkit@0.3.2: {}
+
+  verkit@0.4.0: {}
 
   vite-dev-rpc@2.0.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   '@cloudflare/workers-types': ^5.20260811.1
   '@sentry/cloudflare': ^10.70.0
   '@sentry/nuxt': ^10.70.0
-  '@nuxt/kit': ^4.5.2
+  '@nuxt/kit': https://pkg.pr.new/@nuxt/kit@36162
   '@nuxt/module-builder': ^1.0.2
   '@nuxt/schema': ^4.5.2
   '@nuxt/test-utils': ^4.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   '@cloudflare/workers-types': ^5.20260811.1
   '@sentry/cloudflare': ^10.70.0
   '@sentry/nuxt': ^10.70.0
-  '@nuxt/kit': https://pkg.pr.new/@nuxt/kit@36162
+  '@nuxt/kit': ^4.5.2
   '@nuxt/module-builder': ^1.0.2
   '@nuxt/schema': ^4.5.2
   '@nuxt/test-utils': ^4.1.0


### PR DESCRIPTION
## Summary

- show size budget checks as Nuxt terminal tasks
- publish client and server failures in one live Diagnostics panel
- support selection, search, copy fix, dismiss, and open file actions
- remove Diagnostics when a later build resolves them
- fall back to Nuxt notices or logger output on older terminal hosts
- use the upstream Kit API and a lightweight raw host bridge

## Verification

- 192 Nuxt DX tests pass
- lint passes
- typecheck passes
- build passes
- real Nuxt CLI TUI opens the panel with the `d` shortcut
- live panel data crosses the Nuxt dev fork boundary

## Upstream dependency

This stays draft until Nuxt CLI supports declarative module panels.
The package does not bundle Nuxt CLI or pin a nightly.