### PR TITLE
fix(nuxt-cloudflare): classify a Durable Object eviction as a D1 session reset

### DIFF
--- a/packages/nuxt-cloudflare/src/d1.ts
+++ b/packages/nuxt-cloudflare/src/d1.ts
@@ -100,6 +100,16 @@ const SESSION_RESET_D1_SIGNALS = [
   'Internal error while starting up D1 DB storage caused object to be reset',
   'Internal error in D1 DB storage caused object to be reset',
   'storage caused object to be reset',
+  // Cloudflare evicts the Durable Object backing a session and reports it in
+  // its own words: "Connection closed: this Durable Object instance is no
+  // longer active. Reconnect or retry the request." Same family as
+  // `D1_RESET_DO` — the session is gone, the query is replayable.
+  //
+  // Match the Durable Object clause, NOT the "Connection closed" prefix the
+  // message leads with: that prefix is generic enough to appear on unrelated
+  // transports, and replaying an arbitrary closed connection as a D1 session
+  // reset would retry writes that never belonged to this classifier.
+  'Durable Object instance is no longer active',
 ] as const
 const TRANSIENT_D1_SIGNALS = [
   'Network connection lost',

--- a/packages/nuxt-cloudflare/tests/d1.test.ts
+++ b/packages/nuxt-cloudflare/tests/d1.test.ts
@@ -95,6 +95,34 @@ describe('d1 retry classification', () => {
       cause: new Error('D1_ERROR: Replica disconnected from primary.'),
     }))).toEqual({ _tag: 'transient' })
   })
+
+  // Cloudflare evicts the Durable Object backing a D1 session and reports it
+  // with its own wording. Seen in production 2026-08-26 on two unrelated
+  // requests 5ms apart; unclassified, it reached Sentry as an opaque 500
+  // instead of the retryable path every other eviction takes.
+  it('classifies a Durable Object eviction as a session reset', () => {
+    expect(classifyD1RetryError(new Error(
+      'D1_ERROR: Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.',
+    ))).toEqual({ _tag: 'session-reset' })
+  })
+
+  it('classifies the eviction through a wrapping driver error', () => {
+    const wrapped = new Error('Failed query: select "team_id" from "team_catalogs"', {
+      cause: new Error(
+        'D1_ERROR: Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.',
+      ),
+    })
+    expect(classifyD1RetryError(wrapped)).toEqual({ _tag: 'session-reset' })
+    expect(isTransientD1Error(wrapped)).toBe(true)
+  })
+
+  // The eviction text leads with "Connection closed", which is generic enough
+  // to appear on unrelated transports. Match the Durable Object clause instead,
+  // so a websocket or fetch teardown never gets replayed as a D1 session reset.
+  it('does not treat an unrelated closed connection as retryable', () => {
+    expect(classifyD1RetryError(new Error('Connection closed before a response was received')))
+      .toEqual({ _tag: 'permanent' })
+  })
 })
 
 describe('isReplayableD1Sql', () => {


### PR DESCRIPTION
Cloudflare evicts the Durable Object backing a D1 session and reports it in its own words:

```
D1_ERROR: Connection closed: this Durable Object instance is no longer active. Reconnect or retry the request.
```

That text matched nothing in `SESSION_RESET_D1_SIGNALS` or `TRANSIENT_D1_SIGNALS`, so `classifyD1RetryError` returned `permanent`, `isTransientD1Error` returned `false`, and the recovering session neither retried it nor surfaced it as the standard retryable failure. Callers saw an opaque driver error for what is the same condition as `D1_RESET_DO`: the session is gone and the query is replayable.

## Evidence

Production, gscdump.com, 2026-08-26 at `03:28:26Z` — two unrelated requests **5ms apart**, different routes and different tenants:

- `GET /api/partner/v1/sites/*/indexing/urls` → `DrizzleQueryError` wrapping the eviction on `.cause`
- `GET /api/partner/v1/sites/*/sitemaps` → same root cause

Four more unsampled hits of the same wording on a sibling Worker in the same hour, so it was one platform-side session blip rather than anything app-specific. Both reached Sentry as unrecognised 500s instead of taking the retry path every other eviction takes.

## The matching choice

This matches the **Durable Object clause**, not the `"Connection closed"` prefix the message leads with. That prefix is generic enough to appear on unrelated transports (websocket and fetch teardowns), and replaying an arbitrary closed connection as a D1 session reset would retry writes that never belonged to this classifier. There's a test pinning that boundary, and it passed before the fix — so it's guarding the choice, not the change.

## Tests

Three cases added to `d1 retry classification`:

- the bare eviction message classifies as `session-reset`
- the same message through a wrapping driver error (the shape it actually arrives in) classifies as `session-reset` and satisfies `isTransientD1Error`
- an unrelated `"Connection closed before a response was received"` stays `permanent`

Both new eviction cases proven red first (`expected { _tag: 'permanent' } to deeply equal { _tag: 'session-reset' }`).

337 package tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)