### PR TITLE
feat(runner): persist job history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - run: pnpm dev:prepare
       - run: pnpm lint
       - run: bash infra/github-runner/supervisor.test.sh
+      - run: bash infra/github-runner/job-history.test.sh
+      - run: bash infra/github-runner/backfill-job-history.test.sh
       - run: bash infra/github-runner/publish-status.test.sh
       - run: pnpm typecheck
       - run: pnpm test

--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -61,6 +61,10 @@ install -Dm755 infra/github-runner/supervisor \
   ~/.local/lib/harlan-desktop-github-runner/supervisor
 install -Dm755 infra/github-runner/publish-status \
   ~/.local/lib/harlan-desktop-github-runner/publish-status
+install -Dm755 infra/github-runner/job-history \
+  ~/.local/lib/harlan-desktop-github-runner/job-history
+install -Dm755 infra/github-runner/backfill-job-history \
+  ~/.local/lib/harlan-desktop-github-runner/backfill-job-history
 install -Dm644 infra/github-runner/runners.conf \
   ~/.config/harlan-desktop-github-runner/runners.conf
 install -Dm644 infra/github-runner/harlan-desktop-github-runner.service \
@@ -103,7 +107,9 @@ journalctl --user --unit harlan-desktop-github-runner.service --follow
 
 The supervisor publishes `status.json` beside its runtime state every 15 seconds.
 
-The snapshot contains pool demand, active jobs, recent outcomes, and container resources. It contains no credentials or Docker configuration.
+The snapshot contains pool demand, active jobs, recent outcomes, lifetime Runner job totals, and container resources. It contains no credentials or Docker configuration.
+
+Raw Runner jobs persist for 90 days. Daily totals persist until they are removed manually.
 
 Stop local CI before shutting down or doing CPU-heavy local work:
 
