### PR TITLE
chore(runner): add Hogwild status pools

### DIFF
--- a/infra/github-runner/hogwild-runners.conf
+++ b/infra/github-runner/hogwild-runners.conf
@@ -7,4 +7,6 @@ harlan-zw/gscdump.com|harlan-desktop-ci|0|4|4|8g|10g
 harlan-zw/mdream.dev|harlan-desktop-ci|0|3|4|6g|8g
 harlan-zw/zhead.dev|harlan-desktop-ci|0|3|4|6g|8g
 harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|4|6g|8g
+harlan-zw/hogwild-status|harlan-desktop-ci|0|2|2|2g|3g
+harlan-zw/hogwild-status|harlan-desktop-deploy|0|1|2|2g|3g
 skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|7g|9g

--- a/infra/github-runner/hogwild-runners.conf
+++ b/infra/github-runner/hogwild-runners.conf
@@ -7,6 +7,6 @@ harlan-zw/gscdump.com|harlan-desktop-ci|0|4|4|8g|10g
 harlan-zw/mdream.dev|harlan-desktop-ci|0|3|4|6g|8g
 harlan-zw/zhead.dev|harlan-desktop-ci|0|3|4|6g|8g
 harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|4|6g|8g
-harlan-zw/hogwild-status|harlan-desktop-ci|0|2|2|2g|3g
-harlan-zw/hogwild-status|harlan-desktop-deploy|0|1|2|2g|3g
+harlan-zw/hogwild.harlanzw.com|harlan-desktop-ci|0|2|2|2g|3g
+harlan-zw/hogwild.harlanzw.com|harlan-desktop-deploy|0|1|2|2g|3g
 skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|7g|9g


### PR DESCRIPTION
## Summary

Keep the canonical Hogwild runner inventory aligned with the live host.

## What shipped

- add a small `harlan-zw/hogwild.harlanzw.com` CI pool
- add a separate deploy pool for the same private repo

## Notes

The live host already uses these exact pool limits.

> [!NOTE]
> This PR was written and opened by an AI coding agent.