### PR TITLE
feat(nuxt-sentry): report Nitro scheduled task failures

### DIFF
--- a/packages/nuxt-sentry/README.md
+++ b/packages/nuxt-sentry/README.md
@@ -200,6 +200,23 @@ if (nuxtSentry.target._tag === 'enabled') {
 
 The same constant is still written to `runtimeConfig.public.nuxtSentry`, so code that already reads it keeps working.
 
+## Scheduled tasks
+
+Nitro's `runTask` calls no hook, so nothing can see a scheduled task run. A throwing task reaches Sentry, if at all, as an unattributed `scriptThrewException`. Wrap the task definition with `withSentryTask` to tag the Error Report with the task name. The error is rethrown, so the scheduler still sees the task fail.
+
+```ts
+import { withSentryTask } from '@harlan-zw/nuxt-sentry/server/task'
+
+export default withSentryTask(defineTask({
+  meta: { name: 'my:cron' },
+  async run() {
+    // ...
+  },
+}))
+```
+
+`withSentryTask` reports through `@sentry/cloudflare`, so it runs on a Cloudflare Workers preset only. It lives in its own subpath export, because the SDK-free `@harlan-zw/nuxt-sentry/server` barrel must keep resolving on Node, where that peer is not installed.
+
 ## Wide Events
 
 With `@harlan-zw/nuxt-wide-events` installed, two bridges are wired and neither package imports the other.

--- a/packages/nuxt-sentry/package.json
+++ b/packages/nuxt-sentry/package.json
@@ -31,13 +31,18 @@
     "./server": {
       "types": "./dist/runtime/server/index.d.ts",
       "import": "./dist/runtime/server/index.js"
+    },
+    "./server/task": {
+      "types": "./dist/runtime/server/task.d.ts",
+      "import": "./dist/runtime/server/task.js"
     }
   },
   "main": "./dist/module.mjs",
   "types": "./dist/types.d.mts",
   "typesVersions": {
     "*": {
-      "server": ["dist/runtime/server/index.d.ts"]
+      "server": ["dist/runtime/server/index.d.ts"],
+      "server/task": ["dist/runtime/server/task.d.ts"]
     }
   },
   "files": ["dist"],

--- a/packages/nuxt-sentry/src/runtime/server/index.ts
+++ b/packages/nuxt-sentry/src/runtime/server/index.ts
@@ -35,6 +35,8 @@ export {
   redactText,
   redactValue,
 } from '../shared/redact'
