### PR TITLE
feat: allow nuxt v5 in module compatibility ranges

### DIFF
--- a/packages/comark-content/package.json
+++ b/packages/comark-content/package.json
@@ -71,7 +71,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vue": ">=3.5.0 <4.0.0"
   },
   "dependencies": {

--- a/packages/comark-content/src/module.ts
+++ b/packages/comark-content/src/module.ts
@@ -78,7 +78,7 @@ export default defineNuxtModule<ModuleOptions>({
     // calling hasNuxtModuleCompatibility() sees no version and fails closed.
     version,
     configKey: 'content',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   moduleDependencies: {
     '@nuxt/ui': {

--- a/packages/nuxt-cf-jobs/package.json
+++ b/packages/nuxt-cf-jobs/package.json
@@ -137,7 +137,7 @@
   },
   "peerDependencies": {
     "@sentry/cloudflare": "catalog:",
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/nuxt-cf-jobs/src/module.ts
+++ b/packages/nuxt-cf-jobs/src/module.ts
@@ -77,7 +77,7 @@ export default defineNuxtModule<ModuleOptions>().with({
   meta: {
     name: '@harlan-zw/nuxt-cf-jobs',
     configKey: 'cfJobs',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     queues: {},

--- a/packages/nuxt-cloudflare/package.json
+++ b/packages/nuxt-cloudflare/package.json
@@ -100,7 +100,7 @@
     "test:contract": "nuxt build tests/fixtures/cache-contract && vitest run tests/cache-contract.nitro.test.ts"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "wrangler": ">=4.120.0 <5.0.0"
   },
   "dependencies": {

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -451,7 +451,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@harlan-zw/nuxt-cloudflare',
     configKey: 'nuxtCloudflare',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     bindingTypes: true,

--- a/packages/nuxt-domain-events/package.json
+++ b/packages/nuxt-domain-events/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@harlan-zw/nuxt-cf-jobs": "workspace:^",
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/nuxt-domain-events/src/module.ts
+++ b/packages/nuxt-domain-events/src/module.ts
@@ -12,7 +12,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@harlan-zw/nuxt-domain-events',
     configKey: 'domainEvents',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     eventsDir: 'server/events',

--- a/packages/nuxt-dx/package.json
+++ b/packages/nuxt-dx/package.json
@@ -52,7 +52,7 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vite": "^8.0.0"
   },
   "dependencies": {

--- a/packages/nuxt-dx/src/module.ts
+++ b/packages/nuxt-dx/src/module.ts
@@ -341,7 +341,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@harlan-zw/nuxt-dx',
     configKey: 'nuxtDx',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     enabled: true,

--- a/packages/nuxt-github-sponsors/package.json
+++ b/packages/nuxt-github-sponsors/package.json
@@ -67,7 +67,7 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0"
+    "nuxt": ">=4.5.0 <6.0.0"
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",

--- a/packages/nuxt-github-sponsors/src/module.ts
+++ b/packages/nuxt-github-sponsors/src/module.ts
@@ -29,7 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@harlan-zw/nuxt-github-sponsors',
     configKey: 'githubSponsors',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   /**
    * `tiers` is absent on purpose. Nuxt merges these defaults with `defu`, which

--- a/packages/nuxt-sentry/package.json
+++ b/packages/nuxt-sentry/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "@sentry/cloudflare": "catalog:",
     "@sentry/nuxt": "catalog:",
-    "nuxt": ">=4.5.0 <5.0.0"
+    "nuxt": ">=4.5.0 <6.0.0"
   },
   "peerDependenciesMeta": {
     "@sentry/cloudflare": {

--- a/packages/nuxt-sentry/src/module.ts
+++ b/packages/nuxt-sentry/src/module.ts
@@ -60,7 +60,7 @@ export default defineNuxtModule<ModuleOptions>({
     // size budget override has to be copied into each app.
     name: MODULE_NAME,
     configKey: 'nuxtSentry',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     enabled: true,

--- a/packages/nuxt-use-query/package.json
+++ b/packages/nuxt-use-query/package.json
@@ -124,7 +124,7 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vite": "^8.0.0",
     "zod": "^4.0.0"
   },

--- a/packages/nuxt-use-query/src/module.ts
+++ b/packages/nuxt-use-query/src/module.ts
@@ -32,7 +32,7 @@ export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: '@harlan-zw/nuxt-use-query',
     configKey: 'nuxtUseQuery',
-    compatibility: { nuxt: '>=4.5.0 <5.0.0' },
+    compatibility: { nuxt: '>=4.5.0 <6.0.0' },
   },
   defaults: {
     contracts: {

--- a/packages/nuxt-wide-events/package.json
+++ b/packages/nuxt-wide-events/package.json
@@ -67,7 +67,7 @@
     "test:pack": "rm -rf .pack && pnpm pack --pack-destination .pack && tar -tf .pack/*.tgz"
   },
   "peerDependencies": {
-    "nuxt": ">=4.5.0 <5.0.0",
+    "nuxt": ">=4.5.0 <6.0.0",
     "vite": "^8.0.0"
   },
   "dependencies": {

--- a/packages/nuxt-wide-events/src/module.ts
+++ b/packages/nuxt-wide-events/src/module.ts
@@ -43,7 +43,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: '@harlan-zw/nuxt-wide-events',
     configKey: 'wideEvents',
     compatibility: {
-      nuxt: '>=4.5.0 <5.0.0',
+      nuxt: '>=4.5.0 <6.0.0',
     },
   },
   defaults: {


### PR DESCRIPTION
Every module declares `nuxt: '>=4.5.0 <5.0.0'`, so Nuxt 5 disables all of them
at install.

I hit this running harlanzw.com on the v5 nightly: five modules were disabled,
and every content-backed route 404'd because `[...all].vue` calls a composable
that the disabled `@harlan-zw/comark-content` never registers. The feed routes
still worked, since they import `queryCollection` from the package directly and
bypass the module.

This widens the range to `<6.0.0` in each module's `meta.compatibility` and in
its `peerDependencies`. The upper bound stays so an unreleased v6 will not
silently match.

Nine packages: comark-content, nuxt-cf-jobs, nuxt-cloudflare, nuxt-domain-events,
nuxt-dx, nuxt-github-sponsors, nuxt-sentry, nuxt-use-query, nuxt-wide-events.

Build, tests and typecheck all pass on Nuxt 4.

Note this only changes what the range permits, it is not evidence the modules
work on v5. Everything verified here ran against Nuxt 4, since that is what the
repo installs. It unblocks v5 testing rather than declaring v5 support.