### PR TITLE
chore(runner): add gh and zstd to job image

### DIFF
--- a/infra/github-runner/Dockerfile
+++ b/infra/github-runner/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
     ca-certificates \
     curl \
     git \
+    gh \
     jq \
     libicu74 \
     libssl3t64 \
@@ -18,6 +19,7 @@ RUN apt-get update \
     python3 \
     unzip \
     xz-utils \
+    zstd \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --home-dir /home/runner --shell /bin/bash runner


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `harlan-desktop-deploy` image had no `gh`, so workflow shell steps that call GitHub failed with exit 127. It also lacked `zstd`, which made `actions/cache` fall back to gzip.

This adds both tools. In a Docker benchmark over the image's 676 MB runner tree, gzip decompression took 2.52 seconds and zstd took 0.37 seconds. The archives were 226 MB and 201 MB, respectively.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.