### PR TITLE
fix(runner): preserve GitHub API budget

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -136,7 +136,7 @@ Environment overrides:
 | `HARLAN_DESKTOP_RUNNER_CPU_BUDGET` | `32` | Threshold above which bursts are held. Not a cap; see below. |
 | `HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB` | `36` | Gibibytes of container memory limit in-flight work may hold. Leave the rest for the workstation. |
 | `HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
-| `HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS` | `30` | Time between queued job demand checks. |
+| `HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS` | `60` | Time between queued job demand checks. Values below 60 use 60 to protect the GitHub API budget. |
 | `HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS` | `15` | Time between read-only status snapshots. |
 | `HARLAN_DESKTOP_RUNNER_DRAIN_TIMEOUT_SECONDS` | `1800` | Time a stop waits for jobs in flight before it kills them. Keep the unit's `TimeoutStopSec` above it. |
 | `HARLAN_DESKTOP_RUNNER_IMAGE` | `harlan-desktop-github-runner:2.336.0` | Image tag. |

--- a/infra/github-runner/harlan-desktop-github-runner.service
+++ b/infra/github-runner/harlan-desktop-github-runner.service
@@ -13,7 +13,7 @@ Environment=HARLAN_DESKTOP_RUNNER_CONFIG=%h/.config/harlan-desktop-github-runner
 Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=72
 # Leave 12 GiB of the 60 GiB host outside runner container limits.
 Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=48
-Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=15
+Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=60
 ExecStart=%h/.local/lib/harlan-desktop-github-runner/supervisor
 Restart=always
 RestartSec=10

--- a/infra/github-runner/hogwild-github-runner.service
+++ b/infra/github-runner/hogwild-github-runner.service
@@ -19,7 +19,7 @@ Environment=XDG_RUNTIME_DIR=/run/github-runner
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=/var/lib/github-runner/config/runners.conf
 Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20
 Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24
-Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=15
+Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=60
 Environment=HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=90
 LoadCredentialEncrypted=github-harlan-zw-token:/etc/credstore.encrypted/hogwild-github-harlan-zw-token
 LoadCredentialEncrypted=github-skilld-dev-token:/etc/credstore.encrypted/hogwild-github-skilld-dev-token

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -71,7 +71,11 @@ readonly drain_timeout_seconds="${HARLAN_DESKTOP_RUNNER_DRAIN_TIMEOUT_SECONDS:-1
 # How often the offline registrations are swept. A delete needs two sweeps in a
 # row, so a dead registration clears after twice this long at worst.
 readonly prune_interval_seconds="${HARLAN_DESKTOP_RUNNER_PRUNE_INTERVAL_SECONDS:-300}"
-readonly demand_poll_seconds="${HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS:-30}"
+readonly configured_demand_poll_seconds="${HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS:-60}"
+# Each repository needs at least two API reads per scan. Faster scans exhaust
+# one owner's shared GitHub API budget before its hourly reset.
+readonly minimum_demand_poll_seconds=60
+readonly demand_poll_seconds=$(( configured_demand_poll_seconds > minimum_demand_poll_seconds ? configured_demand_poll_seconds : minimum_demand_poll_seconds ))
 # GitHub can retain corrupt queued jobs after their pull request closes. They can
 # neither run nor be cancelled, so they must not keep creating runner demand.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -217,6 +217,13 @@ if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memory
   exit 1
 fi
 
+queued_poll_count="$(rg --fixed-strings --count 'actions/runs?status=queued' "$test_root/calls/gh")"
+if (( queued_poll_count != 1 )); then
+  cat "$test_root/calls/gh"
+  printf 'Expected demand polling to preserve the GitHub API budget.\n' >&2
+  exit 1
+fi
+
 printf 'Queued job demand passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -217,7 +217,7 @@ if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memory
   exit 1
 fi
 
-queued_poll_count="$(rg --fixed-strings --count 'actions/runs?status=queued' "$test_root/calls/gh")"
+queued_poll_count="$(grep -F -c 'actions/runs?status=queued' "$test_root/calls/gh")"
 if (( queued_poll_count != 1 )); then
   cat "$test_root/calls/gh"
   printf 'Expected demand polling to preserve the GitHub API budget.\n' >&2


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The 15 second demand scan exhausted one owner token across seven repositories.

Demand scans now use a 60 second minimum. This preserves prompt zero-warm admission without losing GitHub API access.

> 🤖 AI disclosure: [Codex](https://openai.com/codex/) modified this description.
