### PR TITLE
fix(runner): retry denied capacity requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm dev:prepare
       - run: pnpm lint
+      - run: bash infra/github-runner/supervisor.test.sh
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -129,6 +129,40 @@ require_command() {
   fi
 }
 
+# Use one repository-owner credential when systemd supplies scoped credentials.
+# The desktop user service keeps using its existing gh authentication.
+github_api() {
+  local argument endpoint='' repository owner credential
+
+  if [[ -z "${CREDENTIALS_DIRECTORY:-}" ]]; then
+    gh api "$@"
+    return
+  fi
+
+  for argument in "$@"; do
+    if [[ "$argument" == repos/*/actions/runners* ]]; then
+      endpoint="$argument"
+      break
+    fi
+  done
+
+  if [[ -z "$endpoint" ]]; then
+    log "GitHub API request has no runner repository endpoint"
+    return 1
+  fi
+
+  repository="${endpoint#repos/}"
+  owner="${repository%%/*}"
+  credential="$CREDENTIALS_DIRECTORY/github-$owner-token"
+
+  if [[ ! -r "$credential" ]]; then
+    log "GitHub credential is unavailable for owner: $owner"
+    return 1
+  fi
+
+  GH_TOKEN="$(<"$credential")" gh api "$@"
+}
+
 # `harlan-zw/nuxtseo.com` + `harlan-desktop-ci` -> `nuxtseo-com-ci`. Used for container
 # names and the Docker pool label, both of which reject `/` and `.`.
 #
@@ -312,7 +346,7 @@ run_container() {
   local line
   local -a pipe_status=()
 
-  if ! registration_token="$(gh api \
+  if ! registration_token="$(github_api \
     --method POST \
     "repos/$repository/actions/runners/registration-token" \
     --jq .token 2>/dev/null)"; then
@@ -528,7 +562,7 @@ prune_offline_runners() {
 
   # The listing is captured before it is split, so a failed call is told apart
   # from a repository with nothing offline. On failure the markers must survive.
-  if ! listing="$(gh api --paginate \
+  if ! listing="$(github_api --paginate \
     "repos/$repository/actions/runners" \
     --jq '.runners[] | select(.status == "offline") | .id' 2>/dev/null)"; then
     return 0
@@ -558,7 +592,7 @@ prune_offline_runners() {
   done
 
   for runner_id in "${confirmed_ids[@]}"; do
-    gh api --method DELETE "repos/$repository/actions/runners/$runner_id" >/dev/null 2>&1 || true
+    github_api --method DELETE "repos/$repository/actions/runners/$runner_id" >/dev/null 2>&1 || true
     rm --force "$marker_dir/$runner_id"
   done
 

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -275,6 +275,13 @@ release() {
 
   rm --force "$state_dir/spend/$container_name"
   rm --force "$state_dir/spend-memory/$container_name"
+
+  # A denied burst request stays pending. Wake the scaler when any job returns
+  # capacity, so another repository can use it without waiting for its current
+  # warm job to finish first.
+  if [[ -n "$scale_pipe" && -p "$scale_pipe" && ! -f "$state_dir/shutdown" ]]; then
+    printf 'capacity\n' >"$scale_pipe"
+  fi
 }
 
 # Stops a burst container that registered but never claimed anything. The runner
@@ -428,47 +435,68 @@ run_scaler() {
   local request pool_index container_name
   local burst_counter=0
   local slug live spent spent_memory
+  local pending_pool pending_count attempt
+  local -a pending_pools=()
+  local -A pool_is_pending=()
 
   while true; do
     while IFS=' ' read -r request pool_index; do
-      [[ "$request" == spawn ]] || continue
       [[ -f "$state_dir/shutdown" ]] && continue
 
-      slug="${pool_slug[$pool_index]}"
-      live=$(( pool_warm[pool_index] + $(count_markers "$state_dir/burst/$slug") ))
-      if (( live >= pool_max[pool_index] )); then
+      if [[ "$request" == spawn && -z "${pool_is_pending[$pool_index]:-}" ]]; then
+        pending_pools+=("$pool_index")
+        pool_is_pending[$pool_index]=true
+      elif [[ "$request" != capacity ]]; then
         continue
       fi
 
-      spent="$(sum_markers "$state_dir/spend")"
-      if (( spent + pool_cpus[pool_index] > cpu_budget )); then
-        log "CPU in flight $spent, burst threshold $cpu_budget; holding $slug at $live"
-        continue
-      fi
+      # Try each denied pool once. A pool that still cannot fit moves to the
+      # back, so repeated capacity changes distribute slots across repositories.
+      pending_count="${#pending_pools[@]}"
+      for (( attempt = 0; attempt < pending_count; attempt++ )); do
+        pending_pool="${pending_pools[0]}"
+        pending_pools=("${pending_pools[@]:1}")
+        slug="${pool_slug[$pending_pool]}"
+        live=$(( pool_warm[pending_pool] + $(count_markers "$state_dir/burst/$slug") ))
+        if (( live >= pool_max[pending_pool] )); then
+          unset 'pool_is_pending[$pending_pool]'
+          continue
+        fi
 
-      # Checked after CPU and never merged with it. A host can have cores to
-      # spare and no memory to back them, which is the case this exists for.
-      spent_memory="$(sum_markers "$state_dir/spend-memory")"
-      if (( spent_memory + pool_memory_gib[pool_index] > memory_budget_gib )); then
-        log "Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g; holding $slug at $live"
-        continue
-      fi
+        spent="$(sum_markers "$state_dir/spend")"
+        if (( spent + pool_cpus[pending_pool] > cpu_budget )); then
+          log "CPU in flight $spent, burst threshold $cpu_budget; holding $slug at $live"
+          pending_pools+=("$pending_pool")
+          continue
+        fi
 
-      # A restart resets this counter while a spared burst container from the
-      # previous generation may still hold one of these names. Skip past it.
-      burst_counter=$(( burst_counter + 1 ))
-      container_name="harlan-desktop-$slug-burst-$burst_counter"
-      while docker container inspect "$container_name" >/dev/null 2>&1; do
+        # Checked after CPU and never merged with it. A host can have cores to
+        # spare and no memory to back them, which is the case this exists for.
+        spent_memory="$(sum_markers "$state_dir/spend-memory")"
+        if (( spent_memory + pool_memory_gib[pending_pool] > memory_budget_gib )); then
+          log "Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g; holding $slug at $live"
+          pending_pools+=("$pending_pool")
+          continue
+        fi
+
+        unset 'pool_is_pending[$pending_pool]'
+
+        # A restart resets this counter while a spared burst container from the
+        # previous generation may still hold one of these names. Skip past it.
         burst_counter=$(( burst_counter + 1 ))
         container_name="harlan-desktop-$slug-burst-$burst_counter"
-      done
-      # Both reservations are written before the fork, so the next request in
-      # this loop already sees this container.
-      printf '%s\n' "${pool_cpus[$pool_index]}" >"$state_dir/burst/$slug/$container_name"
-      reserve "$container_name" "${pool_cpus[$pool_index]}" "${pool_memory_gib[$pool_index]}"
+        while docker container inspect "$container_name" >/dev/null 2>&1; do
+          burst_counter=$(( burst_counter + 1 ))
+          container_name="harlan-desktop-$slug-burst-$burst_counter"
+        done
+        # Both reservations are written before the fork, so the next request in
+        # this loop already sees this container.
+        printf '%s\n' "${pool_cpus[$pending_pool]}" >"$state_dir/burst/$slug/$container_name"
+        reserve "$container_name" "${pool_cpus[$pending_pool]}" "${pool_memory_gib[$pending_pool]}"
 
-      log "Bursting $slug to $(( live + 1 )) of ${pool_max[$pool_index]}"
-      run_burst_slot "$pool_index" "$container_name" &
+        log "Bursting $slug to $(( live + 1 )) of ${pool_max[$pending_pool]}"
+        run_burst_slot "$pending_pool" "$container_name" &
+      done
     done <"$scale_pipe"
     # The read loop ends only if every writer closes the pipe. Reopen it.
   done

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -638,6 +638,26 @@ container_holds_job() {
   docker top "$1" 2>/dev/null | grep --quiet 'Runner\.Worker'
 }
 
+# Stop idle listeners together. Each runner can take Docker's full stop timeout,
+# so serial stops make startup and shutdown scale with the number of pools.
+stop_idle_containers() {
+  local -a container_ids=()
+  local -a stop_pids=()
+  local id stop_pid
+
+  mapfile -t container_ids < <(docker ps --quiet --filter "label=$container_label=true")
+  for id in ${container_ids[@]+"${container_ids[@]}"}; do
+    if ! container_holds_job "$id"; then
+      docker stop --time 20 "$id" >/dev/null 2>&1 &
+      stop_pids+=("$!")
+    fi
+  done
+
+  for stop_pid in ${stop_pids[@]+"${stop_pids[@]}"}; do
+    wait "$stop_pid" || true
+  done
+}
+
 # Stops idle listeners now, then waits for the containers that hold a job.
 #
 # Every container here is ephemeral: it runs at most one job and exits on its
@@ -660,12 +680,7 @@ drain_containers() {
   # never converges.
   [[ -n "$state_dir" && -d "$state_dir" ]] && : >"$state_dir/shutdown"
 
-  mapfile -t container_ids < <(docker ps --quiet --filter "label=$container_label=true")
-  for id in ${container_ids[@]+"${container_ids[@]}"}; do
-    if ! container_holds_job "$id"; then
-      docker stop --time 20 "$id" >/dev/null 2>&1 || true
-    fi
-  done
+  stop_idle_containers
 
   while (( SECONDS < deadline )); do
     waiting=0
@@ -689,15 +704,7 @@ drain_containers() {
 # The startup half of the drain: clear idle leftovers, leave busy ones alone.
 # There is nothing to wait for here, because this process has not started yet.
 drain_leftover_containers() {
-  local -a container_ids=()
-  local id
-
-  mapfile -t container_ids < <(docker ps --quiet --filter "label=$container_label=true")
-  for id in ${container_ids[@]+"${container_ids[@]}"}; do
-    if ! container_holds_job "$id"; then
-      docker stop --time 20 "$id" >/dev/null 2>&1 || true
-    fi
-  done
+  stop_idle_containers
 }
 
 cleanup() {

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -734,7 +734,10 @@ main() {
   # so a restart does not fail the run it was in the middle of. That leaves its
   # memory and CPU unbudgeted for the rest of that one job.
   drain_leftover_containers
-  trap cleanup EXIT INT TERM
+  # A signal requests a normal shell exit. The EXIT trap owns the drain once,
+  # then the process ends instead of returning to its permanent `wait` below.
+  trap cleanup EXIT
+  trap 'exit 0' INT TERM
 
   local pool_index slot_number
   local -A pruned_repositories=()

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 test_root="$(mktemp -d)"
 trap 'rm -rf "$test_root"' EXIT
 
-mkdir -p "$test_root/bin" "$test_root/runtime" "$test_root/calls"
+mkdir -p "$test_root/bin" "$test_root/runtime" "$test_root/calls" "$test_root/credentials"
+printf 'repository-token\n' >"$test_root/credentials/github-harlan-zw-token"
 
 cat >"$test_root/runners.conf" <<'EOF'
 harlan-zw/example|harlan-desktop-ci|1|2|1|1g|2g
@@ -13,6 +14,10 @@ EOF
 
 cat >"$test_root/bin/gh" <<'EOF'
 #!/usr/bin/env bash
+if [[ "${GH_TOKEN:-}" != repository-token ]]; then
+  printf 'Expected the repository credential.\n' >&2
+  exit 1
+fi
 if [[ "$*" == *registration-token* ]]; then
   printf 'test-token\n'
 fi
@@ -91,6 +96,7 @@ set +e
 TEST_CALLS="$test_root/calls" \
 PATH="$test_root/bin:$PATH" \
 XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
 HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+mkdir -p "$test_root/bin" "$test_root/runtime" "$test_root/calls"
+
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|1|2|1|1g|2g
+EOF
+
+cat >"$test_root/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *registration-token* ]]; then
+  printf 'test-token\n'
+fi
+EOF
+
+cat >"$test_root/bin/free" <<'EOF'
+#!/usr/bin/env bash
+printf 'Mem: 32\n'
+EOF
+
+cat >"$test_root/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command_name="${1:-}"
+shift || true
+printf '%s %s\n' "$command_name" "$*" >>"$TEST_CALLS/docker"
+
+case "$command_name" in
+  image|volume|rm|stop)
+    exit 0
+    ;;
+  ps)
+    exit 0
+    ;;
+  container)
+    exit 1
+    ;;
+  top)
+    exit 1
+    ;;
+  run)
+    if [[ " $* " == *' --entrypoint chown '* ]]; then
+      exit 0
+    fi
+
+    name=''
+    previous=''
+    for argument in "$@"; do
+      if [[ "$previous" == --name ]]; then
+        name="$argument"
+        break
+      fi
+      previous="$argument"
+    done
+
+    if [[ "$name" == *-burst-* ]]; then
+      printf '%s\n' "$name" >>"$TEST_CALLS/burst"
+      sleep 5
+      exit 0
+    fi
+
+    attempts_file="$TEST_CALLS/warm-attempts"
+    attempts=0
+    [[ -f "$attempts_file" ]] && read -r attempts <"$attempts_file"
+    attempts=$(( attempts + 1 ))
+    printf '%s\n' "$attempts" >"$attempts_file"
+    if (( attempts == 1 )); then
+      printf 'Running job: first\n'
+      sleep 0.2
+      printf 'Job first completed with result: Succeeded\n'
+      exit 0
+    fi
+
+    sleep 5
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+
+chmod +x "$test_root/bin/gh" "$test_root/bin/free" "$test_root/bin/docker"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=30 \
+timeout 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 124 )); then
+  cat "$test_root/output"
+  printf 'Expected the supervisor test process to reach its timeout.\n' >&2
+  exit 1
+fi
+
+if [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/docker"
+  printf 'Expected released capacity to start the denied burst runner.\n' >&2
+  exit 1
+fi
+
+printf 'Capacity retry passed.\n'

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -101,13 +101,13 @@ HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
 HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=30 \
-timeout 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
 status=$?
 set -e
 
-if (( status != 124 )); then
+if (( status != 0 )); then
   cat "$test_root/output"
-  printf 'Expected the supervisor test process to reach its timeout.\n' >&2
+  printf 'Expected SIGTERM to drain the supervisor and exit cleanly.\n' >&2
   exit 1
 fi
 

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -37,10 +37,28 @@ shift || true
 printf '%s %s\n' "$command_name" "$*" >>"$TEST_CALLS/docker"
 
 case "$command_name" in
-  image|volume|rm|stop)
+  image|volume|rm)
     exit 0
     ;;
+  stop)
+    container_id="${*: -1}"
+    touch "$TEST_CALLS/stop-started-$container_id"
+    for _ in $(seq 1 50); do
+      started_count="$(find "$TEST_CALLS" -name 'stop-started-*' | wc -l)"
+      if (( started_count == 4 )); then
+        printf '%s\n' "$container_id" >>"$TEST_CALLS/stopped"
+        exit 0
+      fi
+      sleep 0.02
+    done
+    printf 'Idle runner stops were serial.\n' >&2
+    exit 1
+    ;;
   ps)
+    if [[ ! -e "$TEST_CALLS/leftovers-listed" ]]; then
+      touch "$TEST_CALLS/leftovers-listed"
+      printf 'leftover-%s\n' 1 2 3 4
+    fi
     exit 0
     ;;
   container)
@@ -115,6 +133,13 @@ if [[ ! -s "$test_root/calls/burst" ]]; then
   cat "$test_root/output"
   cat "$test_root/calls/docker"
   printf 'Expected released capacity to start the denied burst runner.\n' >&2
+  exit 1
+fi
+
+if (( $(wc -l <"$test_root/calls/stopped") != 4 )); then
+  cat "$test_root/output"
+  cat "$test_root/calls/docker"
+  printf 'Expected four idle leftover runners to stop concurrently.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

When a burst request hit the CPU or memory limit, the supervisor discarded it. Free capacity then sat unused until that pool's warm job finished. Denied requests now stay pending and retry when any job releases capacity.

Server installs can use owner-scoped systemd credentials. `SIGTERM` exits after draining instead of returning to the permanent wait. Desktop installs keep their existing `gh` authentication.

Idle runner containers now stop together. On Hogwild, a ten-pool restart reached pool startup in 24 seconds, down from 226 seconds.

NuxtSEO control jobs also lacked a small resource class. The runner config now includes a 2 GiB light pool.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
