### PR TITLE
fix(runner): publish portable timestamps

### DIFF
--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -179,7 +179,7 @@ pools="$(jq --compact-output --null-input \
 if [[ -n "$fixed_now_epoch_ms" ]]; then
   updated_at="$fixed_now_epoch_ms"
 else
-  updated_at="$(date +%s%3N)"
+  updated_at="$(( $(date +%s) * 1000 ))"
 fi
 
 jq --null-input \

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -40,6 +40,19 @@ esac
 EOF
 chmod +x "$test_root/bin/docker"
 
+cat >"$test_root/bin/date" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  +%s) printf '1787930500\n' ;;
+  +%s.%N) printf '1787930500.123456789\n' ;;
+  +%s%3N) printf '1787930500123456789\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$test_root/bin/date"
+
 PATH="$test_root/bin:$PATH" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24 \
@@ -78,6 +91,13 @@ jq --exit-status '
 
 if [[ "$(stat -c '%a' "$snapshot")" != 640 ]]; then
   printf 'Expected the runner snapshot to be group-readable only.\n' >&2
+  exit 1
+fi
+
+PATH="$test_root/bin:$PATH" \
+./infra/github-runner/publish-status "$test_root/state"
+if ! jq --exit-status '.updatedAt == 1787930500000' "$snapshot" >/dev/null; then
+  printf 'Expected a portable millisecond timestamp.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hogwild uses uutils `date`. Its `%3N` output kept all nine nanosecond digits, so the private dashboard rejected every runner snapshot.

The publisher now derives milliseconds from portable epoch seconds.

### 📝 Migration

```bash
sudo install -Dm755 infra/github-runner/publish-status /var/lib/github-runner/bin/publish-status
```

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.