### PR TITLE
feat(github-runner): publish memory attribution and hold state

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -199,8 +199,10 @@ sudo install -Dm755 infra/github-runner/backfill-job-history /var/lib/github-run
 sudo install -Dm644 infra/github-runner/hogwild-runners.conf /var/lib/github-runner/config/runners.conf
 sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
 sudo install -Dm644 infra/github-runner/hogwild-logind.conf /etc/systemd/logind.conf.d/runner-safe-power.conf
+sudo install -Dm644 infra/github-runner/hogwild-tmp.conf /etc/tmpfiles.d/runner-tmp.conf
 sudo install -Dm755 infra/github-runner/hogwild-safe-poweroff /usr/local/sbin/hogwild-safe-poweroff
 sudo systemctl daemon-reload
+sudo systemd-tmpfiles --clean
 sudo systemctl kill --signal HUP systemd-logind
 sudo systemctl restart hogwild-github-runner.service
 ```

--- a/infra/github-runner/hogwild-tmp.conf
+++ b/infra/github-runner/hogwild-tmp.conf
@@ -1,0 +1,10 @@
+# /tmp on hogwild is a tmpfs, so every file in it spends the same pages the
+# runner pools budget. systemd ships a ten day retention, which is right for a
+# disk-backed /tmp and wrong here: on 2026-09-05 a leaked 5.4M shared object per
+# invocation accumulated 1,847 files and 9.4g over a week, took `MemAvailable`
+# below the deploy pool's reservation plus headroom, and held that pool at 0 for
+# over three hours while the supervisor logged a correct refusal every 30s.
+#
+# Two days keeps a build's scratch alive far longer than any job runs, and caps
+# what a leaking process can take out of the memory budget.
+q /tmp 1777 root root 2d

--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -45,6 +45,34 @@ memory_bytes_for() {
 
 readonly temporary_pools="$(mktemp --tmpdir="$state_dir" .status-pools.XXXXXX)"
 readonly temporary_snapshot="$(mktemp --tmpdir="$state_dir" .status.XXXXXX)"
+# Host memory, split by who is holding it. `MemAvailable` alone cannot say
+# whether a host is busy or whether a RAM-backed filesystem ate the budget, and
+# on 2026-09-05 that difference cost 3h21m of a held deploy pool.
+host_memory_total_bytes() {
+  awk '/^MemTotal:/ { print $2 * 1024; exit }' /proc/meminfo
+}
+
+host_memory_available_bytes() {
+  awk '/^MemAvailable:/ { print $2 * 1024; exit }' /proc/meminfo
+}
+
+host_ram_backed_bytes() {
+  df --block-size=1 --output=fstype,used 2>/dev/null \
+    | awk '$1 == "tmpfs" || $1 == "ramfs" { total += $2 } END { print total + 0 }'
+}
+
+# What the pools themselves have reserved, from the supervisor's own markers, so
+# the dashboard never re-derives a number the scheduler already owns.
+runner_in_flight_bytes() {
+  local total=0 marker value
+  for marker in "$state_dir/spend-memory"/*; do
+    [[ -f "$marker" ]] || continue
+    read -r value <"$marker" || value=''
+    [[ "$value" =~ ^[0-9]+$ ]] && total=$(( total + value ))
+  done
+  printf '%s' "$(( total * 1024 * 1024 * 1024 ))"
+}
+
 cleanup() {
   rm --force "$temporary_pools" "$temporary_snapshot"
 }
@@ -149,6 +177,12 @@ while IFS='|' read -r repository labels warm maximum cpus memory_reservation mem
     read -r queued_value <"$state_dir/queued/$slug" || queued_value=''
     [[ "$queued_value" =~ ^[0-9]+$ ]] && queued="$queued_value"
   fi
+  held_reason=''
+  held_since='null'
+  if [[ -r "$state_dir/held/$slug" ]]; then
+    read -r held_reason <"$state_dir/held/$slug" || held_reason=''
+    held_since="$(( $(stat --format=%Y "$state_dir/held/$slug") * 1000 ))"
+  fi
   jq --compact-output --null-input \
     --arg name "$slug" \
     --arg repository "$repository" \
@@ -157,8 +191,12 @@ while IFS='|' read -r repository labels warm maximum cpus memory_reservation mem
     --argjson memoryLimitBytes "$memory_limit_bytes" \
     --argjson memoryReservationBytes "$memory_reservation_bytes" \
     --argjson queued "$queued" \
+    --arg heldReason "$held_reason" \
+    --argjson heldSince "$held_since" \
     '{
       cpuPerRunner: $cpuPerRunner,
+      heldReason: (if $heldReason == "" then null else $heldReason end),
+      heldSince: $heldSince,
       maximum: $maximum,
       memoryLimitBytes: $memoryLimitBytes,
       memoryReservationBytes: $memoryReservationBytes,
@@ -210,6 +248,18 @@ else
   updated_at="$(( $(date +%s) * 1000 ))"
 fi
 
+host_memory="$(jq --compact-output --null-input \
+  --argjson totalBytes "$(host_memory_total_bytes)" \
+  --argjson availableBytes "$(host_memory_available_bytes)" \
+  --argjson ramBackedBytes "$(host_ram_backed_bytes)" \
+  --argjson inFlightBytes "$(runner_in_flight_bytes)" \
+  '{
+    availableBytes: $availableBytes,
+    inFlightBytes: $inFlightBytes,
+    ramBackedBytes: $ramBackedBytes,
+    totalBytes: $totalBytes
+  }')"
+
 jq --null-input \
   --argjson cpuBudget "$cpu_budget" \
   --argjson memoryBudgetBytes "$(( memory_budget_gib * 1024 * 1024 * 1024 ))" \
@@ -219,10 +269,12 @@ jq --null-input \
   --argjson recentJobs "$recent_jobs" \
   --argjson runners "$runners" \
   --argjson updatedAt "$updated_at" \
+  --argjson hostMemory "$host_memory" \
   '{
-    version: 3,
+    version: 4,
     updatedAt: $updatedAt,
     budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes, memoryHeadroomBytes: $memoryHeadroomBytes },
+    hostMemory: $hostMemory,
     jobTotals: $jobTotals,
     pools: $pools,
     runners: $runners,

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -7,12 +7,16 @@ trap 'rm -rf "$test_root"' EXIT
 
 mkdir -p "$test_root/bin" "$test_root/history/daily" "$test_root/history/jobs" \
   "$test_root/state/jobs" "$test_root/state/queued" "$test_root/state/spend" \
-  "$test_root/state/spend-memory"
+  "$test_root/state/spend-memory" "$test_root/state/held"
 
 cat >"$test_root/state/runners.conf" <<'EOF'
 harlan-zw/example|harlan-desktop-ci|0|4|4|4g|8g|10g
 EOF
 printf '2\n' >"$test_root/state/queued/example-ci"
+# A held pool reads as an idle one until the reason reaches the snapshot. The
+# mtime is the hold's start, so a dashboard can age it.
+printf 'Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g\n' >"$test_root/state/held/example-ci"
+touch --date='@1787930450' "$test_root/state/held/example-ci"
 printf '4\n' >"$test_root/state/spend/harlan-desktop-example-ci-burst-1"
 printf '4\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
 cat >"$test_root/state/jobs/harlan-desktop-example-ci-burst-1.json" <<'EOF'
@@ -65,12 +69,14 @@ HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
 
 snapshot="$test_root/state/status.json"
 jq --exit-status '
-  .version == 3
+  .version == 4
   and .updatedAt == 1787930500000
   and .budgets == { cpu: 20, memoryBytes: 25769803776, memoryHeadroomBytes: 8589934592 }
   and .jobTotals == { actualMilliseconds: 100000, billableMinutes: 2, completed: 1, trackedSince: 1787930200000 }
   and .pools == [{
     cpuPerRunner: 4,
+    heldReason: "Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g",
+    heldSince: 1787930450000,
     live: 1,
     maximum: 4,
     memoryLimitBytes: 8589934592,
@@ -93,6 +99,10 @@ jq --exit-status '
     tasks: 47
   }]
   and (.recentJobs | length) == 1
+  and (.hostMemory.totalBytes > 0)
+  and (.hostMemory.availableBytes > 0)
+  and (.hostMemory.ramBackedBytes >= 0)
+  and (.hostMemory.inFlightBytes == 4294967296)
 ' "$snapshot" >/dev/null
 
 if [[ "$(stat -c '%a' "$snapshot")" != 640 ]]; then

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -282,6 +282,15 @@ host_available_memory_gib() {
   free --gibi | awk '/^Mem:/ { print $7 }'
 }
 
+# RAM-backed filesystems spend the same pages the pools budget, and they are
+# invisible in `MemAvailable`: a full /tmp reads exactly like a busy host. The
+# hold reason names them so the next multi-hour hold is one log line rather than
+# a host login (2026-09-05, a 12g /tmp held the deploy pool at 0 for 3h21m).
+host_ram_backed_memory_gib() {
+  df --block-size=1G --output=fstype,used 2>/dev/null \
+    | awk '$1 == "tmpfs" || $1 == "ramfs" { total += $2 } END { print total + 0 }'
+}
+
 # Sum of a marker directory's contents. Each file is named after its container,
 # so concurrent slots create and remove distinct paths and never contend.
 sum_markers() {
@@ -774,7 +783,7 @@ run_burst_slot() {
 run_scaler() {
   local request pool_index container_name
   local burst_counter=0
-  local slug live spent spent_memory available_memory hold_reason
+  local slug live spent spent_memory available_memory ram_backed_memory hold_reason
   local pending_pool pending_count attempt candidate priority_index queued_demand
   local -a pending_pools=()
   local -A pool_is_pending=()
@@ -852,6 +861,10 @@ run_scaler() {
               hold_reason='Available memory is unknown'
             elif (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
               hold_reason="Available memory ${available_memory}g, headroom ${memory_headroom_gib}g"
+              ram_backed_memory="$(host_ram_backed_memory_gib)"
+              if [[ "$ram_backed_memory" =~ ^[0-9]+$ ]] && (( ram_backed_memory > 0 )); then
+                hold_reason="${hold_reason}, RAM-backed filesystems hold ${ram_backed_memory}g"
+              fi
             fi
           fi
         fi

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -825,6 +825,7 @@ run_scaler() {
         slug="${pool_slug[$pending_pool]}"
         live=$(( pool_warm[pending_pool] + $(count_markers "$state_dir/burst/$slug") ))
         if (( live >= pool_max[pending_pool] )); then
+          rm --force "$state_dir/held/$slug"
           unset 'pool_is_pending[$pending_pool]'
           continue
         fi
@@ -840,6 +841,7 @@ run_scaler() {
             read -r queued_demand <"$state_dir/queued/$slug" || queued_demand=''
           fi
           if [[ "$queued_demand" == 0 ]]; then
+            rm --force "$state_dir/held/$slug"
             unset 'pool_is_pending[$pending_pool]'
             log "Dropping held demand for $slug; its queued count returned to zero"
             continue
@@ -874,7 +876,11 @@ run_scaler() {
           # The journal already carries this, and nothing reads the journal until
           # someone notices. `publish-status` turns the marker into the dashboard's
           # hold state, so a pool held for hours stops looking like an idle one.
-          printf '%s\n' "$hold_reason" >"$state_dir/held/$slug"
+          # That state ages the hold from the marker's mtime. Write the marker
+          # only while it is absent, so later gate runs keep the hold's start.
+          if [[ ! -e "$state_dir/held/$slug" ]]; then
+            printf '%s\n' "$hold_reason" >"$state_dir/held/$slug"
+          fi
           if (( pool_is_deploy[pending_pool] )); then
             pending_pools=("$pending_pool" "${pending_pools[@]}")
             break
@@ -884,6 +890,9 @@ run_scaler() {
         fi
 
         unset 'pool_is_pending[$pending_pool]'
+        # The hold ends when the gate admits the pool. Remove the marker beside
+        # the scheduling it guarded, or the pool reports held while it runs.
+        rm --force "$state_dir/held/$slug"
 
         # A restart resets this counter while a spared burst container from the
         # previous generation may still hold one of these names. Skip past it.

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -499,6 +499,15 @@ run_demand_poller() {
       fi
       queued="$(queued_jobs_for_pool "$pool_index" "${repository_jobs[$repository]}")"
       publish_queue_count "$pool_index" "$queued"
+      # A hold ends when its demand ends, not only when a capacity event
+      # arrives. The gate reads pending entries on spawn and capacity requests
+      # alone, and a cancelled run sends neither: no burst is running to finish
+      # and the deficit is zero, so the entry would sit held over an idle pool
+      # until restart. Wake the gate whenever a held pool's scan reaches zero;
+      # its zero-demand drop then removes the marker beside the queued count.
+      if (( queued == 0 )) && [[ -f "$state_dir/held/${pool_slug[$pool_index]}" ]]; then
+        printf 'capacity\n' >"$scale_pipe"
+      fi
       idle="$(count_idle_burst "$pool_index")"
       deficit=$(( queued - idle ))
       for (( request = 0; request < deficit; request++ )); do

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -493,6 +493,7 @@ run_demand_poller() {
       fi
       if [[ "${repository_result[$repository]}" == unavailable ]]; then
         rm --force "$state_dir/queued/${pool_slug[$pool_index]}"
+        rm --force "$state_dir/held/${pool_slug[$pool_index]}"
         log "Queued job demand is unavailable for ${pool_slug[$pool_index]}"
         continue
       fi
@@ -870,6 +871,10 @@ run_scaler() {
         fi
         if [[ -n "$hold_reason" ]]; then
           log "$hold_reason; holding $slug at $live"
+          # The journal already carries this, and nothing reads the journal until
+          # someone notices. `publish-status` turns the marker into the dashboard's
+          # hold state, so a pool held for hours stops looking like an idle one.
+          printf '%s\n' "$hold_reason" >"$state_dir/held/$slug"
           if (( pool_is_deploy[pending_pool] )); then
             pending_pools=("$pending_pool" "${pending_pools[@]}")
             break
@@ -1102,7 +1107,7 @@ main() {
   # read from the real reservations.
   state_dir="$state_root"
   rm --recursive --force "$state_dir"
-  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline" "$state_dir/jobs" "$state_dir/queued"
+  mkdir --parents "$state_dir/spend" "$state_dir/spend-memory" "$state_dir/claimed" "$state_dir/burst" "$state_dir/offline" "$state_dir/jobs" "$state_dir/queued" "$state_dir/held"
   chmod 0750 "$state_dir"
   scale_pipe="$state_dir/scale"
   cp "$config_file" "$published_config"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -558,9 +558,17 @@ if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
   exit 1
 fi
 
-if ! grep --quiet 'Available memory 2g, headroom 2g; holding example-ci at 0' "$test_root/output"; then
+if ! grep --quiet 'Available memory 2g, headroom 2g' "$test_root/output"; then
   cat "$test_root/output"
   printf 'Expected the memory headroom decision in the supervisor log.\n' >&2
+  exit 1
+fi
+
+# A RAM-backed filesystem spends the pages the pools budget, and `MemAvailable`
+# cannot say so. Without this the reader sees only that memory is gone.
+if ! grep --quiet 'RAM-backed filesystems hold [0-9]\+g; holding example-ci at 0' "$test_root/output"; then
+  cat "$test_root/output"
+  printf 'Expected the hold reason to name RAM-backed filesystem usage.\n' >&2
   exit 1
 fi
 

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -316,7 +316,7 @@ if (( $(wc -l <"$test_root/calls/burst") != 2 )); then
   exit 1
 fi
 
-if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, live: 0, maximum: 2, memoryLimitBytes: 2147483648, memoryReservationBytes: 1073741824, name: "example-ci", queued: 2, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
+if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, heldReason: null, heldSince: null, live: 0, maximum: 2, memoryLimitBytes: 2147483648, memoryReservationBytes: 1073741824, name: "example-ci", queued: 2, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
   cat "$test_root/calls/status.json"
   printf 'Expected queued demand in the published runner status.\n' >&2
   exit 1

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -689,6 +689,93 @@ fi
 
 printf 'Held start survives later gate runs passed.\n'
 
+# A hold must end when its demand ends, not only when a capacity event
+# arrives. The gate runs on spawn and capacity requests alone, so a run that
+# is cancelled while its pool is held sends neither: the next scan publishes
+# queued 0 and stays quiet, and no busy slot ever returns capacity. The
+# marker then reports a hold over an idle pool until restart. Hold one cold
+# pool at low memory, cancel its run with no other pools and no bursts, and
+# require the published hold to clear within one demand scan.
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-enabled" "$test_root/calls/low-memory"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|0|2|1|1g|2g|3g
+EOF
+
+set +e
+(
+  TEST_CALLS="$test_root/calls" \
+  PATH="$test_root/bin:$PATH" \
+  XDG_RUNTIME_DIR="$test_root/runtime" \
+  CREDENTIALS_DIRECTORY="$test_root/credentials" \
+  HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+  HARLAN_DESKTOP_RUNNER_CPU_BUDGET=2 \
+  HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
+  HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=2 \
+  HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+  HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+  HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.2 \
+  HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
+  timeout --preserve-status --kill-after=1 100 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+) &
+supervisor_pid=$!
+
+saw_hold=''
+cancelled_demand=''
+saw_queued_zero=''
+held_cleared=''
+while kill -0 "$supervisor_pid" 2>/dev/null; do
+  pool_json="$(jq --compact-output '.pools[] | select(.name == "example-ci")' "$test_root/calls/status.json" 2>/dev/null || true)"
+  if [[ -n "$pool_json" ]]; then
+    held_reason="$(jq --raw-output '.heldReason // empty' <<<"$pool_json")"
+    queued_count="$(jq --raw-output '.queued' <<<"$pool_json")"
+    if [[ -n "$held_reason" ]]; then
+      saw_hold=1
+      if [[ -z "$cancelled_demand" ]]; then
+        rm --force "$test_root/calls/queue-enabled"
+        cancelled_demand=1
+      fi
+    fi
+    [[ "$queued_count" == 0 ]] && saw_queued_zero=1
+    if [[ -n "$saw_hold" && -n "$cancelled_demand" && -z "$held_reason" ]]; then
+      held_cleared=1
+    fi
+  fi
+  sleep 0.05
+done
+wait "$supervisor_pid"
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the supervisor to exit cleanly while the hold end was checked.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$saw_hold" ]]; then
+  cat "$test_root/output"
+  printf 'Expected the low memory hold to publish a hold reason.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$saw_queued_zero" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected the cancelled run to publish a queued count of zero.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$held_cleared" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/status.json"
+  printf 'Expected the published hold to clear once its queued count reached zero with no capacity event.\n' >&2
+  exit 1
+fi
+
+printf 'Cancelled hold clears without a capacity event passed.\n'
+
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"
 touch "$test_root/calls/queue-priority"

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -128,6 +128,9 @@ EOF
 
 cat >"$test_root/bin/free" <<'EOF'
 #!/usr/bin/env bash
+if [[ -f "$TEST_CALLS/slow-free" ]]; then
+  sleep 1
+fi
 printf '              total used free shared buff/cache available\n'
 if [[ -f "$TEST_CALLS/low-memory" ]]; then
   printf 'Mem:             32   24    2      0          6         2\n'
@@ -612,6 +615,80 @@ fi
 
 printf 'Repeated demand re-runs the memory gate passed.\n'
 
+# The dashboard ages a hold from the marker's mtime. A gate re-run that
+# rewrites the marker resets that start, so a hold ages past no snapshot.
+# Two queued jobs mean two gate runs, and `slow-free` separates their marker
+# writes by more than a second so the rewrite lands in a later mtime second.
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-enabled" "$test_root/calls/low-memory" "$test_root/calls/slow-free"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|0|2|1|1g|2g|3g
+EOF
+
+set +e
+(
+  TEST_CALLS="$test_root/calls" \
+  PATH="$test_root/bin:$PATH" \
+  XDG_RUNTIME_DIR="$test_root/runtime" \
+  CREDENTIALS_DIRECTORY="$test_root/credentials" \
+  HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+  HARLAN_DESKTOP_RUNNER_CPU_BUDGET=4 \
+  HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
+  HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+  HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+  HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.2 \
+  HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
+  timeout --preserve-status --kill-after=1 8 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+) &
+supervisor_pid=$!
+
+held_since_first=''
+held_since_drifted=''
+while kill -0 "$supervisor_pid" 2>/dev/null; do
+  if [[ -s "$test_root/calls/status.json" ]]; then
+    held_since="$(jq --raw-output '.pools[] | select(.name == "example-ci") | .heldSince // empty' "$test_root/calls/status.json" 2>/dev/null || true)"
+    if [[ -n "$held_since" ]]; then
+      if [[ -z "$held_since_first" ]]; then
+        held_since_first="$held_since"
+      elif [[ "$held_since" != "$held_since_first" ]]; then
+        held_since_drifted="$held_since"
+      fi
+    fi
+  fi
+  sleep 0.05
+done
+wait "$supervisor_pid"
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the supervisor to exit cleanly while the hold start was checked.\n' >&2
+  exit 1
+fi
+
+holds="$(grep --count 'holding example-ci at 0' "$test_root/output" || true)"
+if (( holds < 2 )); then
+  cat "$test_root/output"
+  printf 'Expected a second gate run behind the held marker, saw %s hold(s).\n' "$holds" >&2
+  exit 1
+fi
+
+if [[ -z "$held_since_first" ]]; then
+  cat "$test_root/calls/status.json"
+  printf 'Expected the held pool to publish a hold start time.\n' >&2
+  exit 1
+fi
+
+if [[ -n "$held_since_drifted" ]]; then
+  cat "$test_root/output"
+  printf 'Expected the published hold start %s to survive later gate runs, saw %s.\n' "$held_since_first" "$held_since_drifted" >&2
+  exit 1
+fi
+
+printf 'Held start survives later gate runs passed.\n'
+
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"
 touch "$test_root/calls/queue-priority"
@@ -663,6 +740,8 @@ printf 'Deploy priority passed.\n'
 # then does the busy slot return capacity. CI has to be admitted on the freed
 # slot with no empty deploy burst in front of it. The second scan lands after
 # the 60 second demand poll floor, so this block runs longer than the others.
+# Once the held demand is dropped, the published hold must go too: a marker
+# that survives the drop reports a healthy pool as held until restart.
 rm -rf "$test_root/calls" "$test_root/runtime"
 mkdir -p "$test_root/calls" "$test_root/runtime"
 touch "$test_root/calls/queue-cancel" "$test_root/calls/hold-warm-job"
@@ -678,6 +757,8 @@ HARLAN_DESKTOP_RUNNER_CPU_BUDGET=12 \
 HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=12 \
 HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
 HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
 timeout --preserve-status --kill-after=1 70 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
 status=$?
 set -e
@@ -698,6 +779,12 @@ fi
 if grep --quiet -- '-deploy-burst-' "$test_root/calls/burst" 2>/dev/null; then
   cat "$test_root/calls/burst"
   printf 'Expected the cancelled deploy not to burst an empty runner.\n' >&2
+  exit 1
+fi
+
+if ! jq --exit-status '.pools[] | select(.name == "example-deploy") | .heldReason == null and .heldSince == null' "$test_root/calls/status.json" >/dev/null; then
+  cat "$test_root/calls/status.json"
+  printf 'Expected the dropped deploy demand to clear the published hold.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
### 📚 Description

Stacked on #123.

The status snapshot could not have explained today's outage. It carries a pool's capacity and its queued count, so a pool held at 0 on memory renders exactly like an idle one, and it carries no host memory at all, so 12g sitting in a tmpfs looked like ordinary use. hogwild.harlanzw.com would have shown a healthy host for the whole 3h21m.

`status.json` moves to version 4 with two additions.

`hostMemory` splits the host four ways: total, available, RAM-backed filesystems, and what the pools have reserved. The last reads the supervisor's own spend markers rather than deriving the number again, because a dashboard that recomputes a scheduler's arithmetic drifts from it.

`pools[].heldReason` and `pools[].heldSince` carry the supervisor's own refusal. It already computes the reason and logs it every 30 seconds; nothing reads the journal until someone goes looking. The marker is written where the pool is held and removed where it schedules, beside the existing queued marker, so the two cannot disagree.

```json
"hostMemory": { "totalBytes": 32212254720, "availableBytes": 18253611008, "ramBackedBytes": 12884901888, "inFlightBytes": 13958643712 },
"pools": [{ "name": "nuxtseo-com-deploy", "heldReason": "Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g", "heldSince": 1788604742000 }]
```

The site rendering is a separate PR. This is the data it needs.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).