### PR TITLE
fix(runner)!: schedule jobs by memory reservation

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -126,15 +126,19 @@ service drains the queue.
 
 ## Tuning
 
-`runners.conf` carries `warm`, `max`, and `cpus` per pool. Use zero warm runners
-to make every job pass admission before runner registration.
+`runners.conf` carries CPU, memory reservation, memory limit, and pool size.
+Use zero warm runners to make every job pass admission before registration.
+
+The memory reservation represents expected peak use. It spends the host memory
+budget and becomes Docker's soft limit. The memory limit is a higher hard cap.
 
 Environment overrides:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `HARLAN_DESKTOP_RUNNER_CPU_BUDGET` | `32` | Threshold above which bursts are held. Not a cap; see below. |
-| `HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB` | `36` | Gibibytes of container memory limit in-flight work may hold. Leave the rest for the workstation. |
+| `HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB` | `36` | Gibibytes of expected peak memory that running jobs may reserve. |
+| `HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB` | `8` | Available host memory that admission must leave after one new reservation. |
 | `HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS` | `300` | Time a burst container may sit unclaimed before it is retired. |
 | `HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS` | `60` | Time between queued job demand checks. Values below 60 use 60 to protect the GitHub API budget. |
 | `HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS` | `15` | Time between read-only status snapshots. |
@@ -152,17 +156,17 @@ CPU oversubscribes safely. A container over its quota is throttled and its job
 takes longer. Memory does not behave that way, and the difference has already
 cost a production deploy.
 
-`--memory` is a limit, not a reservation. Docker admits containers whose limits
-sum well past physical RAM, and nothing reserves anything. On this host that
-reached 164g of limits committed against 60g of RAM. The kernel resolves the
-overcommit by killing the largest resident process, which is always a build, so
-the symptom is a deploy dying at `nuxt build` with exit 129 while comfortably
-inside its own 32g limit. It was not killed for exceeding its cap. It was the
-biggest thing alive when the CI containers admitted beside it ran the host out.
+`--memory` is a hard limit. Charging every job for that limit left CPUs idle.
+Charging current use alone can admit several jobs before their builds grow.
+
+Each pool now sets a reservation and a hard limit. The scheduler charges the
+reservation before registration. Deploy reservations stay near measured peaks.
+Flat CI reservations stay below their abnormal hard limit.
 
 Every demand-started runner spends CPU and memory before registration.
 
-A runner starts only when both reservations fit.
+A runner starts only when both reservations fit. It must also leave the host
+memory headroom available at admission time.
 
 Warm jobs can claim before admission.
 

