### PR TITLE
fix(runner): use the Hogwild CPU burst threshold

### DIFF
--- a/infra/github-runner/hogwild-github-runner.service
+++ b/infra/github-runner/hogwild-github-runner.service
@@ -17,7 +17,7 @@ RuntimeDirectoryMode=0750
 Environment=HOME=/var/lib/github-runner
 Environment=XDG_RUNTIME_DIR=/run/github-runner
 Environment=HARLAN_DESKTOP_RUNNER_CONFIG=/var/lib/github-runner/config/runners.conf
-Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=20
+Environment=HARLAN_DESKTOP_RUNNER_CPU_BUDGET=32
 Environment=HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=24
 Environment=HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=6
 Environment=HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=60


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hogwild has 24 CPUs, but runner admission stopped at 20. Jobs queued while current use sat near six CPUs. Raise the threshold to 32 so CPU quotas can overcommit, while memory admission keeps its existing limits.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.