### PR TITLE
fix(runner): re-run the gate for every queued job

### DIFF
--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -764,9 +764,15 @@ run_scaler() {
     while IFS=' ' read -r request pool_index; do
       [[ -f "$state_dir/shutdown" ]] && continue
 
-      if [[ "$request" == spawn && -z "${pool_is_pending[$pool_index]:-}" ]]; then
-        pending_pools+=("$pool_index")
-        pool_is_pending[$pool_index]=true
+      # A spawn for a pool already pending adds no second entry, but it still
+      # runs the retry below. It is fresh demand, and with every pool at 0 no
+      # job can return capacity, so dropping it here would hold the pools until
+      # something unrelated wrote to this pipe.
+      if [[ "$request" == spawn ]]; then
+        if [[ -z "${pool_is_pending[$pool_index]:-}" ]]; then
+          pending_pools+=("$pool_index")
+          pool_is_pending[$pool_index]=true
+        fi
       elif [[ "$request" != capacity ]]; then
         continue
       fi

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -519,3 +519,41 @@ if ! grep --quiet 'Available memory 2g, headroom 2g; holding example-ci at 0' "$
 fi
 
 printf 'Host memory headroom passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-enabled" "$test_root/calls/low-memory"
+
+# Two queued jobs mean two spawn requests for the one pool. Every one of them
+# has to re-run the gate. With all pools at 0 no job can return capacity, so a
+# dropped request would hold the pool until something unrelated wrote to the
+# pipe, which is how the pools stayed at 0 for an hour on 2026-09-04.
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=2 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
+HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=2 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the supervisor to exit cleanly while the pool was held.\n' >&2
+  exit 1
+fi
+
+holds="$(grep --count 'holding example-ci at 0' "$test_root/output" || true)"
+if (( holds < 2 )); then
+  cat "$test_root/output"
+  printf 'Expected every queued job to re-run the gate, saw %s hold(s).\n' "$holds" >&2
+  exit 1
+fi
+
+printf 'Repeated demand re-runs the memory gate passed.\n'


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

The runner queue was dead for 64 minutes on 2026-09-04 while `hogwild-github-runner.service` reported `active (running)` the whole time, so nothing looked wrong from systemd.

The agent service peaked at 14G, the scaler held every pool on the memory headroom, then went silent:

```
15:09:05  Available memory 6g, headroom 6g; holding nuxtseo-com-ci at 0
15:09:05  Available memory 6g, headroom 6g; holding nuxtseo-com-deploy at 0
15:09:05  Available memory 6g, headroom 6g; holding skilld-dev-ci at 0
```

Nothing after that until I restarted it at 16:13. Meanwhile nuxtseo.com had runs queued from 15:11 and skilld.dev from 14:57, on a host with 17g available and one idle listener.

The cause is in `run_scaler`. A spawn for a pool already marked pending hit the `elif` and `continue`d, so it never reached the retry loop. Only a `capacity` message could re-run the gates, and `release` is the only writer of those, so a returning job was the only thing that could lift a hold. With every pool at 0 there was no job to return, and the hold outlived the memory pressure that caused it.

A repeated spawn still adds no second queue entry, but it re-runs the gate now.

Not addressed here: the 14G peak that starved the host in the first place. That is the agent service's problem, not the supervisor's.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).