### PR TITLE
feat(runner): add light job pool

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -35,12 +35,13 @@ and no webhook endpoint is needed.
 
 ## Labels
 
-Two labels serve every repository, so a workflow's `runs-on` is the same string
-everywhere and a site moves between hosted and self-hosted by changing one input.
+Resource labels serve every repository, so a workflow's `runs-on` is the same
+string everywhere and a site moves between hosts by changing one input.
 
 | Label | Use |
 | --- | --- |
 | `harlan-desktop-ci` | Lint, typecheck, test, build. No production secret. |
+| `harlan-desktop-light` | Detection, reports, and API calls. Two CPUs and 2 GB by default. |
 | `harlan-desktop-deploy` | Production deploys. Larger container, one at a time. |
 
 Write them as `runs-on: [self-hosted, linux, x64, harlan-desktop-ci]`. The runner adds

--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -23,6 +23,7 @@
 # GitHub-hosted runners.
 
 harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|2|8|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-light|1|6|2|2g|3g
 harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|1|1|16|20g|24g
 harlan-zw/gscdump.com|harlan-desktop-ci|1|5|6|12g|14g
 harlan-zw/mdream.dev|harlan-desktop-ci|1|3|6|12g|14g


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

NuxtSEO control jobs had to share the 12 or 20 GiB runner classes used by builds and deploys. This adds a 2 GiB, two-CPU class for those jobs.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
