### PR TITLE
fix(runner): give skilld.dev CI a limit above its node heap

### DIFF
--- a/infra/github-runner/hogwild-runners.conf
+++ b/infra/github-runner/hogwild-runners.conf
@@ -6,6 +6,13 @@
 # already gives that repository 12g, so the same commit passed or failed purely
 # on which host claimed it. Its row here now carries the desktop's memory triple.
 
+# skilld.dev's `build` job hit the same wall on 2026-09-05. Its workflow sets
+# `NODE_OPTIONS: --max-old-space-size=8192`, so node may grow past the 7g limit
+# this file gave it, and the container killed it mid Nitro bundle with exit 129.
+# The desktop already gives it 12g, so the same commit passed or failed on which
+# host claimed the job. Its `harlan-desktop-ci` row now carries the desktop's
+# memory triple. Keep a container limit above the job's node heap ceiling.
+
 harlan-zw/nuxtseo.com|harlan-desktop-deploy,nuxtseo-deploy|0|1|12|13g|16g|20g
 harlan-zw/nuxtseo.com|harlan-desktop-ci,nuxtseo-ci|0|4|8|5g|9g|11g
 harlan-zw/nuxtseo.com|harlan-desktop-light|0|6|2|1g|2g|3g
@@ -15,7 +22,7 @@ harlan-zw/zhead.dev|harlan-desktop-ci|0|3|4|3g|6g|8g
 harlan-zw/scripts.nuxt.com|harlan-desktop-ci|0|2|4|3g|6g|8g
 harlan-zw/hogwild.harlanzw.com|harlan-desktop-ci|0|2|2|1g|2g|3g
 harlan-zw/hogwild.harlanzw.com|harlan-desktop-deploy|0|1|2|1g|2g|3g
-skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|4g|7g|9g
+skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|4g|12g|14g
 skilld-dev/skilld.dev|harlan-desktop-deploy|0|1|4|5g|7g|9g
 
 harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|2g|4g|5g


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

`skilld-dev/skilld.dev` PR #142 failed its `build` job twice with exit 129 and no build error, dying part way through the Nitro bundle. I chased it as a SIGHUP from the runner's no output watchdog, which is what the workflow comment there claims. That was wrong.

Exit 129 is the container memory limit. This file already records the same failure for `gscdump.com`, measured at 7.82 GiB peak against an 8g cap.

skilld.dev's build sets `NODE_OPTIONS: --max-old-space-size=8192`, so node is permitted to grow to 8g while this host capped the container at 7g. The heap ceiling sat above the hard limit, so a large enough bundle could only end one way.

`harlan-desktop-ci` is served by this host and by the desktop, and `runners.conf` already gives skilld.dev 12g there. So the same commit passed or failed on which host happened to claim the job. That is why #133 was green and #142 was red on the same day.

Its `harlan-desktop-ci` row now carries the desktop's memory triple, matching what gscdump.com got for the same reason.

I left the `harlan-desktop-deploy` row at 7g. The deploy job does not set an enlarged heap, so it has no ceiling to clear. Say if you would rather they moved together.

Worth a follow up, not in this PR: the comment in skilld.dev's `test.yml` attributes this to a 45 second no output watchdog and a heartbeat wrapper. The heartbeat was firing 19 seconds before the kill, so that explanation is wrong and will mislead the next person. I can correct it.

### 📝 Migration

The supervisor reads this file at runtime. Restart or reload `hogwild-github-runner.service` so the new limit applies to freshly started containers.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
