### PR TITLE
fix(runner): reserve capacity for deploys

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -17,6 +17,9 @@ The supervisor polls queued GitHub Actions jobs by runner label.
 
 It reserves host capacity before it registers a runner.
 
+Pending deploys reserve the next available capacity. CI and light pools wait
+until the oldest deploy fits and starts.
+
 Workflow shells with no jobs create no demand.
 
 A warm listener remains optional for a pool that needs lower startup latency.

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -775,7 +775,7 @@ run_scaler() {
   local request pool_index container_name
   local burst_counter=0
   local slug live spent spent_memory available_memory hold_reason
-  local pending_pool pending_count attempt candidate priority_index
+  local pending_pool pending_count attempt candidate priority_index queued_demand
   local -a pending_pools=()
   local -A pool_is_pending=()
 
@@ -817,6 +817,23 @@ run_scaler() {
         if (( live >= pool_max[pending_pool] )); then
           unset 'pool_is_pending[$pending_pool]'
           continue
+        fi
+
+        # A zero-warm pool has no listeners, so its published queued count is
+        # its only demand. A run cancelled while this entry sat held leaves the
+        # count at zero, and admitting the entry would burst an empty runner
+        # that reserves its share until the idle reaper returns it. Drop the
+        # stale entry so freed capacity goes to the next pool.
+        if (( pool_warm[pending_pool] == 0 )); then
+          queued_demand=''
+          if [[ -r "$state_dir/queued/$slug" ]]; then
+            read -r queued_demand <"$state_dir/queued/$slug" || queued_demand=''
+          fi
+          if [[ "$queued_demand" == 0 ]]; then
+            unset 'pool_is_pending[$pending_pool]'
+            log "Dropping held demand for $slug; its queued count returned to zero"
+            continue
+          fi
         fi
 
         hold_reason=''

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -127,6 +127,7 @@ declare -a pool_memory_swap=()
 # The unsuffixed reservation goes to Docker. Only this integer form is summed.
 declare -a pool_memory_reservation_gib=()
 declare -a pool_slug=()
+declare -a pool_is_deploy=()
 
 # One entry per repository, however many pools it owns. Pruning is per
 # repository, so a repository with two pools must not be pruned twice.
@@ -251,6 +252,11 @@ read_config() {
     pool_memory_swap+=("$memory_swap")
     pool_memory_reservation_gib+=("$memory_reservation_gib")
     pool_slug+=("$(pool_slug_for "$repository" "$label")")
+    if [[ ",$label," == *,harlan-desktop-deploy,* ]]; then
+      pool_is_deploy+=(1)
+    else
+      pool_is_deploy+=(0)
+    fi
   done <"$config_file"
 
   if (( ${#pool_repository[@]} == 0 )); then
@@ -455,10 +461,14 @@ queued_jobs_for_pool() {
 
 run_demand_poller() {
   local pool_index repository jobs queued idle deficit request
+  local -a deploy_requests=()
+  local -a standard_requests=()
   local -A repository_jobs=()
   local -A repository_result=()
 
   while [[ ! -f "$state_dir/shutdown" ]]; do
+    deploy_requests=()
+    standard_requests=()
     repository_jobs=()
     repository_result=()
     for pool_index in "${!pool_repository[@]}"; do
@@ -482,8 +492,17 @@ run_demand_poller() {
       idle="$(count_idle_burst "$pool_index")"
       deficit=$(( queued - idle ))
       for (( request = 0; request < deficit; request++ )); do
-        printf 'spawn %s\n' "$pool_index" >"$scale_pipe"
+        if (( pool_is_deploy[pool_index] )); then
+          deploy_requests+=("$pool_index")
+        else
+          standard_requests+=("$pool_index")
+        fi
       done
+    done
+    # Send the complete scan as deploys first. Config order must not decide
+    # whether production work can reserve capacity.
+    for pool_index in ${deploy_requests[@]+"${deploy_requests[@]}"} ${standard_requests[@]+"${standard_requests[@]}"}; do
+      printf 'spawn %s\n' "$pool_index" >"$scale_pipe"
     done
     sleep "$demand_poll_seconds"
   done
@@ -755,8 +774,8 @@ run_burst_slot() {
 run_scaler() {
   local request pool_index container_name
   local burst_counter=0
-  local slug live spent spent_memory available_memory
-  local pending_pool pending_count attempt
+  local slug live spent spent_memory available_memory hold_reason
+  local pending_pool pending_count attempt candidate priority_index
   local -a pending_pools=()
   local -A pool_is_pending=()
 
@@ -779,10 +798,20 @@ run_scaler() {
 
       # Try each denied pool once. A pool that still cannot fit moves to the
       # back, so repeated capacity changes distribute slots across repositories.
+      # The oldest pending deploy goes first. Once denied, it stays first and
+      # reserves future capacity by stopping lower-priority admissions.
       pending_count="${#pending_pools[@]}"
       for (( attempt = 0; attempt < pending_count; attempt++ )); do
-        pending_pool="${pending_pools[0]}"
-        pending_pools=("${pending_pools[@]:1}")
+        priority_index=0
+        for candidate in "${!pending_pools[@]}"; do
+          if (( pool_is_deploy[pending_pools[candidate]] )); then
+            priority_index="$candidate"
+            break
+          fi
+        done
+        pending_pool="${pending_pools[$priority_index]}"
+        unset "pending_pools[$priority_index]"
+        pending_pools=("${pending_pools[@]}")
         slug="${pool_slug[$pending_pool]}"
         live=$(( pool_warm[pending_pool] + $(count_markers "$state_dir/burst/$slug") ))
         if (( live >= pool_max[pending_pool] )); then
@@ -790,30 +819,31 @@ run_scaler() {
           continue
         fi
 
+        hold_reason=''
         spent="$(sum_markers "$state_dir/spend")"
         if (( spent + pool_cpus[pending_pool] > cpu_budget )); then
-          log "CPU in flight $spent, burst threshold $cpu_budget; holding $slug at $live"
-          pending_pools+=("$pending_pool")
-          continue
+          hold_reason="CPU in flight $spent, burst threshold $cpu_budget"
+        else
+          # Checked after CPU and never merged with it. A host can have cores to
+          # spare and no memory to back them, which is the case this exists for.
+          spent_memory="$(sum_markers "$state_dir/spend-memory")"
+          if (( spent_memory + pool_memory_reservation_gib[pending_pool] > memory_budget_gib )); then
+            hold_reason="Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g"
+          else
+            available_memory="$(host_available_memory_gib)"
+            if [[ ! "$available_memory" =~ ^[0-9]+$ ]]; then
+              hold_reason='Available memory is unknown'
+            elif (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
+              hold_reason="Available memory ${available_memory}g, headroom ${memory_headroom_gib}g"
+            fi
+          fi
         fi
-
-        # Checked after CPU and never merged with it. A host can have cores to
-        # spare and no memory to back them, which is the case this exists for.
-        spent_memory="$(sum_markers "$state_dir/spend-memory")"
-        if (( spent_memory + pool_memory_reservation_gib[pending_pool] > memory_budget_gib )); then
-          log "Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g; holding $slug at $live"
-          pending_pools+=("$pending_pool")
-          continue
-        fi
-
-        available_memory="$(host_available_memory_gib)"
-        if [[ ! "$available_memory" =~ ^[0-9]+$ ]]; then
-          log "Available memory is unknown; holding $slug at $live"
-          pending_pools+=("$pending_pool")
-          continue
-        fi
-        if (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
-          log "Available memory ${available_memory}g, headroom ${memory_headroom_gib}g; holding $slug at $live"
+        if [[ -n "$hold_reason" ]]; then
+          log "$hold_reason; holding $slug at $live"
+          if (( pool_is_deploy[pending_pool] )); then
+            pending_pools=("$pending_pool" "${pending_pools[@]}")
+            break
+          fi
           pending_pools+=("$pending_pool")
           continue
         fi

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -3,7 +3,13 @@
 set -euo pipefail
 
 test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
+state_home="$(mktemp -d)"
+trap 'rm -rf "$test_root" "$state_home"' EXIT
+
+# Every invocation must point HARLAN_DESKTOP_RUNNER_HISTORY_DIR at the test
+# root. A write into the default history root lands here and fails the final
+# check, so the suite can never touch real runner history again.
+export XDG_STATE_HOME="$state_home"
 
 mkdir -p "$test_root/bin" "$test_root/runtime" "$test_root/calls" "$test_root/credentials"
 printf 'repository-token\n' >"$test_root/credentials/github-harlan-zw-token"
@@ -47,6 +53,28 @@ fi
 if [[ "$*" == *'actions/runs/73/jobs'* && -f "$TEST_CALLS/queue-priority" ]]; then
   printf 'self-hosted,harlan-desktop-deploy\n'
   printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-cancel" ]]; then
+  for _ in $(seq 1 50); do
+    [[ -f "$TEST_CALLS/warm-running" ]] && break
+    sleep 0.01
+  done
+  scans=0
+  [[ -f "$TEST_CALLS/cancel-scans" ]] && read -r scans <"$TEST_CALLS/cancel-scans"
+  scans=$(( scans + 1 ))
+  printf '%s\n' "$scans" >"$TEST_CALLS/cancel-scans"
+  if (( scans >= 2 )); then
+    touch "$TEST_CALLS/scanned-after-cancel"
+  fi
+  printf '73\t2026-08-27T04:30:00Z\tpush\tmain\t6666666666666666666666666666666666666666\n'
+fi
+if [[ "$*" == *'actions/runs/73/jobs'* && -f "$TEST_CALLS/queue-cancel" ]]; then
+  if [[ -f "$TEST_CALLS/scanned-after-cancel" ]]; then
+    printf 'self-hosted,harlan-desktop-ci\n'
+  else
+    printf 'self-hosted,harlan-desktop-deploy\n'
+    printf 'self-hosted,harlan-desktop-ci\n'
+  fi
 fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf '76\t2026-08-26T00:00:00Z\tpull_request\tfix/closed\t3333333333333333333333333333333333333333\n'
@@ -176,6 +204,12 @@ case "$command_name" in
     if (( attempts == 1 )); then
       touch "$TEST_CALLS/warm-running"
       printf 'Running job: first\n'
+      if [[ -f "$TEST_CALLS/hold-warm-job" ]]; then
+        for _ in $(seq 1 2000); do
+          [[ -f "$TEST_CALLS/scanned-after-cancel" ]] && break
+          sleep 0.05
+        done
+      fi
       sleep 0.2
       printf 'Job first completed with result: Succeeded\n'
       exit 0
@@ -585,6 +619,7 @@ PATH="$test_root/bin:$PATH" \
 XDG_RUNTIME_DIR="$test_root/runtime" \
 CREDENTIALS_DIRECTORY="$test_root/credentials" \
 HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
 HARLAN_DESKTOP_RUNNER_CPU_BUDGET=12 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=12 \
 HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
@@ -614,3 +649,54 @@ if grep --quiet --fixed-strings -- '-ci-burst-' "$test_root/calls/burst"; then
 fi
 
 printf 'Deploy priority passed.\n'
+
+# A deploy run cancelled while its burst request is held must release the
+# reservation. Scan one queues the deploy, scan two lists it gone, and only
+# then does the busy slot return capacity. CI has to be admitted on the freed
+# slot with no empty deploy burst in front of it. The second scan lands after
+# the 60 second demand poll floor, so this block runs longer than the others.
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-cancel" "$test_root/calls/hold-warm-job"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=12 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=12 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 70 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the cancelled deploy reservation to drain cleanly.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet -- '-ci-burst-' "$test_root/calls/burst" 2>/dev/null; then
+  cat "$test_root/output"
+  [[ -f "$test_root/calls/burst" ]] && cat "$test_root/calls/burst"
+  printf 'Expected CI to be admitted once the deploy demand vanished.\n' >&2
+  exit 1
+fi
+
+if grep --quiet -- '-deploy-burst-' "$test_root/calls/burst" 2>/dev/null; then
+  cat "$test_root/calls/burst"
+  printf 'Expected the cancelled deploy not to burst an empty runner.\n' >&2
+  exit 1
+fi
+
+printf 'Cancelled deploy reservation passed.\n'
+
+if [[ -n "$(find "$state_home" -mindepth 1 -print -quit)" ]]; then
+  find "$state_home"
+  printf 'Expected every invocation to keep job history inside the test root.\n' >&2
+  exit 1
+fi

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -37,6 +37,17 @@ fi
 if [[ "$*" == *'actions/runs/77/jobs'* && -f "$TEST_CALLS/queue-enabled" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n%.0s' 1 2
 fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-priority" ]]; then
+  for _ in $(seq 1 50); do
+    [[ -f "$TEST_CALLS/warm-running" ]] && break
+    sleep 0.01
+  done
+  printf '73\t2026-08-27T04:30:00Z\tpush\tmain\t6666666666666666666666666666666666666666\n'
+fi
+if [[ "$*" == *'actions/runs/73/jobs'* && -f "$TEST_CALLS/queue-priority" ]]; then
+  printf 'self-hosted,harlan-desktop-deploy\n'
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-stale" ]]; then
   printf '76\t2026-08-26T00:00:00Z\tpull_request\tfix/closed\t3333333333333333333333333333333333333333\n'
 fi
@@ -163,6 +174,7 @@ case "$command_name" in
     attempts=$(( attempts + 1 ))
     printf '%s\n' "$attempts" >"$attempts_file"
     if (( attempts == 1 )); then
+      touch "$TEST_CALLS/warm-running"
       printf 'Running job: first\n'
       sleep 0.2
       printf 'Job first completed with result: Succeeded\n'
@@ -557,3 +569,48 @@ if (( holds < 2 )); then
 fi
 
 printf 'Repeated demand re-runs the memory gate passed.\n'
+
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-priority"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-busy|1|1|4|1g|2g|3g
+harlan-zw/example|harlan-desktop-ci|0|1|4|1g|2g|3g
+harlan-zw/example|harlan-desktop-deploy|0|1|12|1g|2g|3g
+EOF
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=12 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=12 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected deploy priority scheduling to drain cleanly.\n' >&2
+  exit 1
+fi
+
+if [[ "$(<"$test_root/calls/burst")" != *-deploy-burst-* ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/burst"
+  printf 'Expected the pending deploy to receive released capacity first.\n' >&2
+  exit 1
+fi
+
+if grep --quiet --fixed-strings -- '-ci-burst-' "$test_root/calls/burst"; then
+  cat "$test_root/output"
+  cat "$test_root/calls/burst"
+  printf 'Expected CI admission to wait behind the pending deploy.\n' >&2
+  exit 1
+fi
+
+printf 'Deploy priority passed.\n'


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

On Hogwild, the 12 CPU deploy pool waited while smaller CI pools repeatedly took each freed slot. Deploy demand now goes first and reserves the next slot until it fits.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).