### PR TITLE
feat(runner): publish private status telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: pnpm dev:prepare
       - run: pnpm lint
       - run: bash infra/github-runner/supervisor.test.sh
+      - run: bash infra/github-runner/publish-status.test.sh
       - run: pnpm typecheck
       - run: pnpm test
       - run: pnpm build

--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -59,6 +59,8 @@ docker build --tag harlan-desktop-github-runner:2.336.0 infra/github-runner
 
 install -Dm755 infra/github-runner/supervisor \
   ~/.local/lib/harlan-desktop-github-runner/supervisor
+install -Dm755 infra/github-runner/publish-status \
+  ~/.local/lib/harlan-desktop-github-runner/publish-status
 install -Dm644 infra/github-runner/runners.conf \
   ~/.config/harlan-desktop-github-runner/runners.conf
 install -Dm644 infra/github-runner/harlan-desktop-github-runner.service \
@@ -99,6 +101,10 @@ gh api repos/harlan-zw/nuxtseo.com/actions/runners \
 journalctl --user --unit harlan-desktop-github-runner.service --follow
 ```
 
+The supervisor publishes `status.json` beside its runtime state every 15 seconds.
+
+The snapshot contains pool demand, active jobs, recent outcomes, and container resources. It contains no credentials or Docker configuration.
+
 Stop local CI before shutting down or doing CPU-heavy local work:
 
 ```bash
@@ -131,6 +137,7 @@ Environment overrides:
 | `HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB` | `36` | Gibibytes of container memory limit in-flight work may hold. Leave the rest for the workstation. |
 | `HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
 | `HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS` | `30` | Time between queued job demand checks. |
+| `HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS` | `15` | Time between read-only status snapshots. |
 | `HARLAN_DESKTOP_RUNNER_DRAIN_TIMEOUT_SECONDS` | `1800` | Time a stop waits for jobs in flight before it kills them. Keep the unit's `TimeoutStopSec` above it. |
 | `HARLAN_DESKTOP_RUNNER_IMAGE` | `harlan-desktop-github-runner:2.336.0` | Image tag. |
 | `HARLAN_DESKTOP_RUNNER_CONFIG` | `/etc/harlan-desktop-github-runner/runners.conf` | Pool table. |
@@ -173,6 +180,7 @@ Install the versioned Hogwild files into their fixed system paths:
 
 ```bash
 sudo install -Dm755 infra/github-runner/supervisor /var/lib/github-runner/bin/supervisor
+sudo install -Dm755 infra/github-runner/publish-status /var/lib/github-runner/bin/publish-status
 sudo install -Dm644 infra/github-runner/hogwild-runners.conf /var/lib/github-runner/config/runners.conf
 sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
 sudo install -Dm644 infra/github-runner/hogwild-logind.conf /etc/systemd/logind.conf.d/runner-safe-power.conf

--- a/infra/github-runner/hogwild-github-runner.service
+++ b/infra/github-runner/hogwild-github-runner.service
@@ -13,7 +13,7 @@ SupplementaryGroups=docker
 StateDirectory=github-runner
 StateDirectoryMode=0700
 RuntimeDirectory=github-runner
-RuntimeDirectoryMode=0700
+RuntimeDirectoryMode=0750
 Environment=HOME=/var/lib/github-runner
 Environment=XDG_RUNTIME_DIR=/run/github-runner
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=/var/lib/github-runner/config/runners.conf

