### PR TITLE
fix(ci): skip remote cache on self-hosted runners

### DIFF
--- a/.github/workflows/harlan-desktop-site-ci.yml
+++ b/.github/workflows/harlan-desktop-site-ci.yml
@@ -98,7 +98,10 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: pnpm
+          # Self-hosted containers share one persistent pnpm store. Restoring a
+          # GitHub cache over it adds network work and can stall setup-node.
+          cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') && 'pnpm' || '' }}
+          package-manager-cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') }}
       - run: pnpm install --frozen-lockfile ${{ inputs.install-args }}
       # ESLint does no type-aware linting on these sites, so it never reads a
       # `.nuxt` directory and `prepare-command` is pure cost here.
@@ -116,7 +119,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: pnpm
+          cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') && 'pnpm' || '' }}
+          package-manager-cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') }}
       - run: pnpm install --frozen-lockfile ${{ inputs.install-args }}
       - if: inputs.prepare-command != ''
         run: ${{ inputs.prepare-command }}
@@ -136,7 +140,8 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: pnpm
+          cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') && 'pnpm' || '' }}
+          package-manager-cache: ${{ !contains(fromJSON(inputs.runs-on), 'self-hosted') }}
       - run: pnpm install --frozen-lockfile ${{ inputs.install-args }}
       - if: inputs.prepare-command != ''
         run: ${{ inputs.prepare-command }}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A 301 MB pnpm cache restore for skilld.dev stalled at 97.2% inside setup-node, even though every Hogwild container already mounts the same persistent pnpm store. Self-hosted calls now skip GitHub's package cache; GitHub-hosted calls keep it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).