--- a/infra/github-runner/harlan-desktop-runner
+++ b/infra/github-runner/harlan-desktop-runner
@@ -101,8 +101,8 @@ pool_section() {
 
   printf '%-26s %5s %6s %5s  %s\n' 'POOL' 'WARM' 'BURST' 'BUSY' 'REPOSITORY'
 
-  local repository labels warm max cpus memory memory_swap
-  while IFS='|' read -r repository labels warm max cpus memory memory_swap; do
+  local repository labels warm max cpus memory_reservation memory_limit memory_swap
+  while IFS='|' read -r repository labels warm max cpus memory_reservation memory_limit memory_swap; do
     repository="${repository#"${repository%%[![:space:]]*}"}"
     [[ -z "$repository" || "$repository" == \#* || -z "$memory_swap" ]] && continue
 
@@ -128,6 +128,13 @@ pool_section() {
   # from GitHub with no say from the supervisor.
   printf '\nCPU in flight  %s, burst threshold %s' "$spent" "$budget"
   (( spent >= budget )) && printf '  %sbursts held%s' "$yellow" "$reset"
+  printf '\n'
+
+  local spent_memory memory_budget
+  spent_memory="$(sum_files "$state_root/spend-memory")"
+  memory_budget="${HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB:-36}"
+  printf 'Memory reserved %sg, budget %sg' "$spent_memory" "$memory_budget"
+  (( spent_memory >= memory_budget )) && printf '  %sbursts held%s' "$yellow" "$reset"
   printf '\n'
 
   local containers

--- a/infra/github-runner/hogwild-github-runner.service
+++ b/infra/github-runner/hogwild-github-runner.service
@@ -19,6 +19,7 @@ Environment=XDG_RUNTIME_DIR=/run/github-runner
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=/var/lib/github-runner/config/runners.conf
 Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20
 Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24
+Environment=HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=6
 Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=60
 Environment=HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=90
 LoadCredentialEncrypted=github-harlan-zw-token:/etc/credstore.encrypted/hogwild-github-harlan-zw-token

--- a/infra/github-runner/hogwild-runners.conf
+++ b/infra/github-runner/hogwild-runners.conf
@@ -1,12 +1,21 @@
-# repository | labels | warm | max | cpus | memory | memory-swap
+# repository | labels | warm | max | cpus | memory-reservation | memory-limit | memory-swap
 
-harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|0|1|12|16g|20g
-harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|0|4|8|9g|11g
-harlan-zw/nuxtseo.com|harlan-desktop-light|0|6|2|2g|3g
-harlan-zw/gscdump.com|harlan-desktop-ci|0|4|4|8g|10g
-harlan-zw/mdream.dev|harlan-desktop-ci|0|3|4|6g|8g
-harlan-zw/zhead.dev|harlan-desktop-ci|0|3|4|6g|8g
-harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|4|6g|8g
-harlan-zw/hogwild.harlanzw.com|harlan-desktop-ci|0|2|2|2g|3g
-harlan-zw/hogwild.harlanzw.com|harlan-desktop-deploy|0|1|2|2g|3g
-skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|7g|9g
+harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|0|1|12|13g|16g|20g
+harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|0|4|8|5g|9g|11g
+harlan-zw/nuxtseo.com|harlan-desktop-light|0|6|2|1g|2g|3g
+harlan-zw/gscdump.com|harlan-desktop-ci|0|4|4|4g|8g|10g
+harlan-zw/mdream.dev|harlan-desktop-ci|0|3|4|4g|8g|10g
+harlan-zw/zhead.dev|harlan-desktop-ci|0|3|4|3g|6g|8g
+harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|4|3g|6g|8g
+harlan-zw/hogwild.harlanzw.com|harlan-desktop-ci|0|2|2|1g|2g|3g
+harlan-zw/hogwild.harlanzw.com|harlan-desktop-deploy|0|1|2|1g|2g|3g
+skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|4g|7g|9g
+skilld-dev/skilld.dev|harlan-desktop-deploy|0|1|4|5g|7g|9g
+
+harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|2g|4g|5g
+harlan-zw/gscdump|harlan-desktop-ci|0|2|4|3g|5g|6g
+harlan-zw/massivemonster.com|harlan-desktop-ci|0|2|8|3g|6g|8g
+harlan-zw/nuxt-audit|harlan-desktop-ci|0|2|4|2g|4g|5g
+harlan-zw/ripast|harlan-desktop-ci|0|2|2|1g|2g|3g
+harlan-zw/nuxt-ai-kit|harlan-desktop-ci|0|2|4|3g|5g|6g
+harlan-zw/gscdump.com|harlan-desktop-deploy|0|1|8|10g|12g|14g

--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -6,6 +6,7 @@ readonly state_dir="${1:?Runner state directory is required}"
 readonly output_file="${2:-$state_dir/status.json}"
 readonly cpu_budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
 readonly memory_budget_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB:-36}"
+readonly memory_headroom_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB:-8}"
 readonly fixed_now_epoch_ms="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS:-}"
 readonly container_label='com.harlanzw.desktop-runner'
 
@@ -110,12 +111,16 @@ if [[ -r "$state_dir/recent/jobs.ndjson" ]]; then
     | jq --compact-output --slurp '[.[] | select(type == "object")] | .[-20:]')"
 fi
 
-while IFS='|' read -r repository labels warm maximum cpus memory memory_swap; do
+while IFS='|' read -r repository labels warm maximum cpus memory_reservation memory_limit memory_swap; do
   repository="${repository#"${repository%%[![:space:]]*}"}"
   [[ -z "$repository" || "$repository" == \#* || -z "$memory_swap" ]] && continue
   slug="$(pool_slug_for "$repository" "$labels")"
-  if ! memory_bytes="$(memory_bytes_for "$memory")"; then
-    printf 'Pool memory has no supported suffix: %s\n' "$memory" >&2
+  if ! memory_reservation_bytes="$(memory_bytes_for "$memory_reservation")"; then
+    printf 'Pool memory reservation has no supported suffix: %s\n' "$memory_reservation" >&2
+    exit 1
+  fi
+  if ! memory_limit_bytes="$(memory_bytes_for "$memory_limit")"; then
+    printf 'Pool memory limit has no supported suffix: %s\n' "$memory_limit" >&2
     exit 1
   fi
   queued='null'
@@ -128,12 +133,14 @@ while IFS='|' read -r repository labels warm maximum cpus memory memory_swap; do
     --arg repository "$repository" \
     --argjson cpuPerRunner "$cpus" \
     --argjson maximum "$maximum" \
-    --argjson memoryPerRunnerBytes "$memory_bytes" \
+    --argjson memoryLimitBytes "$memory_limit_bytes" \
+    --argjson memoryReservationBytes "$memory_reservation_bytes" \
     --argjson queued "$queued" \
     '{
       cpuPerRunner: $cpuPerRunner,
       maximum: $maximum,
-      memoryPerRunnerBytes: $memoryPerRunnerBytes,
+      memoryLimitBytes: $memoryLimitBytes,
+      memoryReservationBytes: $memoryReservationBytes,
       name: $name,
       queued: $queued,
       repository: $repository
@@ -185,14 +192,15 @@ fi
 jq --null-input \
   --argjson cpuBudget "$cpu_budget" \
   --argjson memoryBudgetBytes "$(( memory_budget_gib * 1024 * 1024 * 1024 ))" \
+  --argjson memoryHeadroomBytes "$(( memory_headroom_gib * 1024 * 1024 * 1024 ))" \
   --argjson pools "$pools" \
   --argjson recentJobs "$recent_jobs" \
   --argjson runners "$runners" \
   --argjson updatedAt "$updated_at" \
   '{
-    version: 1,
+    version: 2,
     updatedAt: $updatedAt,
-    budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes },
+    budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes, memoryHeadroomBytes: $memoryHeadroomBytes },
     pools: $pools,
     runners: $runners,
     recentJobs: $recentJobs

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -9,11 +9,11 @@ mkdir -p "$test_root/bin" "$test_root/state/jobs" "$test_root/state/queued" \
   "$test_root/state/recent" "$test_root/state/spend" "$test_root/state/spend-memory"
 
 cat >"$test_root/state/runners.conf" <<'EOF'
-harlan-zw/example|harlan-desktop-ci|0|4|4|8g|10g
+harlan-zw/example|harlan-desktop-ci|0|4|4|4g|8g|10g
 EOF
 printf '2\n' >"$test_root/state/queued/example-ci"
 printf '4\n' >"$test_root/state/spend/harlan-desktop-example-ci-burst-1"
-printf '8\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
+printf '4\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
 cat >"$test_root/state/jobs/harlan-desktop-example-ci-burst-1.json" <<'EOF'
 {"name":"test & build","startedAt":1787930400000}
 EOF
@@ -61,14 +61,15 @@ HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
 
 snapshot="$test_root/state/status.json"
 jq --exit-status '
-  .version == 1
+  .version == 2
   and .updatedAt == 1787930500000
-  and .budgets == { cpu: 20, memoryBytes: 25769803776 }
+  and .budgets == { cpu: 20, memoryBytes: 25769803776, memoryHeadroomBytes: 8589934592 }
   and .pools == [{
     cpuPerRunner: 4,
     live: 1,
     maximum: 4,
-    memoryPerRunnerBytes: 8589934592,
+    memoryLimitBytes: 8589934592,
+    memoryReservationBytes: 4294967296,
     name: "example-ci",
     queued: 2,
     repository: "harlan-zw/example",

--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -1,6 +1,6 @@
 # Runner pools, one per line, fields separated by `|`.
 #
-#   repository | labels | warm | max | cpus | memory | memory-swap
+#   repository | labels | warm | max | cpus | memory-reservation | memory-limit | memory-swap
 #
 # labels  Comma separated. The first one names the pool. Carry an old label
 #         alongside the shared one while a repository's workflows are migrated,
@@ -9,13 +9,13 @@
 #       the number of jobs that start with no wait.
 # max   Ceiling for the pool, warm included. Reached only under burst.
 # cpus  Quota for one container, and the unit the CPU budget is spent in.
+# memory-reservation  Expected peak memory. The scheduler spends this value.
+# memory-limit        Hard container limit for one runaway job.
+# memory-swap         Combined hard memory and swap limit.
 #
-# Pool memory is sized from measured peaks, not guesses. Read them from a live
-# container with `memory.peak` in its cgroup while a job runs. Measured
-# 2026-08-19: the nuxtseo deploy build peaked at 10.7g, and the busiest CI
-# container at 7.8g. Oversizing is not free here, because a warm slot promises
-# its whole limit the moment it claims a job, and that promise is what the burst
-# budget has to subtract.
+# Size reservations from measured peaks. Read `memory.peak` from a live
+# container while a representative job runs. Deploy reservations stay near
+# their peak. Flat CI jobs keep a larger hard limit for abnormal runs.
 #
 # Public repositories are absent on purpose. A self-hosted runner on a public
 # repository lets a fork pull request run code on this workstation, so
@@ -26,21 +26,21 @@
 # GitHub credentials with administration access to that org, so it cannot mint
 # registration tokens there.
 
-harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|0|1|16|20g|24g
-harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|0|8|6|12g|14g
-harlan-zw/nuxtseo.com|harlan-desktop-light|0|6|2|2g|3g
-harlan-zw/gscdump.com|harlan-desktop-ci|0|5|6|12g|14g
-harlan-zw/gscdump.com|harlan-desktop-deploy|0|1|8|12g|14g
-harlan-zw/mdream.dev|harlan-desktop-ci|0|3|6|12g|14g
-harlan-zw/zhead.dev|harlan-desktop-ci|0|3|6|12g|14g
-harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|6|12g|14g
-skilld-dev/skilld.dev|harlan-desktop-ci|0|3|6|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|0|1|16|13g|20g|24g
+harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|0|8|6|8g|12g|14g
+harlan-zw/nuxtseo.com|harlan-desktop-light|0|6|2|1g|2g|3g
+harlan-zw/gscdump.com|harlan-desktop-ci|0|5|6|6g|12g|14g
+harlan-zw/gscdump.com|harlan-desktop-deploy|0|1|8|10g|12g|14g
+harlan-zw/mdream.dev|harlan-desktop-ci|0|3|6|6g|12g|14g
+harlan-zw/zhead.dev|harlan-desktop-ci|0|3|6|4g|12g|14g
+harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|6|4g|12g|14g
+skilld-dev/skilld.dev|harlan-desktop-ci|0|3|6|4g|12g|14g
 
 # Packages and smaller sites moved off GitHub-hosted runners 2026-08-31.
 # Sizes are the hogwild (30g) measurements; a larger host can raise them.
-harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|4g|5g
-harlan-zw/gscdump|harlan-desktop-ci|0|2|4|5g|6g
-harlan-zw/massivemonster.com|harlan-desktop-ci|0|2|4|6g|8g
-harlan-zw/nuxt-audit|harlan-desktop-ci|0|2|4|4g|5g
-harlan-zw/ripast|harlan-desktop-ci|0|2|2|2g|3g
-harlan-zw/nuxt-ai-kit|harlan-desktop-ci|0|2|4|5g|6g
+harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|2g|4g|5g
+harlan-zw/gscdump|harlan-desktop-ci|0|2|4|3g|5g|6g
+harlan-zw/massivemonster.com|harlan-desktop-ci|0|2|4|3g|6g|8g
+harlan-zw/nuxt-audit|harlan-desktop-ci|0|2|4|2g|4g|5g
+harlan-zw/ripast|harlan-desktop-ci|0|2|2|1g|2g|3g
+harlan-zw/nuxt-ai-kit|harlan-desktop-ci|0|2|4|3g|5g|6g

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -30,20 +30,16 @@
 # containers would burst past `max` every time. The scaler writes each reservation
 # before it forks, which makes the count exact.
 #
-# Only work in flight spends the budget: a warm container spends while it holds a
-# job, and a burst container spends from the moment it is launched, because it
-# was launched to take one. Idle warm listeners cost about 60 MB and no CPU, so
-# charging for them would block every burst on an otherwise idle host.
+# Only work in flight spends the budget. A warm container spends while it holds
+# a job. A burst container spends when it launches. Idle warm listeners cost
+# about 60 MB and no CPU.
 #
 # CPU and memory are both budgeted, and for different reasons. CPU oversubscribes
 # safely: a container over its quota is throttled and its job just runs slower.
-# Memory does not. `--memory` is a LIMIT, not a RESERVATION, so Docker will
-# happily admit containers whose limits sum past physical RAM. Nothing reserves
-# anything, and the kernel resolves the overcommit by killing the largest RSS in
-# the cgroup that loses, which is always a build. That is how a 32g deploy
-# container gets OOM-killed on a 60g host: not by exceeding its own limit, but by
-# being the biggest thing alive when CI containers admitted beside it exhausted
-# the host. Budgeting memory the same way CPU is budgeted is what stops it.
+# Memory does not. Each pool therefore has two memory values. The reservation
+# represents expected peak use and spends the host budget. The hard limit stops
+# one runaway job. This lets flat CI jobs run beside a larger deploy without
+# pretending every job already consumes its hard limit.
 
 set -euo pipefail
 
@@ -53,13 +49,13 @@ readonly config_file="${HARLAN_DESKTOP_RUNNER_CONFIG:-/etc/harlan-desktop-github
 # modest oversubscription keeps a wide matrix moving without starving
 # interactive work on the workstation.
 readonly cpu_budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
-# Gibibytes of container memory limit that in-flight work may hold at once. This
-# is a ceiling on what is PROMISED, not on what is used, so it must leave room
-# for the workstation itself: a desktop session with an IDE, a browser and a few
-# language servers holds 30g here without trying. On a 60g host, 36g of budget
-# keeps the deploy pool (32g) able to run alone while holding CI back, and lets
-# three CI containers (12g each) share the host when no deploy is in flight.
+# Gibibytes of expected peak memory that in-flight work may reserve. This must
+# leave room for the workstation and abnormal growth up to each hard limit.
 readonly memory_budget_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB:-36}"
+# Keep this much currently available memory after each admission. Reservations
+# cover expected growth after admission. This guard covers host work and sudden
+# pressure that is outside the runner pool.
+readonly memory_headroom_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB:-8}"
 # A burst container that has claimed nothing by now is surplus. Stopping it
 # returns the pool to `warm` after a quiet spell.
 readonly burst_idle_seconds="${HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS:-300}"
@@ -115,11 +111,11 @@ declare -a pool_label=()
 declare -a pool_warm=()
 declare -a pool_max=()
 declare -a pool_cpus=()
-declare -a pool_memory=()
+declare -a pool_memory_reservation=()
+declare -a pool_memory_limit=()
 declare -a pool_memory_swap=()
-# `pool_memory` as a plain integer of gibibytes, for the budget arithmetic. The
-# unsuffixed string goes to Docker; only this one is summed.
-declare -a pool_memory_gib=()
+# The unsuffixed reservation goes to Docker. Only this integer form is summed.
+declare -a pool_memory_reservation_gib=()
 declare -a pool_slug=()
 
 # One entry per repository, however many pools it owns. Pruning is per
@@ -202,25 +198,36 @@ repository_slug_for() {
 }
 
 read_config() {
-  local repository label warm max cpus memory memory_swap
+  local repository label warm max cpus memory_reservation memory_limit memory_swap extra
+  local memory_reservation_gib memory_limit_gib memory_swap_gib
 
   if [[ ! -r "$config_file" ]]; then
     log "Runner config is unreadable: $config_file"
     return 1
   fi
 
-  while IFS='|' read -r repository label warm max cpus memory memory_swap; do
+  while IFS='|' read -r repository label warm max cpus memory_reservation memory_limit memory_swap extra; do
     # Skip comments and blank lines. Leading whitespace is tolerated so the file
     # can be indented.
     repository="${repository#"${repository%%[![:space:]]*}"}"
     [[ -z "$repository" || "$repository" == \#* ]] && continue
 
-    if [[ -z "$memory_swap" ]]; then
+    if [[ -z "$memory_swap" || -n "$extra" ]]; then
       log "Malformed pool line: $repository"
       return 1
     fi
     if [[ ! "$warm" =~ ^[0-9]+$ || ! "$max" =~ ^[1-9][0-9]*$ || ! "$cpus" =~ ^[1-9][0-9]*$ || "$warm" -gt "$max" ]]; then
       log "Invalid warm, max, or CPU value for $repository"
+      return 1
+    fi
+    if ! memory_reservation_gib="$(memory_gib_for "$memory_reservation")" \
+      || ! memory_limit_gib="$(memory_gib_for "$memory_limit")" \
+      || ! memory_swap_gib="$(memory_gib_for "$memory_swap")"; then
+      log "Invalid memory value for $repository"
+      return 1
+    fi
+    if (( memory_reservation_gib >= memory_limit_gib || memory_limit_gib > memory_swap_gib )); then
+      log "Memory must increase from reservation to limit to swap for $repository"
       return 1
     fi
 
@@ -229,9 +236,10 @@ read_config() {
     pool_warm+=("$warm")
     pool_max+=("$max")
     pool_cpus+=("$cpus")
-    pool_memory+=("$memory")
+    pool_memory_reservation+=("$memory_reservation")
+    pool_memory_limit+=("$memory_limit")
     pool_memory_swap+=("$memory_swap")
-    pool_memory_gib+=("$(memory_gib_for "$memory")")
+    pool_memory_reservation_gib+=("$memory_reservation_gib")
     pool_slug+=("$(pool_slug_for "$repository" "$label")")
   done <"$config_file"
 
@@ -241,22 +249,21 @@ read_config() {
   fi
 }
 
-# `12g` -> `12`. Docker's suffixes are accepted so the config stays in Docker's
-# own units, and anything else is refused rather than guessed at: a pool silently
-# read as 0 would spend nothing and defeat the budget entirely.
+# `12g` becomes `12`. Docker suffixes keep the config in Docker's own units.
 memory_gib_for() {
   local value="$1"
   local number="${value%[gGmM]}"
 
   case "$value" in
-    *[gG]) printf '%s' "$number" ;;
+    [1-9]*[gG]) [[ "$number" =~ ^[1-9][0-9]*$ ]] && printf '%s' "$number" ;;
     # Rounded up, so a sub-gibibyte pool still spends a whole unit.
-    *[mM]) printf '%s' "$(( (number + 1023) / 1024 ))" ;;
-    *)
-      log "Pool memory '$value' has no g or m suffix; treating it as gibibytes"
-      printf '%s' "$value"
-      ;;
+    [1-9]*[mM]) [[ "$number" =~ ^[1-9][0-9]*$ ]] && printf '%s' "$(( (number + 1023) / 1024 ))" ;;
+    *) return 1 ;;
   esac