--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly state_dir="${1:?Runner state directory is required}"
+readonly output_file="${2:-$state_dir/status.json}"
+readonly cpu_budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
+readonly memory_budget_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB:-36}"
+readonly fixed_now_epoch_ms="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS:-}"
+readonly container_label='com.harlanzw.desktop-runner'
+
+if [[ ! -r "$state_dir/runners.conf" ]]; then
+  printf 'Runner config is unavailable: %s\n' "$state_dir/runners.conf" >&2
+  exit 1
+fi
+
+for command_name in docker flock jq; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'Required command is unavailable: %s\n' "$command_name" >&2
+    exit 1
+  fi
+done
+
+pool_slug_for() {
+  local repository="$1"
+  local label="${2%%,*}"
+
+  printf '%s-%s' "${repository##*/}" "${label#harlan-desktop-}" \
+    | tr --complement --squeeze-repeats '[:alnum:]-' '-' \
+    | tr '[:upper:]' '[:lower:]'
+}
+
+memory_bytes_for() {
+  local value="$1"
+  local number="${value%[gGmM]}"
+
+  case "$value" in
+    *[gG]) printf '%s' "$(( number * 1024 * 1024 * 1024 ))" ;;
+    *[mM]) printf '%s' "$(( number * 1024 * 1024 ))" ;;
+    *) return 1 ;;
+  esac
+}
+
+readonly temporary_pools="$(mktemp --tmpdir="$state_dir" .status-pools.XXXXXX)"
+readonly temporary_snapshot="$(mktemp --tmpdir="$state_dir" .status.XXXXXX)"
+cleanup() {
+  rm --force "$temporary_pools" "$temporary_snapshot"
+}
+trap cleanup EXIT
+
+metadata="$(docker ps \
+  --filter "label=$container_label=true" \
+  --format '{{json .}}' | jq --compact-output --slurp '
+  def labels:
+    .Labels
+    | split(",")
+    | map(select(contains("=")) | split("=") | { key: .[0], value: (.[1:] | join("=")) })
+    | from_entries;
+  [ .[]
+    | (labels) as $labels
+    | {
+        id: .ID,
+        name: .Names,
+        pool: $labels["com.harlanzw.desktop-runner.pool"],
+        repository: $labels["com.harlanzw.desktop-runner.repository"]
+      }
+    | select(.id != null and .name != null and .pool != null and .repository != null)
+  ]
+')"
+
+mapfile -t container_ids < <(jq --raw-output '.[].id' <<<"$metadata")
+raw_stats=''
+if (( ${#container_ids[@]} > 0 )); then
+  # Keep logical state when one resource sample fails. The snapshot marks each resource unavailable.
+  raw_stats="$(docker stats --no-stream --format '{{json .}}' "${container_ids[@]}" 2>/dev/null || true)"
+fi
+stats="$(jq --compact-output --slurp '
+  def bytes:
+    capture("^(?<amount>[0-9]+(\\.[0-9]+)?)(?<unit>B|kB|KB|MB|GB|TB|KiB|MiB|GiB|TiB)$") as $match
+    | ($match.amount | tonumber)
+      * ({ B: 1, kB: 1000, KB: 1000, MB: 1000000, GB: 1000000000, TB: 1000000000000,
+           KiB: 1024, MiB: 1048576, GiB: 1073741824, TiB: 1099511627776 }[$match.unit]);
+  [ .[] | {
+      cpuPercent: (try (.CPUPerc | rtrimstr("%") | tonumber) catch null),
+      memoryBytes: (try (.MemUsage | split("/")[0] | gsub(" "; "") | bytes) catch null),
+      name: .Name,
+      networkRxBytes: (try (.NetIO | split("/")[0] | gsub(" "; "") | bytes) catch null),
+      networkTxBytes: (try (.NetIO | split("/")[1] | gsub(" "; "") | bytes) catch null),
+      tasks: (try (.PIDs | tonumber) catch null)
+    }
+  ]
+' <<<"$raw_stats")"
+
+jobs="$({
+  for job_file in "$state_dir/jobs"/*.json; do
+    [[ -f "$job_file" ]] || continue
+    container_name="${job_file##*/}"
+    container_name="${container_name%.json}"
+    # A partial event file is ignored until the next snapshot.
+    jq --compact-output --arg container "$container_name" \
+      'select(.name | type == "string") | select(.startedAt | type == "number") | . + { container: $container }' \
+      "$job_file" 2>/dev/null || true
+  done
+} | jq --compact-output --slurp '.')"
+
+recent_jobs='[]'
+if [[ -r "$state_dir/recent/jobs.ndjson" ]]; then
+  recent_jobs="$(flock --shared "$state_dir/recent/jobs.lock" \
+    tail --lines 40 "$state_dir/recent/jobs.ndjson" \
+    | jq --compact-output --slurp '[.[] | select(type == "object")] | .[-20:]')"
+fi
+
+while IFS='|' read -r repository labels warm maximum cpus memory memory_swap; do
+  repository="${repository#"${repository%%[![:space:]]*}"}"
+  [[ -z "$repository" || "$repository" == \#* || -z "$memory_swap" ]] && continue
+  slug="$(pool_slug_for "$repository" "$labels")"
+  if ! memory_bytes="$(memory_bytes_for "$memory")"; then
+    printf 'Pool memory has no supported suffix: %s\n' "$memory" >&2
+    exit 1
+  fi
+  queued='null'
+  if [[ -r "$state_dir/queued/$slug" ]]; then
+    read -r queued_value <"$state_dir/queued/$slug" || queued_value=''
+    [[ "$queued_value" =~ ^[0-9]+$ ]] && queued="$queued_value"
+  fi
+  jq --compact-output --null-input \
+    --arg name "$slug" \
+    --arg repository "$repository" \
+    --argjson cpuPerRunner "$cpus" \
+    --argjson maximum "$maximum" \
+    --argjson memoryPerRunnerBytes "$memory_bytes" \
+    --argjson queued "$queued" \
+    '{
+      cpuPerRunner: $cpuPerRunner,
+      maximum: $maximum,
+      memoryPerRunnerBytes: $memoryPerRunnerBytes,
+      name: $name,
+      queued: $queued,
+      repository: $repository
+    }' >>"$temporary_pools"
+done <"$state_dir/runners.conf"
+pools="$(jq --compact-output --slurp '.' "$temporary_pools")"
+
+runners="$(jq --compact-output --null-input \
+  --argjson jobs "$jobs" \
+  --argjson metadata "$metadata" \
+  --argjson stats "$stats" '
+  $metadata | map(
+    . as $container
+    | ($jobs | map(select(.container == $container.name)) | first) as $job
+    | ($stats | map(select(.name == $container.name)) | first) as $resources
+    | {
+        activity: (if $job == null then "Starting" else "Running" end),
+        cpuPercent: ($resources.cpuPercent // null),
+        memoryBytes: ($resources.memoryBytes // null),
+        name: $container.name,
+        networkRxBytes: ($resources.networkRxBytes // null),
+        networkTxBytes: ($resources.networkTxBytes // null),
+        pool: $container.pool,
+        repository: $container.repository,
+        tasks: ($resources.tasks // null)
+      }
+      + if $job == null then {} else { job: { name: $job.name, startedAt: $job.startedAt } } end
+  )
+')"
+
+pools="$(jq --compact-output --null-input \
+  --argjson pools "$pools" \
+  --argjson runners "$runners" '
+  $pools | map(
+    . as $pool
+    | . + {
+        live: ([ $runners[] | select(.pool == $pool.name) ] | length),
+        running: ([ $runners[] | select(.pool == $pool.name and .activity == "Running") ] | length)
+      }
+  )
+')"
+
+if [[ -n "$fixed_now_epoch_ms" ]]; then
+  updated_at="$fixed_now_epoch_ms"
+else
+  updated_at="$(date +%s%3N)"
+fi
+
+jq --null-input \
+  --argjson cpuBudget "$cpu_budget" \
+  --argjson memoryBudgetBytes "$(( memory_budget_gib * 1024 * 1024 * 1024 ))" \
+  --argjson pools "$pools" \
+  --argjson recentJobs "$recent_jobs" \
+  --argjson runners "$runners" \
+  --argjson updatedAt "$updated_at" \
+  '{
+    version: 1,
+    updatedAt: $updatedAt,
+    budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes },
+    pools: $pools,
+    runners: $runners,
+    recentJobs: $recentJobs
+  }' >"$temporary_snapshot"
+
+chmod 0640 "$temporary_snapshot"
+mv --force "$temporary_snapshot" "$output_file"

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+mkdir -p "$test_root/bin" "$test_root/state/jobs" "$test_root/state/queued" \
+  "$test_root/state/recent" "$test_root/state/spend" "$test_root/state/spend-memory"
+
+cat >"$test_root/state/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|0|4|4|8g|10g
+EOF
+printf '2\n' >"$test_root/state/queued/example-ci"
+printf '4\n' >"$test_root/state/spend/harlan-desktop-example-ci-burst-1"
+printf '8\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
+cat >"$test_root/state/jobs/harlan-desktop-example-ci-burst-1.json" <<'EOF'
+{"name":"test & build","startedAt":1787930400000}
+EOF
+cat >"$test_root/state/recent/jobs.ndjson" <<'EOF'
+{"completedAt":1787930300000,"name":"lint","outcome":"Succeeded","pool":"example-ci","repository":"harlan-zw/example","startedAt":1787930200000}
+EOF
+
+cat >"$test_root/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  ps)
+    [[ "${TEST_DOCKER_FAIL:-}" == ps ]] && exit 1
+    printf '%s\n' '{"ID":"abc123","Labels":"com.harlanzw.desktop-runner.pool=example-ci,com.harlanzw.desktop-runner.repository=harlan-zw/example,com.harlanzw.desktop-runner=true","Names":"harlan-desktop-example-ci-burst-1"}'
+    ;;
+  stats)
+    printf '%s\n' '{"CPUPerc":"83.40%","ID":"abc123","MemUsage":"620MiB / 8GiB","Name":"harlan-desktop-example-ci-burst-1","NetIO":"879MB / 7.64MB","PIDs":"47"}'
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$test_root/bin/docker"
+
+PATH="$test_root/bin:$PATH" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
+./infra/github-runner/publish-status "$test_root/state"
+
+snapshot="$test_root/state/status.json"
+jq --exit-status '
+  .version == 1
+  and .updatedAt == 1787930500000
+  and .budgets == { cpu: 20, memoryBytes: 25769803776 }
+  and .pools == [{
+    cpuPerRunner: 4,
+    live: 1,
+    maximum: 4,
+    memoryPerRunnerBytes: 8589934592,
+    name: "example-ci",
+    queued: 2,
+    repository: "harlan-zw/example",
+    running: 1
+  }]
+  and .runners == [{
+    activity: "Running",
+    cpuPercent: 83.4,
+    job: { name: "test & build", startedAt: 1787930400000 },
+    memoryBytes: 650117120,
+    name: "harlan-desktop-example-ci-burst-1",
+    networkRxBytes: 879000000,
+    networkTxBytes: 7640000,
+    pool: "example-ci",
+    repository: "harlan-zw/example",
+    tasks: 47
+  }]
+  and (.recentJobs | length) == 1
+' "$snapshot" >/dev/null
+
+if [[ "$(stat -c '%a' "$snapshot")" != 640 ]]; then
+  printf 'Expected the runner snapshot to be group-readable only.\n' >&2
+  exit 1
+fi
+
+snapshot_checksum="$(sha256sum "$snapshot")"
+set +e
+TEST_DOCKER_FAIL=ps \
+PATH="$test_root/bin:$PATH" \
+./infra/github-runner/publish-status "$test_root/state" >/dev/null 2>&1
+failure_status=$?
+set -e
+if (( failure_status == 0 )) || [[ "$(sha256sum "$snapshot")" != "$snapshot_checksum" ]]; then
+  printf 'Expected Docker failure to preserve the previous runner snapshot.\n' >&2
+  exit 1
+fi
+
+printf 'Runner status snapshot passed.\n'

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -76,6 +76,9 @@ readonly demand_poll_seconds="${HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS:-30}"
 # neither run nor be cancelled, so they must not keep creating runner demand.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"
 readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
+readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
+readonly status_output_override="${HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT:-}"
+readonly status_publisher="${HARLAN_DESKTOP_RUNNER_STATUS_PUBLISHER:-$(dirname "${BASH_SOURCE[0]}")/publish-status}"
 readonly container_label='com.harlanzw.desktop-runner'
 # One pnpm store shared by every container, so an ephemeral job resolves packages
 # from local disk instead of refetching them.
@@ -294,6 +297,16 @@ count_idle_burst() {
   printf '%s' "$total"
 }
 
+publish_queue_count() {
+  local pool_index="$1"
+  local queued="$2"
+  local target="$state_dir/queued/${pool_slug[$pool_index]}"
+  local temporary="$target.$$"
+
+  printf '%s\n' "$queued" >"$temporary"
+  mv --force "$temporary" "$target"
+}
+
 queued_job_labels_for_repository() {
   local repository="$1"
   local listing jobs run_id run_status created_at created_epoch
@@ -376,10 +389,12 @@ run_demand_poller() {
         fi
       fi
       if [[ "${repository_result[$repository]}" == unavailable ]]; then
+        rm --force "$state_dir/queued/${pool_slug[$pool_index]}"
         log "Queued job demand is unavailable for ${pool_slug[$pool_index]}"
         continue
       fi
       queued="$(queued_jobs_for_pool "$pool_index" "${repository_jobs[$repository]}")"
+      publish_queue_count "$pool_index" "$queued"
       idle="$(count_idle_burst "$pool_index")"
       deficit=$(( queued - idle ))
       for (( request = 0; request < deficit; request++ )); do
@@ -387,6 +402,69 @@ run_demand_poller() {
       done
     done
     sleep "$demand_poll_seconds"
+  done
+}
+
+record_running_job() {
+  local container_name="$1"
+  local job_name="$2"
+  local target="$state_dir/jobs/$container_name.json"
+  local temporary="$target.$$"
+
+  # Runner output is a boundary. Keep visible text bounded before JSON encoding.
+  job_name="${job_name:0:240}"
+  jq --compact-output --null-input \
+    --arg name "$job_name" \
+    --argjson startedAt "$(( $(date +%s) * 1000 ))" \
+    '{ name: $name, startedAt: $startedAt }' >"$temporary"
+  mv --force "$temporary" "$target"
+}
+
+record_completed_job() {
+  local container_name="$1"
+  local repository="$2"
+  local pool="$3"
+  local reported_outcome="$4"
+  local job_file="$state_dir/jobs/$container_name.json"
+  local outcome event recent_file="$state_dir/recent/jobs.ndjson"
+
+  [[ -r "$job_file" ]] || return 0
+  case "$reported_outcome" in
+    Succeeded) outcome='Succeeded' ;;
+    Failed) outcome='Failed' ;;
+    Canceled|Cancelled) outcome='Cancelled' ;;
+    *) outcome='Unknown' ;;
+  esac
+
+  event="$(jq --compact-output \
+    --arg repository "$repository" \
+    --arg pool "$pool" \
+    --arg outcome "$outcome" \
+    --argjson completedAt "$(( $(date +%s) * 1000 ))" \
+    '. + { completedAt: $completedAt, outcome: $outcome, pool: $pool, repository: $repository }' \
+    "$job_file")"
+
+  (
+    flock --exclusive 9
+    printf '%s\n' "$event" >>"$recent_file"
+    tail --lines 40 "$recent_file" >"$recent_file.$$"
+    mv --force "$recent_file.$$" "$recent_file"
+  ) 9>"$state_dir/recent/jobs.lock"
+  rm --force "$job_file"
+}
+
+run_status_publisher() {
+  local output_file="${status_output_override:-$state_dir/status.json}"
+
+  if [[ ! -x "$status_publisher" ]]; then
+    log "Runner status publisher is unavailable: $status_publisher"
+    return 0
+  fi
+
+  while [[ ! -f "$state_dir/shutdown" ]]; do
+    "$status_publisher" "$state_dir" "$output_file" \
+      || log 'Runner status snapshot failed'
+    sleep "$status_interval_seconds"
   done
 }
 
@@ -461,6 +539,7 @@ run_container() {
   local registration_token
   local runner_name
   local line
+  local job_name reported_outcome
   local -a pipe_status=()
 
   if ! registration_token="$(github_api \
@@ -508,17 +587,27 @@ run_container() {
         # demand signal in this system.
         if [[ "$line" == *'Running job:'* && ! -f "$state_dir/claimed/$container_name" ]]; then
           : >"$state_dir/claimed/$container_name"
+          job_name="${line#*Running job:}"
+          job_name="${job_name#"${job_name%%[![:space:]]*}"}"
+          record_running_job "$container_name" "$job_name"
           # A burst container reserved capacity before it registered.
           if [[ "$slot_kind" == warm ]]; then
             reserve "$container_name" "${pool_cpus[$pool_index]}" "${pool_memory_gib[$pool_index]}"
             printf 'spawn %s\n' "$pool_index" >"$scale_pipe"
           fi
         fi
+        if [[ "$line" == *' completed with result: '* ]]; then
+          reported_outcome="${line##* completed with result: }"
+          record_completed_job "$container_name" "$repository" "${pool_slug[$pool_index]}" "$reported_outcome"
+        fi
       done
   pipe_status=("${PIPESTATUS[@]}")
   set -e
 
   rm --force "$state_dir/claimed/$container_name"
+  if [[ -f "$state_dir/jobs/$container_name.json" ]]; then
+    record_completed_job "$container_name" "$repository" "${pool_slug[$pool_index]}" Unknown
+  fi
   [[ "$slot_kind" == warm ]] && release "$container_name"
 
   # Index 1 is `docker run`. Index 0 is the token `printf`, which cannot fail in
@@ -832,6 +921,8 @@ cleanup() {
 main() {
   require_command docker
   require_command gh
+  require_command jq
+  require_command flock
 
   if ! docker image inspect "$runner_image" >/dev/null 2>&1; then
     log "Runner image is unavailable; build $runner_image from infra/github-runner."
@@ -846,7 +937,8 @@ main() {
   # read from the real reservations.
   state_dir="$state_root"
   rm --recursive --force "$state_dir"
-  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline"
+  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline" "$state_dir/jobs" "$state_dir/queued" "$state_dir/recent"
+  chmod 0750 "$state_dir"
   scale_pipe="$state_dir/scale"
   cp "$config_file" "$published_config"
   mkfifo --mode 0600 "$scale_pipe"
@@ -932,6 +1024,7 @@ main() {
   exec {scale_pipe_holder}>"$scale_pipe"
 
   run_demand_poller &
+  run_status_publisher &
 
   for pool_index in "${!pool_repository[@]}"; do
     log "Pool ${pool_slug[$pool_index]}: ${pool_repository[$pool_index]} warm ${pool_warm[$pool_index]} max ${pool_max[$pool_index]} cpus ${pool_cpus[$pool_index]} memory ${pool_memory[$pool_index]}"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -141,6 +141,8 @@ HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
 HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=30 \
+HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.05 \
+HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
 timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
 status=$?
 set -e
@@ -165,6 +167,12 @@ if (( $(wc -l <"$test_root/calls/stopped") != 4 )); then
   exit 1
 fi
 
+if ! jq --exit-status '.recentJobs | any(.name == "first" and .outcome == "Succeeded")' "$test_root/calls/status.json" >/dev/null; then
+  cat "$test_root/calls/status.json"
+  printf 'Expected completed jobs in the published runner status.\n' >&2
+  exit 1
+fi
+
 printf 'Capacity retry passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"
@@ -183,6 +191,8 @@ HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
 HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.05 \
+HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
 HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
 timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
 status=$?
@@ -198,6 +208,12 @@ if [[ ! -s "$test_root/calls/burst" ]]; then
   cat "$test_root/output"
   cat "$test_root/calls/docker"
   printf 'Expected a queued job to start a zero-warm pool.\n' >&2
+  exit 1
+fi
+
+if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memoryPerRunnerBytes: 1073741824, name: "example-ci", queued: 1, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
+  cat "$test_root/calls/status.json"
+  printf 'Expected queued demand in the published runner status.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Showing runner data currently requires Docker access. That group is root-equivalent on Hogwild.

The supervisor now publishes queue, job, outcome, and container resource data through a group-readable snapshot. It contains no credentials or Docker configuration.

### 📝 Migration

```bash
sudo install -Dm755 infra/github-runner/publish-status /var/lib/github-runner/bin/publish-status
sudo install -Dm755 infra/github-runner/supervisor /var/lib/github-runner/bin/supervisor
sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
sudo systemctl daemon-reload
sudo systemctl restart hogwild-github-runner.service
```

The restart drains active jobs before replacing runners.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.