### PR TITLE
fix(nuxt-sentry): never create a release a deploy did not make

### DIFF
--- a/packages/nuxt-sentry/src/build/sentry-build.ts
+++ b/packages/nuxt-sentry/src/build/sentry-build.ts
@@ -31,11 +31,22 @@ export interface SentryBuildInput {
   hasAuthToken: boolean
 }
 
+/**
+ * What the build plugin may do about a release.
+ *
+ * The plugin names a release from git HEAD when the config omits one, and
+ * creates it. A local build holding a token therefore published a release for
+ * a commit that never deployed. Only a named release is ever created.
+ */
+export type SentryReleaseOptions
+  = | { name: string }
+    | { create: false, inject: false }
+
 export interface SentryBuildOptions {
   org: string
   project?: string
   authToken?: string
-  release?: { name: string }
+  release: SentryReleaseOptions
   sourcemaps: {
     disable: boolean
     filesToDeleteAfterUpload: string[]
@@ -48,15 +59,26 @@ export interface SentryBuildOptions {
   telemetry: false
 }
 
+/**
+ * Whether this build both may upload a source map and has a release to bind it to.
+ *
+ * The module reads the same answer to decide whether to emit a client map at
+ * all, so the rule lives here once.
+ */
+export function uploadsSourceMaps(input: Pick<SentryBuildInput, 'sourceMaps' | 'hasAuthToken' | 'release'>): boolean {
+  return input.sourceMaps && input.hasAuthToken && Boolean(input.release)
+}
+
 export function resolveSentryBuildOptions(input: SentryBuildInput): SentryBuildOptions {
   return {
     org: input.org,
     ...(input.project ? { project: input.project } : {}),
     ...(input.authToken ? { authToken: input.authToken } : {}),
-    // An unnamed release cannot bind an uploaded map to the events it explains.
-    ...(input.release ? { release: { name: input.release } } : {}),
+    release: input.release ? { name: input.release } : { create: false, inject: false },
     sourcemaps: {
-      disable: !input.sourceMaps || !input.hasAuthToken,
+      // An unnamed release cannot bind an uploaded map to the reports it
+      // explains, so the upload is waste that also invents the release.
+      disable: !uploadsSourceMaps(input),
       filesToDeleteAfterUpload: ['**/*.map'],
     },
     // Session Replay is not used anywhere in the estate, and its code is the
@@ -102,7 +124,7 @@ export function checkSentryBuild(input: BuildCheckInput): BuildIssue[] {
   if (input.sourceMaps && input.hasAuthToken && !input.release) {
     issues.push({
       _tag: 'warning',
-      message: 'Source maps upload without a release name, so they cannot bind to the reports they explain. Set SENTRY_RELEASE in the deploy workflow.',
+      message: 'This build carries no release name. Source maps stay local, and no release is created. Set SENTRY_RELEASE in the deploy workflow.',
     })
   }
   if (input.isProduction && input.gate === 'release' && !input.release) {

--- a/packages/nuxt-sentry/src/module.ts
+++ b/packages/nuxt-sentry/src/module.ts
@@ -15,7 +15,7 @@ import {
 } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { resolveReportPolicy } from './build/policy'
-import { checkSentryBuild, hasSentryAuthToken, resolveSentryBuildOptions } from './build/sentry-build'
+import { checkSentryBuild, hasSentryAuthToken, resolveSentryBuildOptions, uploadsSourceMaps } from './build/sentry-build'
 import { resolveRelease, resolveReportTarget } from './build/target'
 import { resolveWideEventDrain } from './build/wide-events'
 
@@ -169,7 +169,7 @@ export default defineNuxtModule<ModuleOptions>({
       ...nuxtOptions.sentry,
     }
 
-    if (sourceMaps && authTokenPresent) {
+    if (uploadsSourceMaps({ sourceMaps, hasAuthToken: authTokenPresent, release })) {
       // `hidden` emits the map and keeps the comment out of the served bundle.
       // `sourcemap.server` is left alone: `@harlan-zw/nuxt-cloudflare` derives
       // `upload_source_maps` from it, and turning it on here would change a

--- a/packages/nuxt-sentry/tests/sentry-build.test.ts
+++ b/packages/nuxt-sentry/tests/sentry-build.test.ts
@@ -1,0 +1,88 @@
+import type { SentryBuildInput } from '../src/build/sentry-build'
+import { describe, expect, it } from 'vitest'
+import { checkSentryBuild, hasSentryAuthToken, resolveSentryBuildOptions, uploadsSourceMaps } from '../src/build/sentry-build'
+
+function input(overrides: Partial<SentryBuildInput> = {}): SentryBuildInput {
+  return {
+    org: 'harlan-zw',
+    project: 'site',
+    release: 'abc123',
+    sourceMaps: true,
+    authToken: 'token',
+    hasAuthToken: true,
+    ...overrides,
+  }
+}
+
+describe('hasSentryAuthToken', () => {
+  it('counts a local dotenv file as a token', () => {
+    expect(hasSentryAuthToken({ hasDotenvFile: true })).toBe(true)
+  })
+
+  it('ignores a blank environment token', () => {
+    expect(hasSentryAuthToken({ sentryAuthToken: '  ', hasDotenvFile: false })).toBe(false)
+  })
+})
+
+describe('resolveSentryBuildOptions', () => {
+  it('names the release a deploy carries', () => {
+    expect(resolveSentryBuildOptions(input()).release).toEqual({ name: 'abc123' })
+  })
+
+  it('uploads source maps for a named release', () => {
+    expect(resolveSentryBuildOptions(input()).sourcemaps.disable).toBe(false)
+  })
+
+  it('refuses to create a release when the build carries no identity', () => {
+    expect(resolveSentryBuildOptions(input({ release: '' })).release).toEqual({
+      create: false,
+      inject: false,
+    })
+  })
+
+  it('uploads no source map when the build carries no release', () => {
+    expect(resolveSentryBuildOptions(input({ release: '' })).sourcemaps.disable).toBe(true)
+  })
+
+  it('uploads no source map without an auth token', () => {
+    expect(resolveSentryBuildOptions(input({ hasAuthToken: false })).sourcemaps.disable).toBe(true)
+  })
+})
+
+describe('uploadsSourceMaps', () => {
+  it('needs a token and a release together', () => {
+    expect(uploadsSourceMaps({ sourceMaps: true, hasAuthToken: true, release: 'abc123' })).toBe(true)
+    expect(uploadsSourceMaps({ sourceMaps: true, hasAuthToken: true, release: '' })).toBe(false)
+    expect(uploadsSourceMaps({ sourceMaps: true, hasAuthToken: false, release: 'abc123' })).toBe(false)
+    expect(uploadsSourceMaps({ sourceMaps: false, hasAuthToken: true, release: 'abc123' })).toBe(false)
+  })
+})
+
+describe('checkSentryBuild', () => {
+  function check(overrides: Partial<Parameters<typeof checkSentryBuild>[0]> = {}) {
+    return checkSentryBuild({
+      sourceMaps: true,
+      hasAuthToken: true,
+      project: 'site',
+      release: 'abc123',
+      gate: 'release',
+      isProduction: true,
+      ...overrides,
+    })
+  }
+
+  it('passes a deploy build', () => {
+    expect(check()).toEqual([])
+  })
+
+  it('fails a source map upload with no project', () => {
+    expect(check({ project: undefined })).toContainEqual(
+      expect.objectContaining({ _tag: 'error' }),
+    )
+  })
+
+  it('warns that a build with no release keeps its source maps local', () => {
+    const messages = check({ release: '' }).map(issue => issue.message)
+    expect(messages).toContainEqual(expect.stringContaining('Source maps stay local'))
+  })
+})


### PR DESCRIPTION
## Problem

`harlan-zw/harlanzw-com` holds two Sentry releases for commits that never left the laptop:

| Release | Created | Deployed |
| --- | --- | --- |
| `fcd3459bb576` | 2026-08-22 | never, not on `origin/main` |
| `6437e0c14771` | 2026-08-24 | never, not on `origin/main` |

Both were created after the `@harlan-zw/nuxt-sentry` migration in `c1cf1a7` (2026-08-18), so this is live on `main`, not old debt.

Mechanism: `resolveRelease` returns `''` on a local build, so `release` was omitted from the plugin options. The Sentry bundler plugin then names a release from git HEAD and creates it, because `release.create` defaults to true. `.env.sentry-build-plugin` supplies the token that authorizes it.

This matters beyond tidiness. The Sentry check-in dates a fix by asking which release carries it. A release that was never deployed is a false answer to that question.

## Change

Without a release identity the build now:

- sets `release: { create: false, inject: false }`, so nothing is created
- uploads no source map, because a map that cannot bind to a release explains nothing, and the upload is what invented the release

`SentryBuildOptions.release` becomes a union of the two legal shapes rather than an optional field, so the "no identity" case cannot be spelled as an absent name.

The existing warning stays and now describes what the build actually does:

> This build carries no release name. Source maps stay local, and no release is created. Set SENTRY_RELEASE in the deploy workflow.

`uploadsSourceMaps` is shared, so the module and the option builder cannot disagree about whether a map is emitted.

## Checks

- `pnpm vitest run` in `nuxt-sentry`: 142 pass, 11 new in `tests/sentry-build.test.ts`. The 3 covering the defect fail on `main`.
- `pnpm lint`, `pnpm typecheck` in `nuxt-sentry`: clean
- All packages: 147 test files pass

Baseline debt, untouched: `nuxt-cloudflare` has 4 pre-existing lint errors in a JSON file, present with this change stashed.

## Follow-up

The two junk releases still exist in Sentry and want deleting by hand. Sites pick this up on the next `nuxt-sentry` release and bump.