@@ -185,6 +191,8 @@ Install the versioned Hogwild files into their fixed system paths:
 ```bash
 sudo install -Dm755 infra/github-runner/supervisor /var/lib/github-runner/bin/supervisor
 sudo install -Dm755 infra/github-runner/publish-status /var/lib/github-runner/bin/publish-status
+sudo install -Dm755 infra/github-runner/job-history /var/lib/github-runner/bin/job-history
+sudo install -Dm755 infra/github-runner/backfill-job-history /var/lib/github-runner/bin/backfill-job-history
 sudo install -Dm644 infra/github-runner/hogwild-runners.conf /var/lib/github-runner/config/runners.conf
 sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
 sudo install -Dm644 infra/github-runner/hogwild-logind.conf /etc/systemd/logind.conf.d/runner-safe-power.conf

--- a/infra/github-runner/backfill-job-history
+++ b/infra/github-runner/backfill-job-history
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly history_dir="${1:-}"
+readonly config_file="${2:-}"
+readonly since="${3:-}"
+readonly until="${4:-$(date --utc +%F)}"
+readonly history_writer="${HARLAN_DESKTOP_RUNNER_JOB_HISTORY:-$(dirname "${BASH_SOURCE[0]}")/job-history}"
+
+if [[ -z "$history_dir" || -z "$config_file" || ! "$since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ || ! "$until" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  printf 'usage: backfill-job-history HISTORY_DIRECTORY CONFIG_FILE SINCE_DATE [UNTIL_DATE]\n' >&2
+  exit 2
+fi
+if [[ ! -r "$config_file" ]]; then
+  printf 'Runner config is unavailable: %s\n' "$config_file" >&2
+  exit 1
+fi
+if [[ ! -x "$history_writer" ]]; then
+  printf 'Runner job history writer is unavailable: %s\n' "$history_writer" >&2
+  exit 1
+fi
+
+github_api() {
+  local repository="$1"
+  shift
+  local owner="${repository%%/*}"
+  local credential=''
+
+  if [[ -n "${CREDENTIALS_DIRECTORY:-}" ]]; then
+    credential="$CREDENTIALS_DIRECTORY/github-$owner-token"
+    if [[ ! -r "$credential" ]]; then
+      printf 'GitHub credential is unavailable for owner: %s\n' "$owner" >&2
+      return 1
+    fi
+    GH_TOKEN="$(<"$credential")" gh api "$@"
+    return
+  fi
+  gh api "$@"
+}
+
+pool_slug_for() {
+  local repository="$1"
+  local label="${2%%,*}"
+
+  printf '%s-%s' "${repository##*/}" "${label#harlan-desktop-}" \
+    | tr --complement --squeeze-repeats '[:alnum:]-' '-' \
+    | tr '[:upper:]' '[:lower:]'
+}
+
+configured_pools_for() {
+  local target_repository="$1"
+  local repository labels
+
+  while IFS='|' read -r repository labels _; do
+    repository="${repository#"${repository%%[![:space:]]*}"}"
+    repository="${repository%"${repository##*[![:space:]]}"}"
+    [[ "$repository" == "$target_repository" ]] || continue
+    pool_slug_for "$repository" "$labels"
+    printf '\n'
+  done <"$config_file" \
+    | jq --raw-input --slurp --compact-output \
+      'split("\n") | map(select(length > 0)) | unique | sort_by(length) | reverse'
+}
+
+temporary_jobs="$(mktemp)"
+cleanup() {
+  rm --force "$temporary_jobs"
+}
+trap cleanup EXIT
+
+declare -A seen_repositories=()
+while IFS='|' read -r repository _; do
+  repository="${repository#"${repository%%[![:space:]]*}"}"
+  repository="${repository%"${repository##*[![:space:]]}"}"
+  [[ -z "$repository" || "$repository" == \#* || -n "${seen_repositories[$repository]:-}" ]] && continue
+  seen_repositories[$repository]=done
+  configured_pools="$(configured_pools_for "$repository")"
+
+  if ! run_ids="$(github_api "$repository" --paginate \
+    "repos/$repository/actions/runs?status=completed&created=$since..$until&per_page=100" \
+    | jq --raw-output '.workflow_runs[].id')"; then
+    printf 'GitHub Actions runs are unavailable for %s.\n' "$repository" >&2
+    exit 1
+  fi
+
+  while read -r run_id; do
+    [[ -n "$run_id" ]] || continue
+    if ! github_api "$repository" --paginate \
+      "repos/$repository/actions/runs/$run_id/jobs?filter=latest&per_page=100" \
+      | jq --compact-output --arg repository "$repository" --argjson pools "$configured_pools" '
+        .jobs[]
+        | (.runner_name // "") as $runnerName
+        | ($pools | map(
+            . as $pool
+            | select($runnerName | startswith("harlan-desktop-\($pool)-"))
+          ) | first) as $pool
+        | select(
+            .status == "completed"
+            and .started_at != null
+            and .completed_at != null
+            and $pool != null
+          )
+        | {
+            completedAt: (.completed_at | fromdateiso8601 * 1000),
+            name: .name[:240],
+            outcome: (
+              if .conclusion == "success" then "Succeeded"
+              elif .conclusion == "failure" then "Failed"
+              elif .conclusion == "cancelled" then "Cancelled"
+              else "Unknown"
+              end
+            ),
+            pool: $pool,
+            repository: $repository,
+            startedAt: (.started_at | fromdateiso8601 * 1000)
+          }
+      ' >>"$temporary_jobs"; then
+      printf 'GitHub Actions jobs are unavailable for %s run %s.\n' "$repository" "$run_id" >&2
+      exit 1
+    fi
+  done <<<"$run_ids"
+done <"$config_file"
+
+"$history_writer" import "$history_dir" <"$temporary_jobs"
+printf 'Imported %s Runner jobs.\n' "$(wc --lines <"$temporary_jobs")"

--- a/infra/github-runner/backfill-job-history.test.sh
+++ b/infra/github-runner/backfill-job-history.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+mkdir --parents "$test_root/bin"
+cat >"$test_root/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+case "$*" in
+  *'/actions/runs?'*)
+    printf '%s\n' '{"workflow_runs":[{"id":77}]}'
+    ;;
+  *'/actions/runs/77/jobs?'*)
+    printf '%s\n' '{"jobs":[{"completed_at":"2026-08-30T00:01:30Z","conclusion":"success","labels":["self-hosted","example-linux"],"name":"build","runner_name":"harlan-desktop-example-linux-x64-01","started_at":"2026-08-30T00:00:00Z","status":"completed"},{"completed_at":"2026-08-30T00:02:00Z","conclusion":"success","labels":["ubuntu-latest"],"name":"hosted build","runner_name":"GitHub Actions 1","started_at":"2026-08-30T00:00:00Z","status":"completed"}]}'
+    ;;
+  *)
+    printf 'Unexpected GitHub API request: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$test_root/bin/gh"
+
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-linux-x64,example-linux|2|node22
+harlan-zw/example|harlan-desktop-linux-x64,example-linux|2|node22
+EOF
+
+output="$(
+  PATH="$test_root/bin:$PATH" \
+  FAKE_GH_LOG="$test_root/gh.log" \
+  HARLAN_DESKTOP_RUNNER_NOW_EPOCH="$(date --utc --date='2026-08-31T00:00:00Z' +%s)" \
+    ./infra/github-runner/backfill-job-history \
+      "$test_root/history" \
+      "$test_root/runners.conf" \
+      2026-08-01 \
+      2026-08-31
+)"
+
+if [[ "$output" != 'Imported 1 Runner jobs.' ]]; then
+  printf 'Expected one self-hosted Runner job to be imported.\n' >&2
+  exit 1
+fi
+
+if (( $(wc --lines <"$test_root/gh.log") != 2 )); then
+  printf 'Expected repeated repositories to be queried once.\n' >&2
+  exit 1
+fi
+
+jq --exit-status '
+  .actualMilliseconds == 90000
+  and .billableMinutes == 2
+  and .completed == 1
+  and .trackedSince == 1788048000000
+' "$test_root/history/daily/2026-08-30.json" >/dev/null
+
+jq --exit-status '
+  .repository == "harlan-zw/example"
+  and .pool == "example-linux-x64"
+  and .outcome == "Succeeded"
+' "$test_root/history/jobs/2026-08-30.ndjson" >/dev/null
+
+printf 'Runner job history backfill passed.\n'

--- a/infra/github-runner/job-history
+++ b/infra/github-runner/job-history
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly operation="${1:-}"
+readonly history_dir="${2:-}"
+readonly raw_retention_days="${HARLAN_DESKTOP_RUNNER_RAW_RETENTION_DAYS:-90}"
+readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
+
+if [[ "$operation" != import || -z "$history_dir" ]]; then
+  printf 'usage: job-history import HISTORY_DIRECTORY\n' >&2
+  exit 2
+fi
+if [[ ! "$raw_retention_days" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'Raw Runner job retention must be a positive day count.\n' >&2
+  exit 2
+fi
+
+for command_name in date flock jq; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'Required command is unavailable: %s\n' "$command_name" >&2
+    exit 1
+  fi
+done
+
+temporary_input="$(mktemp)"
+temporary_jobs=''
+temporary_summary=''
+cleanup() {
+  rm --force "$temporary_input"
+  if [[ -n "$temporary_jobs" ]]; then
+    rm --force "$temporary_jobs"
+  fi
+  if [[ -n "$temporary_summary" ]]; then
+    rm --force "$temporary_summary"
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+cat >"$temporary_input"
+[[ -s "$temporary_input" ]] || exit 0
+
+if ! jq --exit-status --slurp '
+  def count($maximum):
+    type == "number" and . >= 0 and . <= $maximum and floor == .;
+  def text($maximum):
+    type == "string" and length > 0 and length <= $maximum;
+  all(.[];
+    type == "object"
+    and (.completedAt | count(10000000000000))
+    and (.name | text(240))
+    and (.outcome == "Cancelled" or .outcome == "Failed" or .outcome == "Succeeded" or .outcome == "Unknown")
+    and (.pool | type == "string" and test("^[a-z0-9][a-z0-9-]{0,119}$"))
+    and (.repository | type == "string" and test("^[A-Za-z0-9_.-]{1,80}/[A-Za-z0-9_.-]{1,100}$"))
+    and (.startedAt | count(10000000000000))
+    and .completedAt >= .startedAt
+  )
+' "$temporary_input" >/dev/null; then
+  printf 'Runner job history input is invalid.\n' >&2
+  exit 1
+fi
+
+mkdir --parents "$history_dir/daily" "$history_dir/jobs"
+
+if [[ -n "$fixed_now_epoch" ]]; then
+  now_epoch="$fixed_now_epoch"
+else
+  now_epoch="$(date +%s)"
+fi
+if [[ ! "$now_epoch" =~ ^[0-9]+$ ]]; then
+  printf 'Runner history time must be a Unix timestamp.\n' >&2
+  exit 2
+fi
+cutoff_epoch=$(( now_epoch - raw_retention_days * 86400 ))
+cutoff_day="$(date --utc --date="@$cutoff_epoch" +%F)"
+
+(
+  flock --exclusive 9
+
+  while read -r day; do
+    [[ -n "$day" ]] || continue
+    jobs_file="$history_dir/jobs/$day.ndjson"
+    summary_file="$history_dir/daily/$day.json"
+    temporary_jobs="$(mktemp --tmpdir="$history_dir/jobs" ".$day.XXXXXX")"
+    temporary_summary="$(mktemp --tmpdir="$history_dir/daily" ".$day.XXXXXX")"
+    declare -a inputs=("$temporary_input")
+    [[ -r "$jobs_file" ]] && inputs=("$jobs_file" "$temporary_input")
+
+    jq --compact-output --slurp --arg day "$day" '
+      [ .[]
+        | select((.completedAt / 1000 | strftime("%Y-%m-%d")) == $day)
+      ]
+      | sort_by(.completedAt, .repository, .pool, .name, .startedAt)
+      | unique_by([.repository, .pool, .name, .startedAt, .completedAt])
+      | .[]
+    ' "${inputs[@]}" >"$temporary_jobs"
+
+    jq --slurp --arg date "$day" '
+      {
+        actualMilliseconds: (map(.completedAt - .startedAt) | add // 0),
+        billableMinutes: (map(((.completedAt - .startedAt + 59999) / 60000 | floor)) | add // 0),
+        completed: length,
+        date: $date,
+        trackedSince: (map(.startedAt) | min)
+      }
+    ' "$temporary_jobs" >"$temporary_summary"
+
+    mv --force "$temporary_jobs" "$jobs_file"
+    temporary_jobs=''
+    mv --force "$temporary_summary" "$summary_file"
+    temporary_summary=''
+  done < <(jq --raw-output '(.completedAt / 1000 | strftime("%Y-%m-%d"))' "$temporary_input" | sort --unique)
+
+  for jobs_file in "$history_dir/jobs"/*.ndjson; do
+    [[ -f "$jobs_file" ]] || continue
+    day="${jobs_file##*/}"
+    day="${day%.ndjson}"
+    if [[ "$day" < "$cutoff_day" ]]; then
+      rm --force "$jobs_file"
+    fi
+  done
+  true
+) 9>"$history_dir/jobs.lock"

--- a/infra/github-runner/job-history.test.sh
+++ b/infra/github-runner/job-history.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+history_dir="$test_root/history"
+old_started_at="$(( $(date --utc --date='2026-05-01T00:00:00Z' +%s) * 1000 ))"
+recent_started_at="$(( $(date --utc --date='2026-08-30T00:00:00Z' +%s) * 1000 ))"
+now_epoch="$(date --utc --date='2026-08-31T00:00:00Z' +%s)"
+
+cat >"$test_root/jobs.ndjson" <<EOF
+{"completedAt":$(( old_started_at + 61000 )),"name":"old build","outcome":"Succeeded","pool":"example-ci","repository":"harlan-zw/example","startedAt":$old_started_at}
+{"completedAt":$(( recent_started_at + 90000 )),"name":"build","outcome":"Succeeded","pool":"example-ci","repository":"harlan-zw/example","startedAt":$recent_started_at}
+{"completedAt":$(( recent_started_at + 130000 )),"name":"lint","outcome":"Failed","pool":"example-ci","repository":"harlan-zw/example","startedAt":$(( recent_started_at + 120000 ))}
+{"completedAt":$(( recent_started_at + 90000 )),"name":"build","outcome":"Succeeded","pool":"example-ci","repository":"harlan-zw/example","startedAt":$recent_started_at}
+EOF
+
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH="$now_epoch" \
+HARLAN_DESKTOP_RUNNER_RAW_RETENTION_DAYS=90 \
+./infra/github-runner/job-history import "$history_dir" <"$test_root/jobs.ndjson"
+
+if [[ -e "$history_dir/jobs/2026-05-01.ndjson" ]]; then
+  printf 'Expected raw jobs older than 90 days to be removed.\n' >&2
+  exit 1
+fi
+
+if (( $(wc -l <"$history_dir/jobs/2026-08-30.ndjson") != 2 )); then
+  printf 'Expected repeated imports to keep each raw job once.\n' >&2
+  exit 1
+fi
+
+jq --exit-status '
+  .date == "2026-05-01"
+  and .actualMilliseconds == 61000
+  and .billableMinutes == 2
+  and .completed == 1
+  and .trackedSince == $started
+' --argjson started "$old_started_at" "$history_dir/daily/2026-05-01.json" >/dev/null
+
+jq --exit-status '
+  .date == "2026-08-30"
+  and .actualMilliseconds == 100000
+  and .billableMinutes == 3
+  and .completed == 2
+  and .trackedSince == $started
+' --argjson started "$recent_started_at" "$history_dir/daily/2026-08-30.json" >/dev/null
+
+before_checksum="$(sha256sum "$history_dir/daily/2026-08-30.json")"
+set +e
+printf '%s\n' '{"completedAt":"invalid"}' \
+  | ./infra/github-runner/job-history import "$history_dir" >/dev/null 2>&1
+invalid_status=$?
+set -e
+if (( invalid_status == 0 )) || [[ "$(sha256sum "$history_dir/daily/2026-08-30.json")" != "$before_checksum" ]]; then
+  printf 'Expected invalid imports to preserve runner history.\n' >&2
+  exit 1
+fi
+
+printf 'Runner job history passed.\n'

--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -4,6 +4,7 @@ set -euo pipefail
 
 readonly state_dir="${1:?Runner state directory is required}"
 readonly output_file="${2:-$state_dir/status.json}"
+readonly history_dir="${3:-${HARLAN_DESKTOP_RUNNER_HISTORY_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/harlan-desktop-github-runner}}"
 readonly cpu_budget="${HARLAN_DESKTOP_RUNNER_CPU_BUDGET:-32}"
 readonly memory_budget_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB:-36}"
 readonly memory_headroom_gib="${HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB:-8}"
@@ -105,10 +106,30 @@ jobs="$({
 } | jq --compact-output --slurp '.')"
 
 recent_jobs='[]'
-if [[ -r "$state_dir/recent/jobs.ndjson" ]]; then
-  recent_jobs="$(flock --shared "$state_dir/recent/jobs.lock" \
-    tail --lines 40 "$state_dir/recent/jobs.ndjson" \
-    | jq --compact-output --slurp '[.[] | select(type == "object")] | .[-20:]')"
+job_totals='null'
+if [[ -d "$history_dir" ]]; then
+  exec 9>"$history_dir/jobs.lock"
+  flock --shared 9
+  recent_jobs="$({
+    for jobs_file in "$history_dir/jobs"/*.ndjson; do
+      [[ -f "$jobs_file" ]] || continue
+      tail --lines 20 "$jobs_file"
+    done | jq --compact-output --slurp '[.[] | select(type == "object")] | sort_by(.completedAt) | .[-20:]'
+  })"
+
+  daily_files=("$history_dir/daily"/*.json)
+  if [[ -f "${daily_files[0]}" ]]; then
+    job_totals="$(jq --compact-output --slurp '
+      {
+        actualMilliseconds: (map(.actualMilliseconds) | add // 0),
+        billableMinutes: (map(.billableMinutes) | add // 0),
+        completed: (map(.completed) | add // 0),
+        trackedSince: (map(.trackedSince) | min)
+      }
+    ' "${daily_files[@]}")"
+  fi
+  flock --unlock 9
+  exec 9>&-
 fi
 
 while IFS='|' read -r repository labels warm maximum cpus memory_reservation memory_limit memory_swap; do
@@ -193,14 +214,16 @@ jq --null-input \
   --argjson cpuBudget "$cpu_budget" \
   --argjson memoryBudgetBytes "$(( memory_budget_gib * 1024 * 1024 * 1024 ))" \
   --argjson memoryHeadroomBytes "$(( memory_headroom_gib * 1024 * 1024 * 1024 ))" \
+  --argjson jobTotals "$job_totals" \
   --argjson pools "$pools" \
   --argjson recentJobs "$recent_jobs" \
   --argjson runners "$runners" \
   --argjson updatedAt "$updated_at" \
   '{
-    version: 2,
+    version: 3,
     updatedAt: $updatedAt,
     budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes, memoryHeadroomBytes: $memoryHeadroomBytes },
+    jobTotals: $jobTotals,
     pools: $pools,
     runners: $runners,
     recentJobs: $recentJobs

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 test_root="$(mktemp -d)"
 trap 'rm -rf "$test_root"' EXIT
 
-mkdir -p "$test_root/bin" "$test_root/state/jobs" "$test_root/state/queued" \
-  "$test_root/state/recent" "$test_root/state/spend" "$test_root/state/spend-memory"
+mkdir -p "$test_root/bin" "$test_root/history/daily" "$test_root/history/jobs" \
+  "$test_root/state/jobs" "$test_root/state/queued" "$test_root/state/spend" \
+  "$test_root/state/spend-memory"
 
 cat >"$test_root/state/runners.conf" <<'EOF'
 harlan-zw/example|harlan-desktop-ci|0|4|4|4g|8g|10g
@@ -17,8 +18,11 @@ printf '4\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
 cat >"$test_root/state/jobs/harlan-desktop-example-ci-burst-1.json" <<'EOF'
 {"name":"test & build","startedAt":1787930400000}
 EOF
-cat >"$test_root/state/recent/jobs.ndjson" <<'EOF'
+cat >"$test_root/history/jobs/2026-08-28.ndjson" <<'EOF'
 {"completedAt":1787930300000,"name":"lint","outcome":"Succeeded","pool":"example-ci","repository":"harlan-zw/example","startedAt":1787930200000}
+EOF
+cat >"$test_root/history/daily/2026-08-28.json" <<'EOF'
+{"actualMilliseconds":100000,"billableMinutes":2,"completed":1,"date":"2026-08-28","trackedSince":1787930200000}
 EOF
 
 cat >"$test_root/bin/docker" <<'EOF'
@@ -57,13 +61,14 @@ PATH="$test_root/bin:$PATH" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24 \
 HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
-./infra/github-runner/publish-status "$test_root/state"
+./infra/github-runner/publish-status "$test_root/state" "$test_root/state/status.json" "$test_root/history"
 
 snapshot="$test_root/state/status.json"
 jq --exit-status '
-  .version == 2
+  .version == 3
   and .updatedAt == 1787930500000
   and .budgets == { cpu: 20, memoryBytes: 25769803776, memoryHeadroomBytes: 8589934592 }
+  and .jobTotals == { actualMilliseconds: 100000, billableMinutes: 2, completed: 1, trackedSince: 1787930200000 }
   and .pools == [{
     cpuPerRunner: 4,
     live: 1,
@@ -96,7 +101,7 @@ if [[ "$(stat -c '%a' "$snapshot")" != 640 ]]; then
 fi
 
 PATH="$test_root/bin:$PATH" \
-./infra/github-runner/publish-status "$test_root/state"
+./infra/github-runner/publish-status "$test_root/state" "$test_root/state/status.json" "$test_root/history"
 if ! jq --exit-status '.updatedAt == 1787930500000' "$snapshot" >/dev/null; then
   printf 'Expected a portable millisecond timestamp.\n' >&2
   exit 1
@@ -106,7 +111,7 @@ snapshot_checksum="$(sha256sum "$snapshot")"
 set +e
 TEST_DOCKER_FAIL=ps \
 PATH="$test_root/bin:$PATH" \
-./infra/github-runner/publish-status "$test_root/state" >/dev/null 2>&1
+./infra/github-runner/publish-status "$test_root/state" "$test_root/state/status.json" "$test_root/history" >/dev/null 2>&1
 failure_status=$?
 set -e
 if (( failure_status == 0 )) || [[ "$(sha256sum "$snapshot")" != "$snapshot_checksum" ]]; then

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -79,6 +79,8 @@ readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
 readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
 readonly status_output_override="${HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT:-}"
 readonly status_publisher="${HARLAN_DESKTOP_RUNNER_STATUS_PUBLISHER:-$(dirname "${BASH_SOURCE[0]}")/publish-status}"
+readonly history_root="${HARLAN_DESKTOP_RUNNER_HISTORY_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/harlan-desktop-github-runner}"
+readonly history_writer="${HARLAN_DESKTOP_RUNNER_JOB_HISTORY:-$(dirname "${BASH_SOURCE[0]}")/job-history}"
 readonly container_label='com.harlanzw.desktop-runner'
 # One pnpm store shared by every container, so an ephemeral job resolves packages
 # from local disk instead of refetching them.
@@ -437,7 +439,7 @@ record_completed_job() {
   local pool="$3"
   local reported_outcome="$4"
   local job_file="$state_dir/jobs/$container_name.json"
-  local outcome event recent_file="$state_dir/recent/jobs.ndjson"
+  local outcome event
 
   [[ -r "$job_file" ]] || return 0
   case "$reported_outcome" in
@@ -455,12 +457,9 @@ record_completed_job() {
     '. + { completedAt: $completedAt, outcome: $outcome, pool: $pool, repository: $repository }' \
     "$job_file")"
 
-  (
-    flock --exclusive 9
-    printf '%s\n' "$event" >>"$recent_file"
-    tail --lines 40 "$recent_file" >"$recent_file.$$"
-    mv --force "$recent_file.$$" "$recent_file"
-  ) 9>"$state_dir/recent/jobs.lock"
+  if ! printf '%s\n' "$event" | "$history_writer" import "$history_root"; then
+    log 'Completed Runner job history write failed'
+  fi
   rm --force "$job_file"
 }
 
@@ -473,7 +472,7 @@ run_status_publisher() {
   fi
 
   while [[ ! -f "$state_dir/shutdown" ]]; do
-    "$status_publisher" "$state_dir" "$output_file" \
+    "$status_publisher" "$state_dir" "$output_file" "$history_root" \
       || log 'Runner status snapshot failed'
     sleep "$status_interval_seconds"
   done
@@ -948,6 +947,11 @@ main() {
   require_command jq
   require_command flock
 
+  if [[ ! -x "$history_writer" ]]; then
+    log "Runner job history writer is unavailable: $history_writer"
+    return 1
+  fi
+
   if ! docker image inspect "$runner_image" >/dev/null 2>&1; then
     log "Runner image is unavailable; build $runner_image from infra/github-runner."
     return 1
@@ -961,7 +965,7 @@ main() {
   # read from the real reservations.
   state_dir="$state_root"
   rm --recursive --force "$state_dir"
-  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline" "$state_dir/jobs" "$state_dir/queued" "$state_dir/recent"
+  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline" "$state_dir/jobs" "$state_dir/queued"
   chmod 0750 "$state_dir"
   scale_pipe="$state_dir/scale"
   cp "$config_file" "$published_config"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -143,6 +143,7 @@ PATH="$test_root/bin:$PATH" \
 XDG_RUNTIME_DIR="$test_root/runtime" \
 CREDENTIALS_DIRECTORY="$test_root/credentials" \
 HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
 HARLAN_DESKTOP_RUNNER_BURST_IDLE_SECONDS=30 \
@@ -181,6 +182,11 @@ fi
 if ! jq --exit-status '.recentJobs | any(.name == "first" and .outcome == "Succeeded")' "$test_root/calls/status.json" >/dev/null; then
   cat "$test_root/calls/status.json"
   printf 'Expected completed jobs in the published runner status.\n' >&2
+  exit 1
+fi
+
+if ! jq --exit-status '.completed == 1' "$test_root/history/daily/"*.json >/dev/null; then
+  printf 'Expected completed jobs to persist outside runtime state.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Runtime storage keeps only 40 completed Runner jobs. Restarts and later jobs erase older savings data.

This stores 90 days of raw Runner jobs and permanent UTC daily totals. It adds an idempotent GitHub Actions backfill and publishes version 3 status snapshots.

### 📝 Migration

Install `supervisor`, `publish-status`, `job-history`, and `backfill-job-history`. Run the 90 day backfill before restarting `hogwild-github-runner.service`.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).