+}
+
+host_available_memory_gib() {
+  free --gibi | awk '/^Mem:/ { print $7 }'
 }
 
 # Sum of a marker directory's contents. Each file is named after its container,
@@ -573,7 +580,8 @@ run_container() {
     --label "$container_label.pool=${pool_slug[$pool_index]}" \
     --label "$container_label.repository=$repository" \
     --cpus "${pool_cpus[$pool_index]}" \
-    --memory "${pool_memory[$pool_index]}" \
+    --memory-reservation "${pool_memory_reservation[$pool_index]}" \
+    --memory "${pool_memory_limit[$pool_index]}" \
     --memory-swap "${pool_memory_swap[$pool_index]}" \
     --volume "$pnpm_store_volume:/pnpm-store" \
     --env npm_config_store_dir=/pnpm-store \
@@ -596,7 +604,7 @@ run_container() {
           record_running_job "$container_name" "$job_name"
           # A burst container reserved capacity before it registered.
           if [[ "$slot_kind" == warm ]]; then
-            reserve "$container_name" "${pool_cpus[$pool_index]}" "${pool_memory_gib[$pool_index]}"
+            reserve "$container_name" "${pool_cpus[$pool_index]}" "${pool_memory_reservation_gib[$pool_index]}"
             printf 'spawn %s\n' "$pool_index" >"$scale_pipe"
           fi
         fi
@@ -677,7 +685,7 @@ run_burst_slot() {
 run_scaler() {
   local request pool_index container_name
   local burst_counter=0
-  local slug live spent spent_memory
+  local slug live spent spent_memory available_memory
   local pending_pool pending_count attempt
   local -a pending_pools=()
   local -A pool_is_pending=()
@@ -716,8 +724,20 @@ run_scaler() {
         # Checked after CPU and never merged with it. A host can have cores to
         # spare and no memory to back them, which is the case this exists for.
         spent_memory="$(sum_markers "$state_dir/spend-memory")"
-        if (( spent_memory + pool_memory_gib[pending_pool] > memory_budget_gib )); then
+        if (( spent_memory + pool_memory_reservation_gib[pending_pool] > memory_budget_gib )); then
           log "Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g; holding $slug at $live"
+          pending_pools+=("$pending_pool")
+          continue
+        fi
+
+        available_memory="$(host_available_memory_gib)"
+        if [[ ! "$available_memory" =~ ^[0-9]+$ ]]; then
+          log "Available memory is unknown; holding $slug at $live"
+          pending_pools+=("$pending_pool")
+          continue
+        fi
+        if (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
+          log "Available memory ${available_memory}g, headroom ${memory_headroom_gib}g; holding $slug at $live"
           pending_pools+=("$pending_pool")
           continue
         fi
@@ -735,7 +755,7 @@ run_scaler() {
         # Both reservations are written before the fork, so the next request in
         # this loop already sees this container.
         printf '%s\n' "${pool_cpus[$pending_pool]}" >"$state_dir/burst/$slug/$container_name"
-        reserve "$container_name" "${pool_cpus[$pending_pool]}" "${pool_memory_gib[$pending_pool]}"
+        reserve "$container_name" "${pool_cpus[$pending_pool]}" "${pool_memory_reservation_gib[$pending_pool]}"
 
         log "Bursting $slug to $(( live + 1 )) of ${pool_max[$pending_pool]}"
         run_burst_slot "$pending_pool" "$container_name" &
@@ -979,12 +999,12 @@ main() {
   local widest_pool_memory=0
   for pool_index in "${!pool_repository[@]}"; do
     warm_floor=$(( warm_floor + pool_warm[pool_index] * pool_cpus[pool_index] ))
-    warm_memory_floor=$(( warm_memory_floor + pool_warm[pool_index] * pool_memory_gib[pool_index] ))
+    warm_memory_floor=$(( warm_memory_floor + pool_warm[pool_index] * pool_memory_reservation_gib[pool_index] ))
     if (( pool_cpus[pool_index] > widest_pool_cpu )); then
       widest_pool_cpu="${pool_cpus[$pool_index]}"
     fi
-    if (( pool_memory_gib[pool_index] > widest_pool_memory )); then
-      widest_pool_memory="${pool_memory_gib[$pool_index]}"
+    if (( pool_memory_reservation_gib[pool_index] > widest_pool_memory )); then
+      widest_pool_memory="${pool_memory_reservation_gib[$pool_index]}"
     fi
   done
   if (( warm_floor > cpu_budget )); then
@@ -1005,6 +1025,10 @@ main() {
   fi
   if [[ -n "$host_ram_gib" ]] && (( memory_budget_gib > host_ram_gib )); then
     log "Memory budget is ${memory_budget_gib}g on a ${host_ram_gib}g host"
+    return 1
+  fi
+  if [[ ! "$memory_headroom_gib" =~ ^[0-9]+$ ]] || (( memory_headroom_gib >= host_ram_gib )); then
+    log "Memory headroom must be below host RAM"
     return 1
   fi
 
@@ -1031,7 +1055,7 @@ main() {
   run_status_publisher &
 
   for pool_index in "${!pool_repository[@]}"; do
-    log "Pool ${pool_slug[$pool_index]}: ${pool_repository[$pool_index]} warm ${pool_warm[$pool_index]} max ${pool_max[$pool_index]} cpus ${pool_cpus[$pool_index]} memory ${pool_memory[$pool_index]}"
+    log "Pool ${pool_slug[$pool_index]}: ${pool_repository[$pool_index]} warm ${pool_warm[$pool_index]} max ${pool_max[$pool_index]} cpus ${pool_cpus[$pool_index]} memory reservation ${pool_memory_reservation[$pool_index]} limit ${pool_memory_limit[$pool_index]}"
     for slot_number in $(seq 1 "${pool_warm[$pool_index]}"); do
       run_warm_slot "$pool_index" "$slot_number" &
     done

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -9,7 +9,7 @@ mkdir -p "$test_root/bin" "$test_root/runtime" "$test_root/calls" "$test_root/cr
 printf 'repository-token\n' >"$test_root/credentials/github-harlan-zw-token"
 
 cat >"$test_root/runners.conf" <<'EOF'
-harlan-zw/example|harlan-desktop-ci|1|2|1|1g|2g
+harlan-zw/example|harlan-desktop-ci|1|2|1|1g|2g|3g
 EOF
 
 cat >"$test_root/bin/gh" <<'EOF'
@@ -35,7 +35,7 @@ if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-enabled" ]
   printf '77\t2026-08-27T04:30:00Z\n'
 fi
 if [[ "$*" == *'actions/runs/77/jobs'* && -f "$TEST_CALLS/queue-enabled" ]]; then
-  printf 'self-hosted,harlan-desktop-ci\n'
+  printf 'self-hosted,harlan-desktop-ci\n%.0s' 1 2
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf '76\t2026-08-26T00:00:00Z\n'
@@ -47,7 +47,12 @@ EOF
 
 cat >"$test_root/bin/free" <<'EOF'
 #!/usr/bin/env bash
-printf 'Mem: 32\n'
+printf '              total used free shared buff/cache available\n'
+if [[ -f "$TEST_CALLS/low-memory" ]]; then
+  printf 'Mem:             32   24    2      0          6         2\n'
+else
+  printf 'Mem:             32    4   20      0          8        24\n'
+fi
 EOF
 
 cat >"$test_root/bin/docker" <<'EOF'
@@ -160,6 +165,12 @@ if [[ ! -s "$test_root/calls/burst" ]]; then
   exit 1
 fi
 
+if ! grep --quiet --fixed-strings -- '--memory-reservation 1g --memory 2g --memory-swap 3g' "$test_root/calls/docker"; then
+  cat "$test_root/calls/docker"
+  printf 'Expected the runner reservation and hard limit to stay separate.\n' >&2
+  exit 1
+fi
+
 if (( $(wc -l <"$test_root/calls/stopped") != 4 )); then
   cat "$test_root/output"
   cat "$test_root/calls/docker"
@@ -179,7 +190,7 @@ rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"
 touch "$test_root/calls/queue-enabled"
 cat >"$test_root/runners.conf" <<'EOF'
-harlan-zw/example|harlan-desktop-ci|0|2|1|1g|2g
+harlan-zw/example|harlan-desktop-ci|0|2|1|1g|2g|3g
 EOF
 
 set +e
@@ -188,8 +199,8 @@ PATH="$test_root/bin:$PATH" \
 XDG_RUNTIME_DIR="$test_root/runtime" \
 CREDENTIALS_DIRECTORY="$test_root/credentials" \
 HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
-HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
-HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=2 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
 HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
 HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.05 \
 HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
@@ -204,14 +215,14 @@ if (( status != 0 )); then
   exit 1
 fi
 
-if [[ ! -s "$test_root/calls/burst" ]]; then
+if (( $(wc -l <"$test_root/calls/burst") != 2 )); then
   cat "$test_root/output"
   cat "$test_root/calls/docker"
-  printf 'Expected a queued job to start a zero-warm pool.\n' >&2
+  printf 'Expected reservations to admit two queued runners.\n' >&2
   exit 1
 fi
 
-if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memoryPerRunnerBytes: 1073741824, name: "example-ci", queued: 1, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
+if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memoryLimitBytes: 2147483648, memoryReservationBytes: 1073741824, name: "example-ci", queued: 2, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
   cat "$test_root/calls/status.json"
   printf 'Expected queued demand in the published runner status.\n' >&2
   exit 1
@@ -306,3 +317,37 @@ if (( status != 0 )) || rg --quiet 'Queued job demand is unavailable' "$test_roo
 fi
 
 printf 'Empty current workflow demand passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-enabled" "$test_root/calls/low-memory"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=2 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
+HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=2 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/docker"
+  printf 'Expected host memory headroom to hold a queued runner.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet 'Available memory 2g, headroom 2g; holding example-ci at 0' "$test_root/output"; then
+  cat "$test_root/output"
+  printf 'Expected the memory headroom decision in the supervisor log.\n' >&2
+  exit 1
+fi
+
+printf 'Host memory headroom passed.\n'


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

Hogwild charged each job's hard memory limit during admission. This held queued jobs while most CPUs and 21 GiB of host memory remained available.

The scheduler now charges a pool reservation and keeps a separate Docker hard limit. It also holds jobs when admission would leave less than 6 GiB of available host memory.

### ⚠️ Breaking Changes

Runner pool rows now require eight fields. They split memory into reservation, hard limit, and swap limit.

Status snapshots now use schema version 2. They expose separate reservation and limit fields.

### 📝 Migration

Install the updated scripts, Hogwild pool config, and service unit. Reload systemd, then restart `hogwild-github-runner.service` after active jobs drain.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).