### PR TITLE
fix(github-runner): stop a RAM-backed /tmp starving the budget

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -199,8 +199,10 @@ sudo install -Dm755 infra/github-runner/backfill-job-history /var/lib/github-run
 sudo install -Dm644 infra/github-runner/hogwild-runners.conf /var/lib/github-runner/config/runners.conf
 sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
 sudo install -Dm644 infra/github-runner/hogwild-logind.conf /etc/systemd/logind.conf.d/runner-safe-power.conf
+sudo install -Dm644 infra/github-runner/hogwild-tmp.conf /etc/tmpfiles.d/runner-tmp.conf
 sudo install -Dm755 infra/github-runner/hogwild-safe-poweroff /usr/local/sbin/hogwild-safe-poweroff
 sudo systemctl daemon-reload
+sudo systemd-tmpfiles --clean
 sudo systemctl kill --signal HUP systemd-logind
 sudo systemctl restart hogwild-github-runner.service
 ```

--- a/infra/github-runner/hogwild-tmp.conf
+++ b/infra/github-runner/hogwild-tmp.conf
@@ -1,0 +1,10 @@
+# /tmp on hogwild is a tmpfs, so every file in it spends the same pages the
+# runner pools budget. systemd ships a ten day retention, which is right for a
+# disk-backed /tmp and wrong here: on 2026-09-05 a leaked 5.4M shared object per
+# invocation accumulated 1,847 files and 9.4g over a week, took `MemAvailable`
+# below the deploy pool's reservation plus headroom, and held that pool at 0 for
+# over three hours while the supervisor logged a correct refusal every 30s.
+#
+# Two days keeps a build's scratch alive far longer than any job runs, and caps
+# what a leaking process can take out of the memory budget.
+q /tmp 1777 root root 2d

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -282,6 +282,15 @@ host_available_memory_gib() {
   free --gibi | awk '/^Mem:/ { print $7 }'
 }
 
+# RAM-backed filesystems spend the same pages the pools budget, and they are
+# invisible in `MemAvailable`: a full /tmp reads exactly like a busy host. The
+# hold reason names them so the next multi-hour hold is one log line rather than
+# a host login (2026-09-05, a 12g /tmp held the deploy pool at 0 for 3h21m).
+host_ram_backed_memory_gib() {
+  df --block-size=1G --output=fstype,used 2>/dev/null \
+    | awk '$1 == "tmpfs" || $1 == "ramfs" { total += $2 } END { print total + 0 }'
+}
+
 # Sum of a marker directory's contents. Each file is named after its container,
 # so concurrent slots create and remove distinct paths and never contend.
 sum_markers() {
@@ -774,7 +783,7 @@ run_burst_slot() {
 run_scaler() {
   local request pool_index container_name
   local burst_counter=0
-  local slug live spent spent_memory available_memory hold_reason
+  local slug live spent spent_memory available_memory ram_backed_memory hold_reason
   local pending_pool pending_count attempt candidate priority_index queued_demand
   local -a pending_pools=()
   local -A pool_is_pending=()
@@ -852,6 +861,10 @@ run_scaler() {
               hold_reason='Available memory is unknown'
             elif (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
               hold_reason="Available memory ${available_memory}g, headroom ${memory_headroom_gib}g"
+              ram_backed_memory="$(host_ram_backed_memory_gib)"
+              if [[ "$ram_backed_memory" =~ ^[0-9]+$ ]] && (( ram_backed_memory > 0 )); then
+                hold_reason="${hold_reason}, RAM-backed filesystems hold ${ram_backed_memory}g"
+              fi
             fi
           fi
         fi

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -558,9 +558,17 @@ if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
   exit 1
 fi
 
-if ! grep --quiet 'Available memory 2g, headroom 2g; holding example-ci at 0' "$test_root/output"; then
+if ! grep --quiet 'Available memory 2g, headroom 2g' "$test_root/output"; then
   cat "$test_root/output"
   printf 'Expected the memory headroom decision in the supervisor log.\n' >&2
+  exit 1
+fi
+
+# A RAM-backed filesystem spends the pages the pools budget, and `MemAvailable`
+# cannot say so. Without this the reader sees only that memory is gone.
+if ! grep --quiet 'RAM-backed filesystems hold [0-9]\+g; holding example-ci at 0' "$test_root/output"; then
+  cat "$test_root/output"
+  printf 'Expected the hold reason to name RAM-backed filesystem usage.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
### 📚 Description

The nuxtseo.com deploy pool sat at 0 for 3h21m today with a release queued behind it. The supervisor was right to refuse: `MemAvailable` was 17g, and that pool needs its 13g reservation plus 6g headroom.

The memory was in `/tmp`. It is a tmpfs on hogwild, so every file in it holds RAM the pools budget, and systemd ships a ten day retention. A process leaking one 5.4M shared object per invocation had accumulated 1,847 files and 9.4g over a week. Deleting the stale ones took available memory to 20g and the pool scheduled within seconds.

Two halves, so two changes. `hogwild-tmp.conf` ages `/tmp` at two days, far longer than any job runs and short enough to cap what a leak can take. And the hold reason now names RAM-backed filesystem usage, because `MemAvailable` cannot tell a full tmpfs from a busy host: the log said memory was gone and never where it went.

Before, the line read:

```
Available memory 17g, headroom 6g; holding nuxtseo-com-deploy at 0
```

After:

```
Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g; holding nuxtseo-com-deploy at 0
```

Diagnosing this took a host login and six commands. It is now one log line.

Open question: the tmpfs is capped at 15.1g on a 30g host while the pools budget 24g, so the two over-commit RAM by 9g. Aging bounds the accumulation but not the ceiling. Capping the mount would fix it properly, and I left that alone because CI builds legitimately use `/tmp` and I have no measurement of their peak.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).