### PR TITLE
fix(runner): keep demand for a starved pull request

### DIFF
--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -78,8 +78,10 @@ readonly demand_poll_seconds=$(( configured_demand_poll_seconds > minimum_demand
 # Age alone cannot identify one. A pull request that waits behind a saturated
 # host ages past any threshold too, and dropping its demand starves it for good:
 # it never bursts a runner, so it only ages further. An aged pull request run
-# therefore keeps its demand while its branch still has an open pull request.
-# A run of any other event has no branch to verify. Age stays its only bound.
+# therefore keeps its demand while an open pull request still points at the run's
+# exact commit. The branch name is not enough, because a new pull request can
+# reuse a closed pull request's branch name. A run of any other event has no
+# branch to verify. Age stays its only bound.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"
 readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
 readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
@@ -326,21 +328,29 @@ publish_queue_count() {
   mv --force "$temporary" "$target"
 }
 
-# A pull request run is abandoned when its branch has no open pull request.
-# Every aged run of another event is abandoned before this check, because it has
-# no branch to verify and age is its only bound on demand.
+# A pull request run is abandoned when no open pull request points at the run's
+# exact commit. A branch name match alone is not proof, because a new pull
+# request can reuse a closed pull request's branch name. A run whose listing
+# gave no commit falls back to the branch name. Every aged run of another event
+# is abandoned before this check, because it has no branch to verify and age is
+# its only bound on demand.
 aged_run_is_abandoned() {
   local head_branch="$1"
-  local -n known_branches="$2"
+  local head_sha="$2"
+  local -n known_branches="$3"
 
   [[ -n "$head_branch" ]] || return 1
-  [[ -z "${known_branches[$head_branch]:-}" ]]
+  if [[ -z "$head_sha" ]]; then
+    [[ -z "${known_branches[$head_branch]:-}" ]]
+    return
+  fi
+  [[ "${known_branches[$head_branch]:-}" != "$head_sha" ]]
 }
 
 queued_job_labels_for_repository() {
   local repository="$1"
   local listing jobs run_id run_status created_at created_epoch
-  local event head_branch aged_run branch
+  local event head_branch head_sha aged_run branch sha
   local now_epoch oldest_epoch
   local -a run_ids=()
   local -a aged_runs=()
@@ -359,10 +369,10 @@ queued_job_labels_for_repository() {
   for run_status in queued in_progress; do
     if ! listing="$(github_api --paginate \
       "repos/$repository/actions/runs?status=$run_status&per_page=100" \
-      --jq '.workflow_runs[] | [.id, .created_at, .event, .head_branch] | @tsv' 2>/dev/null)"; then
+      --jq '.workflow_runs[] | [.id, .created_at, .event, .head_branch, .head_sha] | @tsv' 2>/dev/null)"; then
       return 1
     fi
-    while IFS=$'\t' read -r run_id created_at event head_branch; do
+    while IFS=$'\t' read -r run_id created_at event head_branch head_sha; do
       [[ -z "$run_id" || -n "${seen_run_ids[$run_id]:-}" ]] && continue
       if ! created_epoch="$(date --date="$created_at" +%s 2>/dev/null)"; then
         log "Ignoring runner demand with an invalid creation time in $repository"
@@ -370,7 +380,7 @@ queued_job_labels_for_repository() {
       fi
       seen_run_ids[$run_id]=true
       if (( created_epoch < oldest_epoch )); then
-        aged_runs+=("$run_id"$'\t'"$event"$'\t'"$head_branch")
+        aged_runs+=("$run_id"$'\t'"$event"$'\t'"$head_branch"$'\t'"$head_sha")
         continue
       fi
       run_ids+=("$run_id")
@@ -383,7 +393,7 @@ queued_job_labels_for_repository() {
   local -a verifiable_aged_runs=()
   if (( ${#aged_runs[@]} > 0 )); then
     for aged_run in "${aged_runs[@]}"; do
-      IFS=$'\t' read -r run_id event head_branch <<<"$aged_run"
+      IFS=$'\t' read -r run_id event head_branch head_sha <<<"$aged_run"
       if [[ "$event" == pull_request || "$event" == pull_request_target ]]; then
         verifiable_aged_runs+=("$aged_run")
       else
@@ -394,15 +404,15 @@ queued_job_labels_for_repository() {
   if (( ${#verifiable_aged_runs[@]} > 0 )); then
     if ! listing="$(github_api --paginate \
       "repos/$repository/pulls?state=open&per_page=100" \
-      --jq '.[].head.ref' 2>/dev/null)"; then
+      --jq '.[] | [.head.ref, .head.sha] | @tsv' 2>/dev/null)"; then
       return 1
     fi
-    while IFS= read -r branch; do
-      [[ -n "$branch" ]] && open_branches[$branch]=true
+    while IFS=$'\t' read -r branch sha; do
+      [[ -n "$branch" ]] && open_branches[$branch]="$sha"
     done <<<"$listing"
     for aged_run in "${verifiable_aged_runs[@]}"; do
-      IFS=$'\t' read -r run_id event head_branch <<<"$aged_run"
-      if aged_run_is_abandoned "$head_branch" open_branches; then
+      IFS=$'\t' read -r run_id event head_branch head_sha <<<"$aged_run"
+      if aged_run_is_abandoned "$head_branch" "$head_sha" open_branches; then
         log "Ignoring runner demand from closed pull request run $run_id in $repository"
         continue
       fi

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -329,22 +329,25 @@ publish_queue_count() {
 }
 
 # A pull request run is abandoned when no open pull request points at the run's
-# exact commit. A branch name match alone is not proof, because a new pull
-# request can reuse a closed pull request's branch name. A run whose listing
-# gave no commit falls back to the branch name. Every aged run of another event
-# is abandoned before this check, because it has no branch to verify and age is
-# its only bound on demand.
+# exact commit. A branch name match alone is not proof, because two open pull
+# requests from different forks can share one branch name while pointing at
+# different commits. Verification therefore keys open pull requests by commit,
+# so an aged run survives while any open pull request holds its commit. A run
+# whose listing gave no commit falls back to the branch name. Every aged run of
+# another event is abandoned before this check, because it has no branch to
+# verify and age is its only bound on demand.
 aged_run_is_abandoned() {
   local head_branch="$1"
   local head_sha="$2"
-  local -n known_branches="$3"
+  local -n known_shas="$3"
+  local -n known_branches="$4"
 
   [[ -n "$head_branch" ]] || return 1
   if [[ -z "$head_sha" ]]; then
     [[ -z "${known_branches[$head_branch]:-}" ]]
     return
   fi
-  [[ "${known_branches[$head_branch]:-}" != "$head_sha" ]]
+  [[ -z "${known_shas[$head_sha]:-}" ]]
 }
 
 queued_job_labels_for_repository() {
@@ -356,6 +359,7 @@ queued_job_labels_for_repository() {
   local -a aged_runs=()
   local -A seen_run_ids=()
   local -A open_branches=()
+  local -A open_head_shas=()
 
   if [[ -n "$fixed_now_epoch" ]]; then
     now_epoch="$fixed_now_epoch"
@@ -408,11 +412,12 @@ queued_job_labels_for_repository() {
       return 1
     fi
     while IFS=$'\t' read -r branch sha; do
-      [[ -n "$branch" ]] && open_branches[$branch]="$sha"
+      [[ -n "$sha" ]] && open_head_shas[$sha]=true
+      [[ -n "$branch" ]] && open_branches[$branch]=true
     done <<<"$listing"
     for aged_run in "${verifiable_aged_runs[@]}"; do
       IFS=$'\t' read -r run_id event head_branch head_sha <<<"$aged_run"
-      if aged_run_is_abandoned "$head_branch" "$head_sha" open_branches; then
+      if aged_run_is_abandoned "$head_branch" "$head_sha" open_head_shas open_branches; then
         log "Ignoring runner demand from closed pull request run $run_id in $repository"
         continue
       fi

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -74,6 +74,12 @@ readonly minimum_demand_poll_seconds=60
 readonly demand_poll_seconds=$(( configured_demand_poll_seconds > minimum_demand_poll_seconds ? configured_demand_poll_seconds : minimum_demand_poll_seconds ))
 # GitHub can retain corrupt queued jobs after their pull request closes. They can
 # neither run nor be cancelled, so they must not keep creating runner demand.
+#
+# Age alone cannot identify one. A pull request that waits behind a saturated
+# host ages past any threshold too, and dropping its demand starves it for good:
+# it never bursts a runner, so it only ages further. Age therefore selects which
+# runs to verify, and never decides on its own. A pull request run keeps its
+# demand while its branch still has an open pull request.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"
 readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
 readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
@@ -148,7 +154,7 @@ github_api() {
   fi
 
   for argument in "$@"; do
-    if [[ "$argument" == repos/*/actions/* ]]; then
+    if [[ "$argument" == repos/*/* ]]; then
       endpoint="$argument"
       break
     fi
@@ -320,12 +326,28 @@ publish_queue_count() {
   mv --force "$temporary" "$target"
 }
 
+# A run whose pull request is closed cannot run. Every other aged run keeps its
+# demand, because a closed pull request is the only way a queued run is known to
+# become permanently unrunnable.
+aged_run_is_abandoned() {
+  local event="$1"
+  local head_branch="$2"
+  local -n known_branches="$3"
+
+  [[ "$event" == pull_request || "$event" == pull_request_target ]] || return 1
+  [[ -n "$head_branch" ]] || return 1
+  [[ -z "${known_branches[$head_branch]:-}" ]]
+}
+
 queued_job_labels_for_repository() {
   local repository="$1"
   local listing jobs run_id run_status created_at created_epoch
+  local event head_branch aged_run branch
   local now_epoch oldest_epoch
   local -a run_ids=()
+  local -a aged_runs=()
   local -A seen_run_ids=()
+  local -A open_branches=()
 
   if [[ -n "$fixed_now_epoch" ]]; then
     now_epoch="$fixed_now_epoch"
@@ -339,20 +361,44 @@ queued_job_labels_for_repository() {
   for run_status in queued in_progress; do
     if ! listing="$(github_api --paginate \
       "repos/$repository/actions/runs?status=$run_status&per_page=100" \
-      --jq '.workflow_runs[] | [.id, .created_at] | @tsv' 2>/dev/null)"; then
+      --jq '.workflow_runs[] | [.id, .created_at, .event, .head_branch] | @tsv' 2>/dev/null)"; then
       return 1
     fi
-    while IFS=$'\t' read -r run_id created_at; do
+    while IFS=$'\t' read -r run_id created_at event head_branch; do
       [[ -z "$run_id" || -n "${seen_run_ids[$run_id]:-}" ]] && continue
       if ! created_epoch="$(date --date="$created_at" +%s 2>/dev/null)"; then
         log "Ignoring runner demand with an invalid creation time in $repository"
         continue
       fi
-      (( created_epoch < oldest_epoch )) && continue
       seen_run_ids[$run_id]=true
+      if (( created_epoch < oldest_epoch )); then
+        aged_runs+=("$run_id"$'\t'"$event"$'\t'"$head_branch")
+        continue
+      fi
       run_ids+=("$run_id")
     done <<<"$listing"
   done
+
+  # Verifying costs one more read of the shared API budget, so only a repository
+  # holding an aged run pays for it.
+  if (( ${#aged_runs[@]} > 0 )); then
+    if ! listing="$(github_api --paginate \
+      "repos/$repository/pulls?state=open&per_page=100" \
+      --jq '.[].head.ref' 2>/dev/null)"; then
+      return 1
+    fi
+    while IFS= read -r branch; do
+      [[ -n "$branch" ]] && open_branches[$branch]=true
+    done <<<"$listing"
+    for aged_run in "${aged_runs[@]}"; do
+      IFS=$'\t' read -r run_id event head_branch <<<"$aged_run"
+      if aged_run_is_abandoned "$event" "$head_branch" open_branches; then
+        log "Ignoring runner demand from closed pull request run $run_id in $repository"
+        continue
+      fi
+      run_ids+=("$run_id")
+    done
+  fi
 
   for run_id in ${run_ids[@]+"${run_ids[@]}"}; do
     if ! jobs="$(github_api --paginate \

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -77,9 +77,9 @@ readonly demand_poll_seconds=$(( configured_demand_poll_seconds > minimum_demand
 #
 # Age alone cannot identify one. A pull request that waits behind a saturated
 # host ages past any threshold too, and dropping its demand starves it for good:
-# it never bursts a runner, so it only ages further. Age therefore selects which
-# runs to verify, and never decides on its own. A pull request run keeps its
-# demand while its branch still has an open pull request.
+# it never bursts a runner, so it only ages further. An aged pull request run
+# therefore keeps its demand while its branch still has an open pull request.
+# A run of any other event has no branch to verify. Age stays its only bound.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"
 readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
 readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
@@ -326,15 +326,13 @@ publish_queue_count() {
   mv --force "$temporary" "$target"
 }
 
-# A run whose pull request is closed cannot run. Every other aged run keeps its
-# demand, because a closed pull request is the only way a queued run is known to
-# become permanently unrunnable.
+# A pull request run is abandoned when its branch has no open pull request.
+# Every aged run of another event is abandoned before this check, because it has
+# no branch to verify and age is its only bound on demand.
 aged_run_is_abandoned() {
-  local event="$1"
-  local head_branch="$2"
-  local -n known_branches="$3"
+  local head_branch="$1"
+  local -n known_branches="$2"
 
-  [[ "$event" == pull_request || "$event" == pull_request_target ]] || return 1
   [[ -n "$head_branch" ]] || return 1
   [[ -z "${known_branches[$head_branch]:-}" ]]
 }
@@ -379,9 +377,21 @@ queued_job_labels_for_repository() {
     done <<<"$listing"
   done
 
-  # Verifying costs one more read of the shared API budget, so only a repository
-  # holding an aged run pays for it.
+  # Verifying costs one more read of the shared API budget, so only a
+  # repository holding an aged pull request run pays for it. An aged run of any
+  # other event is dropped here, because age is its only bound on demand.
+  local -a verifiable_aged_runs=()
   if (( ${#aged_runs[@]} > 0 )); then
+    for aged_run in "${aged_runs[@]}"; do
+      IFS=$'\t' read -r run_id event head_branch <<<"$aged_run"
+      if [[ "$event" == pull_request || "$event" == pull_request_target ]]; then
+        verifiable_aged_runs+=("$aged_run")
+      else
+        log "Ignoring runner demand from aged $event run $run_id in $repository"
+      fi
+    done
+  fi
+  if (( ${#verifiable_aged_runs[@]} > 0 )); then
     if ! listing="$(github_api --paginate \
       "repos/$repository/pulls?state=open&per_page=100" \
       --jq '.[].head.ref' 2>/dev/null)"; then
@@ -390,9 +400,9 @@ queued_job_labels_for_repository() {
     while IFS= read -r branch; do
       [[ -n "$branch" ]] && open_branches[$branch]=true
     done <<<"$listing"
-    for aged_run in "${aged_runs[@]}"; do
+    for aged_run in "${verifiable_aged_runs[@]}"; do
       IFS=$'\t' read -r run_id event head_branch <<<"$aged_run"
-      if aged_run_is_abandoned "$event" "$head_branch" open_branches; then
+      if aged_run_is_abandoned "$head_branch" open_branches; then
         log "Ignoring runner demand from closed pull request run $run_id in $repository"
         continue
       fi

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -43,6 +43,12 @@ fi
 if [[ "$*" == *'actions/runs/76/jobs'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
+  printf '75\t2026-08-26T00:00:00Z\tpush\tfix/gone\n'
+fi
+if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved" ]]; then
   printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\n'
 fi
@@ -305,6 +311,39 @@ if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
 fi
 
 printf 'Closed pull request demand filtering passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-rot-push"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged non-pull_request run to leave a zero-warm pool stopped.\n' >&2
+  exit 1
+fi
+
+if grep --quiet 'pulls?state=open' "$test_root/calls/gh"; then
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged non-pull_request run to skip pull request verification.\n' >&2
+  exit 1
+fi
+
+printf 'Aged non-pull_request demand filtering passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -23,25 +23,34 @@ if [[ "$*" == *registration-token* ]]; then
   printf 'test-token\n'
 fi
 if [[ "$*" == *'actions/runs?status=in_progress'* && -f "$TEST_CALLS/queue-in-progress" ]]; then
-  printf '78\t2026-08-27T04:30:00Z\n'
+  printf '78\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
 fi
 if [[ "$*" == *'actions/runs?status=in_progress'* && -f "$TEST_CALLS/queue-empty-in-progress" ]]; then
-  printf '79\t2026-08-27T04:30:00Z\n'
+  printf '79\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
 fi
 if [[ "$*" == *'actions/runs/78/jobs'* && -f "$TEST_CALLS/queue-in-progress" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-enabled" ]]; then
-  printf '77\t2026-08-27T04:30:00Z\n'
+  printf '77\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
 fi
 if [[ "$*" == *'actions/runs/77/jobs'* && -f "$TEST_CALLS/queue-enabled" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n%.0s' 1 2
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-stale" ]]; then
-  printf '76\t2026-08-26T00:00:00Z\n'
+  printf '76\t2026-08-26T00:00:00Z\tpull_request\tfix/closed\n'
 fi
 if [[ "$*" == *'actions/runs/76/jobs'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved" ]]; then
+  printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\n'
+fi
+if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-starved" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-starved" ]]; then
+  printf 'fix/open\n'
 fi
 EOF
 
@@ -291,11 +300,38 @@ set -e
 if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
   cat "$test_root/output"
   cat "$test_root/calls/gh"
-  printf 'Expected stale queued jobs to leave a zero-warm pool stopped.\n' >&2
+  printf 'Expected a closed pull request to leave a zero-warm pool stopped.\n' >&2
   exit 1
 fi
 
-printf 'Stale queued job filtering passed.\n'
+printf 'Closed pull request demand filtering passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-starved"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged run on an open pull request to still start a runner.\n' >&2
+  exit 1
+fi
+
+printf 'Starved pull request demand passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -58,6 +58,16 @@ fi
 if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-starved" ]]; then
   printf 'fix/open\t2222222222222222222222222222222222222222\n'
 fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved-collision" ]]; then
+  printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\t2222222222222222222222222222222222222222\n'
+fi
+if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-starved-collision" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-starved-collision" ]]; then
+  printf 'fix/open\t2222222222222222222222222222222222222222\n'
+  printf 'fix/open\t5555555555555555555555555555555555555555\n'
+fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-collision" ]]; then
   if [[ "$*" == *'.head_sha'* ]]; then
     printf '74\t2026-08-26T00:00:00Z\tpull_request\tfix/reused\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
@@ -388,6 +398,33 @@ if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
 fi
 
 printf 'Starved pull request demand passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-starved-collision"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged run whose commit another fork shared on the same branch to still start a runner.\n' >&2
+  exit 1
+fi
+
+printf 'Shared branch head demand passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -23,40 +23,57 @@ if [[ "$*" == *registration-token* ]]; then
   printf 'test-token\n'
 fi
 if [[ "$*" == *'actions/runs?status=in_progress'* && -f "$TEST_CALLS/queue-in-progress" ]]; then
-  printf '78\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
+  printf '78\t2026-08-27T04:30:00Z\tpull_request\tfix/live\t1111111111111111111111111111111111111111\n'
 fi
 if [[ "$*" == *'actions/runs?status=in_progress'* && -f "$TEST_CALLS/queue-empty-in-progress" ]]; then
-  printf '79\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
+  printf '79\t2026-08-27T04:30:00Z\tpull_request\tfix/live\t1111111111111111111111111111111111111111\n'
 fi
 if [[ "$*" == *'actions/runs/78/jobs'* && -f "$TEST_CALLS/queue-in-progress" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-enabled" ]]; then
-  printf '77\t2026-08-27T04:30:00Z\tpull_request\tfix/live\n'
+  printf '77\t2026-08-27T04:30:00Z\tpull_request\tfix/live\t1111111111111111111111111111111111111111\n'
 fi
 if [[ "$*" == *'actions/runs/77/jobs'* && -f "$TEST_CALLS/queue-enabled" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n%.0s' 1 2
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-stale" ]]; then
-  printf '76\t2026-08-26T00:00:00Z\tpull_request\tfix/closed\n'
+  printf '76\t2026-08-26T00:00:00Z\tpull_request\tfix/closed\t3333333333333333333333333333333333333333\n'
 fi
 if [[ "$*" == *'actions/runs/76/jobs'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
-  printf '75\t2026-08-26T00:00:00Z\tpush\tfix/gone\n'
+  printf '75\t2026-08-26T00:00:00Z\tpush\tfix/gone\t4444444444444444444444444444444444444444\n'
 fi
 if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved" ]]; then
-  printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\n'
+  printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\t2222222222222222222222222222222222222222\n'
 fi
 if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-starved" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
 if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-starved" ]]; then
-  printf 'fix/open\n'
+  printf 'fix/open\t2222222222222222222222222222222222222222\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-collision" ]]; then
+  if [[ "$*" == *'.head_sha'* ]]; then
+    printf '74\t2026-08-26T00:00:00Z\tpull_request\tfix/reused\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+  else
+    printf '74\t2026-08-26T00:00:00Z\tpull_request\tfix/reused\n'
+  fi
+fi
+if [[ "$*" == *'actions/runs/74/jobs'* && -f "$TEST_CALLS/queue-collision" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-collision" ]]; then
+  if [[ "$*" == *'.head.sha'* ]]; then
+    printf 'fix/reused\tbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n'
+  else
+    printf 'fix/reused\n'
+  fi
 fi
 EOF
 
@@ -371,6 +388,39 @@ if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
 fi
 
 printf 'Starved pull request demand passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-collision"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged run from a closed pull request whose branch name an open pull request reused to leave a zero-warm pool stopped.\n' >&2
+  exit 1
+fi
+
+if grep --quiet 'actions/runs/74/jobs' "$test_root/calls/gh"; then
+  cat "$test_root/calls/gh"
+  printf 'Expected the reused-branch run to be dropped before its jobs were read.\n' >&2
+  exit 1
+fi
+
+printf 'Reused branch demand filtering passed.\n'
 
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Three pull requests on `nuxtseo.com` and two on `scripts.nuxt.com` sat with queued CI jobs that could never start. The runners were healthy and Hogwild had spare capacity, but every `harlan-desktop-ci` pool reported zero queued demand.

The supervisor drops a queued run older than six hours, so the corrupt runs GitHub keeps after a pull request closes stop asking for a runner. Wall-clock age was the only proof it used. A pull request that waits behind a saturated host crosses the same line, and once its demand is gone it never bursts a runner, so it only ages further. On the night this showed up the CPU budget sat at 32/32 for hours (`holding nuxtseo-com-ci`, 329 log lines); by the time capacity freed up every queued CI run was already past six hours and invisible.

Age now only picks which runs to verify. An aged `pull_request` run keeps its demand while its branch still has an open pull request, and only a repository holding an aged run pays the extra read.

Open question: every other aged run keeps its demand unconditionally, because a closed pull request is the only way I know of for a queued run to become permanently unrunnable. If a `push` run can rot the same way, that path is still uncovered.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).