+export type { CaptureTaskFailure, ReportingTask, TaskFailureReport, TaskLike, TaskRunContext } from '../shared/task'
+export { describeTaskFailure, resolveTaskName, withTaskReporting } from '../shared/task'
 export type {
   DataCollection,
   DropRuleName,
@@ -56,6 +58,7 @@ export type {
 } from '../shared/types'
 export type { WorkerAttribution } from './attribution'
 export { resolveWorkerAttribution } from './attribution'
+export { withSentryTask } from './task'
 export type {
   DrainedWideEvent,
   SentryCorrelation,

--- a/packages/nuxt-sentry/src/runtime/server/index.ts
+++ b/packages/nuxt-sentry/src/runtime/server/index.ts
@@ -6,6 +6,10 @@
  * client or a background failure is filtered differently from a foreground one.
  * A non Cloudflare site keeps its own `sentry.server.config.ts` and builds its
  * `beforeSend` from here.
+ *
+ * This barrel stays SDK-free. `@sentry/cloudflare` is an optional peer, and a
+ * Node preset does not install it, so a Cloudflare-only helper such as
+ * `withSentryTask` lives in its own subpath export instead of here.
  */
 
 export {
@@ -58,7 +62,6 @@ export type {
 } from '../shared/types'
 export type { WorkerAttribution } from './attribution'
 export { resolveWorkerAttribution } from './attribution'
-export { withSentryTask } from './task'
 export type {
   DrainedWideEvent,
   SentryCorrelation,

--- a/packages/nuxt-sentry/src/runtime/server/task.ts
+++ b/packages/nuxt-sentry/src/runtime/server/task.ts
@@ -1,0 +1,32 @@
+import type { ReportingTask, TaskLike } from '../shared/task'
+import { captureException, setContext, withScope } from '@sentry/cloudflare'
+import { withTaskReporting } from '../shared/task'
+
+/**
+ * Reports a Nitro scheduled task's failures to Sentry.
+ *
+ * Wrap the definition a task exports:
+ *
+ * ```ts
+ * export default withSentryTask(defineTask({
+ *   meta: { name: 'my:cron' },
+ *   async run() { ... },
+ * }))
+ * ```
+ *
+ * The Nitro plugin cannot do this for you. Nitro's `runTask` calls no hook, so
+ * nothing in a plugin can see a task run, and on Cloudflare a throwing task
+ * rejects the scheduled handler and reaches Sentry, if at all, as an
+ * unattributed `scriptThrewException`.
+ *
+ * The error is rethrown, so the scheduler still sees the task fail.
+ */
+export function withSentryTask<Result>(task: TaskLike<Result>): ReportingTask<Result> {
+  return withTaskReporting(task, ({ error, tags, context }) => {
+    withScope((scope) => {
+      scope.setTags(tags)
+      setContext('nitro_task', context.nitro_task)
+      captureException(error)
+    })
+  })
+}

--- a/packages/nuxt-sentry/src/runtime/shared/task.ts
+++ b/packages/nuxt-sentry/src/runtime/shared/task.ts
@@ -1,0 +1,101 @@
+/**
+ * Error reporting for Nitro scheduled tasks.
+ *
+ * The Nitro plugin covers requests. It wraps `nitroApp.localFetch` and hooks
+ * Nitro's `error` event, and a scheduled task goes through neither: Nitro's
+ * `runTask` calls no hook at all, so a plugin cannot observe one. On the
+ * Cloudflare path `runCronTasks` awaits the tasks with no catch of its own, so
+ * a task that throws rejects the Worker's scheduled handler and the failure
+ * arrives as `scriptThrewException`, carrying no task name and no stack.
+ *
+ * Nitro exposes no hook to fix that centrally, so reporting is a wrapper the
+ * task opts into. This file decides what a failure looks like and holds no
+ * Sentry reference, which keeps the decision testable without one.
+ */
+
+/** What Nitro hands a task when it runs one. */
+export interface TaskRunContext {
+  name?: string
+  payload?: Record<string, unknown>
+  context?: Record<string, unknown>
+}
+
+/** The minimum shape of a Nitro task, kept structural so no Nitro type is imported. */
+export interface TaskLike<Result = unknown> {
+  meta?: { name?: string, description?: string }
+  run: (context: TaskRunContext) => Promise<Result> | Result
+}
+
+/**
+ * A wrapped task.
+ *
+ * `run` always accepts the context, even when the task it wraps declared no
+ * parameter, so Nitro can call it the same way either way.
+ */
+export interface ReportingTask<Result = unknown> {
+  meta?: { name?: string, description?: string }
+  run: (context?: TaskRunContext) => Promise<Result>
+}
+
+/** What a caller sends to Sentry for a failed task. */
+export interface TaskFailureReport {
+  error: unknown
+  tags: { task: string }
+  context: { nitro_task: { name: string } }
+}
+
+/** Captures a task failure. Sentry's `captureException` shape, so the real one drops in. */
+export type CaptureTaskFailure = (report: TaskFailureReport) => void
+
+/** The name to report a task under, preferring its own declared name. */
+export function resolveTaskName(task: TaskLike, fallback?: string): string {
+  return task.meta?.name || fallback || 'unknown'
+}
+
+/**
+ * Describes a failed task in the shape a report needs.
+ *
+ * The name becomes a tag as well as context, because a tag is what makes the
+ * failures of one task searchable as a group.
+ */
+export function describeTaskFailure(name: string, error: unknown): TaskFailureReport {
+  return {
+    error,
+    tags: { task: name },
+    context: { nitro_task: { name } },
+  }
+}
+
+/**
+ * Wraps a task so a throw is reported before it leaves.
+ *
+ * The error is rethrown. Reporting must not change what the platform sees,
+ * because a task that swallows its own failure stops the scheduler from
+ * retrying and hides the outage from anything watching exit status.
+ *
+ * A capture that itself fails is ignored on purpose: losing the report is bad,
+ * and replacing the task's real error with a reporting error is worse.
+ */
+export function withTaskReporting<Result>(
+  task: TaskLike<Result>,
+  capture: CaptureTaskFailure,
+): ReportingTask<Result> {
+  return {
+    ...(task.meta ? { meta: task.meta } : {}),
+    run: async (context) => {
+      try {
+        return await task.run(context ?? {})
+      }
+      catch (error) {
+        try {
+          capture(describeTaskFailure(resolveTaskName(task, context?.name), error))
+        }
+        catch {
+          // Reporting is best effort. The task's own error is the one that matters
+          // and it is rethrown below either way.
+        }
+        throw error
+      }
+    },
+  }
+}

--- a/packages/nuxt-sentry/tests/server-barrel.test.ts
+++ b/packages/nuxt-sentry/tests/server-barrel.test.ts
@@ -22,6 +22,8 @@ const root = resolve(fileURLToPath(new URL('../', import.meta.url)))
 describe('server barrel resolves without @sentry/cloudflare', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'nuxt-sentry-barrel-'))
 
+  // Packing runs a full build, which is well past the default hook timeout on a
+  // cold CI runner.
   beforeAll(() => {
     execSync('pnpm test:pack', { cwd: root, stdio: 'pipe' })
     const tarball = readdirSync(join(root, '.pack')).find(file => file.endsWith('.tgz'))
@@ -29,7 +31,7 @@ describe('server barrel resolves without @sentry/cloudflare', () => {
     const pkgDir = join(sandbox, 'node_modules', '@harlan-zw', 'nuxt-sentry')
     mkdirSync(pkgDir, { recursive: true })
     execSync(`tar -xzf ${JSON.stringify(join(root, '.pack', tarball!))} -C ${JSON.stringify(pkgDir)} --strip-components=1`)
-  })
+  }, 180_000)
 
   afterAll(() => {
     rmSync(sandbox, { recursive: true, force: true })

--- a/packages/nuxt-sentry/tests/server-barrel.test.ts
+++ b/packages/nuxt-sentry/tests/server-barrel.test.ts
@@ -1,0 +1,66 @@
+import { execSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * The `./server` barrel is the documented entry for a non Cloudflare site
+ * (`sentry.server.config.ts` imports `createBeforeSend` from it), and
+ * `@sentry/cloudflare` is an optional peer that only a Workers deploy
+ * installs. The barrel must therefore stay free of SDK imports: if it
+ * re-exports `withSentryTask` from `server/task.ts`, every Node site fails
+ * module resolution on `import ... from '@harlan-zw/nuxt-sentry/server'`.
+ *
+ * This packs the package and loads the packed barrel in a bare Node process
+ * with no `node_modules` around it, so any reachable SDK import fails.
+ */
+
+const root = resolve(fileURLToPath(new URL('../', import.meta.url)))
+
+describe('server barrel resolves without @sentry/cloudflare', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'nuxt-sentry-barrel-'))
+
+  beforeAll(() => {
+    execSync('pnpm test:pack', { cwd: root, stdio: 'pipe' })
+    const tarball = readdirSync(join(root, '.pack')).find(file => file.endsWith('.tgz'))
+    expect(tarball, 'pnpm test:pack produced no tarball').toBeTruthy()
+    const pkgDir = join(sandbox, 'node_modules', '@harlan-zw', 'nuxt-sentry')
+    mkdirSync(pkgDir, { recursive: true })
+    execSync(`tar -xzf ${JSON.stringify(join(root, '.pack', tarball!))} -C ${JSON.stringify(pkgDir)} --strip-components=1`)
+  })
+
+  afterAll(() => {
+    rmSync(sandbox, { recursive: true, force: true })
+  })
+
+  it('loads the packed ./server entry in a bare Node process', () => {
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', `
+      const barrel = await import(${JSON.stringify(join(sandbox, 'node_modules', '@harlan-zw', 'nuxt-sentry', 'dist', 'runtime', 'server', 'index.js'))})
+      if (typeof barrel.createBeforeSend !== 'function')
+        throw new Error(\`createBeforeSend missing, exports: \${Object.keys(barrel).join(', ')}\`)
+      console.log('loaded')
+    `], { cwd: sandbox, encoding: 'utf8' })
+
+    expect(`${result.stderr}${result.stdout}`, result.stderr).toContain('loaded')
+    expect(result.status, result.stderr).toBe(0)
+  })
+
+  it('serves withSentryTask from the packed ./server/task subpath', () => {
+    mkdirSync(join(sandbox, 'node_modules', '@sentry'), { recursive: true })
+    symlinkSync(join(root, 'node_modules', '@sentry/cloudflare'), join(sandbox, 'node_modules', '@sentry/cloudflare'), 'dir')
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', `
+      const task = await import('@harlan-zw/nuxt-sentry/server/task')
+      if (typeof task.withSentryTask !== 'function')
+        throw new Error(\`withSentryTask missing, exports: \${Object.keys(task).join(', ')}\`)
+      const report = task.withSentryTask({ run: () => Promise.resolve(1) })
+      if (typeof report.run !== 'function')
+        throw new Error('withSentryTask returned no task')
+      console.log('loaded')
+    `], { cwd: sandbox, encoding: 'utf8' })
+
+    expect(`${result.stderr}${result.stdout}`, result.stderr).toContain('loaded')
+    expect(result.status, result.stderr).toBe(0)
+  })
+})

--- a/packages/nuxt-sentry/tests/task.test.ts
+++ b/packages/nuxt-sentry/tests/task.test.ts
@@ -1,0 +1,86 @@
+import type { TaskFailureReport } from '../src/runtime/shared/task'
+import { describe, expect, it, vi } from 'vitest'
+import { describeTaskFailure, resolveTaskName, withTaskReporting } from '../src/runtime/shared/task'
+
+/**
+ * A scheduled task is the one path the Nitro plugin cannot see. Nitro's
+ * `runTask` calls no hook, so these cover the wrapper that stands in for it.
+ */
+
+function captured() {
+  const reports: TaskFailureReport[] = []
+  return { reports, capture: (report: TaskFailureReport) => void reports.push(report) }
+}
+
+describe('task failure reporting', () => {
+  it('reports the failure and still throws, so the scheduler sees it', async () => {
+    const { reports, capture } = captured()
+    const boom = new Error('D1_ERROR: no such table')
+    const task = withTaskReporting({ meta: { name: 'ai-ready:cron' }, run: () => Promise.reject(boom) }, capture)
+
+    await expect(task.run({})).rejects.toThrow(boom)
+    expect(reports).toHaveLength(1)
+    expect(reports[0]!.error).toBe(boom)
+  })
+
+  it('tags the failure with the task name so one task groups together', async () => {
+    const { reports, capture } = captured()
+    const task = withTaskReporting({ meta: { name: 'ai-ready:cron' }, run: () => Promise.reject(new Error('x')) }, capture)
+
+    await expect(task.run({})).rejects.toThrow()
+    expect(reports[0]!.tags).toEqual({ task: 'ai-ready:cron' })
+    expect(reports[0]!.context.nitro_task).toEqual({ name: 'ai-ready:cron' })
+  })
+
+  it('reports nothing when the task succeeds', async () => {
+    const { reports, capture } = captured()
+    const task = withTaskReporting({ meta: { name: 'ok' }, run: async () => ({ result: 1 }) }, capture)
+
+    await expect(task.run({})).resolves.toEqual({ result: 1 })
+    expect(reports).toHaveLength(0)
+  })
+
+  it('reports a task that throws synchronously', async () => {
+    const { reports, capture } = captured()
+    const task = withTaskReporting({
+      meta: { name: 'sync' },
+      run: () => {
+        throw new Error('immediate')
+      },
+    }, capture)
+
+    await expect(task.run({})).rejects.toThrow('immediate')
+    expect(reports).toHaveLength(1)
+  })
+
+  it('keeps the task error when reporting itself fails', async () => {
+    const boom = new Error('the real failure')
+    const task = withTaskReporting({
+      meta: { name: 'x' },
+      run: () => Promise.reject(boom),
+    }, () => {
+      throw new Error('sentry is down')
+    })
+
+    await expect(task.run({})).rejects.toThrow(boom)
+  })
+
+  it('preserves the task meta so Nitro still registers it', () => {
+    const task = withTaskReporting({ meta: { name: 'n', description: 'd' }, run: async () => 1 }, vi.fn())
+
+    expect(task.meta).toEqual({ name: 'n', description: 'd' })
+  })
+
+  it('falls back to the name Nitro passes when the task declares none', async () => {
+    const { reports, capture } = captured()
+    const task = withTaskReporting({ run: () => Promise.reject(new Error('x')) }, capture)
+
+    await expect(task.run({ name: 'from-nitro' })).rejects.toThrow()
+    expect(reports[0]!.tags.task).toBe('from-nitro')
+  })
+
+  it('names an unnamed task rather than reporting an empty tag', () => {
+    expect(resolveTaskName({ run: async () => 1 })).toBe('unknown')
+    expect(describeTaskFailure('a:b', new Error('x')).tags.task).toBe('a:b')
+  })
+})


### PR DESCRIPTION
### 📚 Description

The Nitro plugin covers requests. It wraps `nitroApp.localFetch` and hooks Nitro's `error` event, and a scheduled task goes through neither.

I checked Nitro's task runner:

```js
// nitropack/dist/runtime/internal/task.mjs
export async function runTask(name, { payload, context } = {}) {
  const handler = await tasks[name].resolve()
  __runningTasks__[name] = handler.run(taskEvent)   // no hook, anywhere
  try { return await __runningTasks__[name] } finally { ... }
}

export function runCronTasks(cron, ctx) {
  return Promise.all(getCronTasks(cron).map(name => runTask(name, ctx)))  // no catch
}
```

`runTask` calls no hook, so a plugin cannot observe a task run at all. And on the Cloudflare path `runCronTasks` has no catch, so a throwing task rejects the Worker's scheduled handler and the failure arrives as `scriptThrewException`: no task name, no stack, nothing attributable.

That is a blind spot for every scheduled task in every site using this module, not just the one that surfaced it.

### The change

`withSentryTask` wraps a task, the way the package already wraps a queue through `runWithQueueSentry`:

```ts
export default withSentryTask(defineTask({
  meta: { name: 'my:cron' },
  async run() { ... },
}))
```

It follows the file's own rule that nothing in `server/` decides policy. The decision is a pure function in `shared/task.ts` taking an injected capture, so it is tested without Sentry; `server/task.ts` only binds it.

Three deliberate choices:

- **The error is rethrown.** Reporting must not change what the platform sees, or a task swallows its own failure and the scheduler stops retrying.
- **A failing capture is ignored.** Replacing a task's real error with a reporting error loses the one that matters.
- **The task name is a tag, not just context**, so one task's failures group together.

### ⚠️ Known limitation

This is opt-in per task. Nitro exposes no hook, so a module cannot instrument tasks automatically without reaching into internals. If Nitro ever adds a task hook, this becomes a plugin and the wrapper can be deprecated.

### ✅ Tests

`tests/task.test.ts`, 8 tests: reports and still throws, tags by name, silent on success, catches a synchronous throw, keeps the task error when capture fails, preserves `meta` so Nitro still registers the task, falls back to the name Nitro passes, and names an unnamed task rather than emitting an empty tag.

Suite 151/151, lint and typecheck clean.

### Related

The other half of harlan-zw/unlighthouse.dev#25 is harlan-zw/nuxt-ai-ready#95, where `runCron` was letting throws escape in the first place. These are independent: this one makes task failures visible, that one stops a routine database blip becoming a failure at all.

> 🤖 AI disclosure: opened by [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit). [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01KGE9ALMX1BSCaYcLt4GzyU