### PR TITLE
feat(github-runner): publish why a pool refused to start a runner

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -112,6 +112,22 @@ The supervisor publishes `status.json` beside its runtime state every 15 seconds
 
 The snapshot contains pool demand, active jobs, recent outcomes, lifetime Runner job totals, and container resources. It contains no credentials or Docker configuration.
 
+Each pool also carries a hold state. A quiet pool and a refused pool must never render the same.
+
+| Hold | The supervisor refused because |
+| --- | --- |
+| `NotHeld` | Nothing refused this pool. |
+| `AtMaximum` | The pool already runs its maximum runners. |
+| `CpuBudget` | Work in flight spends the CPU burst threshold. |
+| `MemoryBudget` | Work in flight spends the memory budget. |
+| `MemoryHeadroom` | The host lacks the memory this pool reserves. |
+| `MemoryUnknown` | The host memory reading failed. |
+| `DemandUnavailable` | The supervisor could not read queued job demand. |
+
+Every hold carries `since`, the time the supervisor first refused. A hold that has run ten hours is a different story from one that has run ten seconds.
+
+`MemoryHeadroom` also carries `ramBackedBytes`. A full RAM-backed filesystem reads exactly like a busy host in `MemAvailable`.
+
 Raw Runner jobs persist for 90 days. Daily totals persist until they are removed manually.
 
 Stop local CI before shutting down or doing CPU-heavy local work:

--- a/infra/github-runner/publish-status
+++ b/infra/github-runner/publish-status
@@ -177,11 +177,19 @@ while IFS='|' read -r repository labels warm maximum cpus memory_reservation mem
     read -r queued_value <"$state_dir/queued/$slug" || queued_value=''
     [[ "$queued_value" =~ ^[0-9]+$ ]] && queued="$queued_value"
   fi
-  held_reason=''
-  held_since='null'
-  if [[ -r "$state_dir/held/$slug" ]]; then
-    read -r held_reason <"$state_dir/held/$slug" || held_reason=''
-    held_since="$(( $(stat --format=%Y "$state_dir/held/$slug") * 1000 ))"
+  # A quiet pool and a refused pool publish the same zeroes. The supervisor's
+  # marker is the only thing that separates them, so a marker that will not parse
+  # must never render as quiet.
+  hold='{"_tag":"NotHeld"}'
+  if [[ -e "$state_dir/held/$slug" ]]; then
+    if ! hold="$(jq --compact-output --exit-status '
+      select(
+        (._tag | IN("AtMaximum", "CpuBudget", "DemandUnavailable", "MemoryBudget", "MemoryHeadroom", "MemoryUnknown"))
+        and (.since | type == "number")
+      )' "$state_dir/held/$slug" 2>/dev/null)"; then
+      printf 'Pool hold state is unreadable: %s\n' "$slug" >&2
+      hold='{"_tag":"HoldUnreadable"}'
+    fi
   fi
   jq --compact-output --null-input \
     --arg name "$slug" \
@@ -191,12 +199,10 @@ while IFS='|' read -r repository labels warm maximum cpus memory_reservation mem
     --argjson memoryLimitBytes "$memory_limit_bytes" \
     --argjson memoryReservationBytes "$memory_reservation_bytes" \
     --argjson queued "$queued" \
-    --arg heldReason "$held_reason" \
-    --argjson heldSince "$held_since" \
+    --argjson hold "$hold" \
     '{
       cpuPerRunner: $cpuPerRunner,
-      heldReason: (if $heldReason == "" then null else $heldReason end),
-      heldSince: $heldSince,
+      hold: $hold,
       maximum: $maximum,
       memoryLimitBytes: $memoryLimitBytes,
       memoryReservationBytes: $memoryReservationBytes,
@@ -271,7 +277,7 @@ jq --null-input \
   --argjson updatedAt "$updated_at" \
   --argjson hostMemory "$host_memory" \
   '{
-    version: 4,
+    version: 5,
     updatedAt: $updatedAt,
     budgets: { cpu: $cpuBudget, memoryBytes: $memoryBudgetBytes, memoryHeadroomBytes: $memoryHeadroomBytes },
     hostMemory: $hostMemory,

--- a/infra/github-runner/publish-status.test.sh
+++ b/infra/github-runner/publish-status.test.sh
@@ -14,9 +14,11 @@ harlan-zw/example|harlan-desktop-ci|0|4|4|4g|8g|10g
 EOF
 printf '2\n' >"$test_root/state/queued/example-ci"
 # A held pool reads as an idle one until the reason reaches the snapshot. The
-# mtime is the hold's start, so a dashboard can age it.
-printf 'Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g\n' >"$test_root/state/held/example-ci"
-touch --date='@1787930450' "$test_root/state/held/example-ci"
+# reason is a tagged object with the numbers behind it, so a reader sees the size
+# of the shortfall and how long it has held.
+cat >"$test_root/state/held/example-ci" <<'HELD'
+{"_tag":"MemoryHeadroom","since":1787930450000,"availableBytes":18253611008,"headroomBytes":6442450944,"poolBytes":13958643712,"ramBackedBytes":12884901888}
+HELD
 printf '4\n' >"$test_root/state/spend/harlan-desktop-example-ci-burst-1"
 printf '4\n' >"$test_root/state/spend-memory/harlan-desktop-example-ci-burst-1"
 cat >"$test_root/state/jobs/harlan-desktop-example-ci-burst-1.json" <<'EOF'
@@ -69,14 +71,20 @@ HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
 
 snapshot="$test_root/state/status.json"
 jq --exit-status '
-  .version == 4
+  .version == 5
   and .updatedAt == 1787930500000
   and .budgets == { cpu: 20, memoryBytes: 25769803776, memoryHeadroomBytes: 8589934592 }
   and .jobTotals == { actualMilliseconds: 100000, billableMinutes: 2, completed: 1, trackedSince: 1787930200000 }
   and .pools == [{
     cpuPerRunner: 4,
-    heldReason: "Available memory 17g, headroom 6g, RAM-backed filesystems hold 12g",
-    heldSince: 1787930450000,
+    hold: {
+      _tag: "MemoryHeadroom",
+      availableBytes: 18253611008,
+      headroomBytes: 6442450944,
+      poolBytes: 13958643712,
+      ramBackedBytes: 12884901888,
+      since: 1787930450000
+    },
     live: 1,
     maximum: 4,
     memoryLimitBytes: 8589934592,
@@ -126,6 +134,29 @@ failure_status=$?
 set -e
 if (( failure_status == 0 )) || [[ "$(sha256sum "$snapshot")" != "$snapshot_checksum" ]]; then
   printf 'Expected Docker failure to preserve the previous runner snapshot.\n' >&2
+  exit 1
+fi
+
+# A marker the publisher cannot read is a broken pool, not a quiet one. Rendering
+# it as no hold would restore the exact failure this state exists to remove.
+printf 'not json\n' >"$test_root/state/held/example-ci"
+PATH="$test_root/bin:$PATH" \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
+./infra/github-runner/publish-status "$test_root/state" "$test_root/state/status.json" "$test_root/history" 2>/dev/null
+if ! jq --exit-status '.pools[0].hold == { _tag: "HoldUnreadable" }' "$snapshot" >/dev/null; then
+  jq --compact-output '.pools[0].hold' "$snapshot"
+  printf 'Expected an unreadable hold marker to stay distinct from no hold.\n' >&2
+  exit 1
+fi
+
+# A pool the supervisor never refused carries no hold at all.
+rm --force "$test_root/state/held/example-ci"
+PATH="$test_root/bin:$PATH" \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH_MS=1787930500000 \
+./infra/github-runner/publish-status "$test_root/state" "$test_root/state/status.json" "$test_root/history"
+if ! jq --exit-status '.pools[0].hold == { _tag: "NotHeld" }' "$snapshot" >/dev/null; then
+  jq --compact-output '.pools[0].hold' "$snapshot"
+  printf 'Expected a pool with no marker to publish no hold.\n' >&2
   exit 1
 fi
 

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -343,6 +343,55 @@ publish_queue_count() {
   mv --force "$temporary" "$target"
 }
 
+# One marker per pool naming why no runner started. The gate and the demand
+# poller both write it, because both can refuse, and a pool carries one reason
+# at a time. `publish-status` renders the marker into the snapshot, so the
+# reason reaches a reader instead of only the journal.
+#
+# The reason is a tagged object, not a sentence. The status page needs the
+# numbers behind the refusal, and a sentence cannot be read back.
+#
+# The write is atomic and carries the hold's start forward. A hold that has run
+# for ten hours must never read as one that started on the last gate run.
+write_hold() {
+  local slug="$1"
+  local tag="$2"
+  local numbers="${3:-}"
+  local target="$state_dir/held/$slug"
+  local temporary="$target.$$"
+  local since=''
+
+  [[ -n "$numbers" ]] || numbers='{}'
+  if [[ -r "$target" ]]; then
+    since="$(jq --raw-output '.since // empty' "$target" 2>/dev/null)" || since=''
+  fi
+  [[ "$since" =~ ^[0-9]+$ ]] || since="$(( $(date +%s) * 1000 ))"
+
+  if ! jq --compact-output --null-input \
+    --arg tag "$tag" \
+    --argjson since "$since" \
+    --argjson numbers "$numbers" \
+    '{ _tag: $tag, since: $since } + $numbers' >"$temporary" 2>/dev/null; then
+    rm --force "$temporary"
+    log "Could not write the hold reason for $slug"
+    return 0
+  fi
+  mv --force "$temporary" "$target"
+}
+
+clear_hold() {
+  rm --force "$state_dir/held/$1"
+}
+
+# Empty when the pool holds no reason. A caller retires only the reason it owns,
+# so one writer never erases another writer's refusal.
+hold_tag_for() {
+  local target="$state_dir/held/$1"
+
+  [[ -r "$target" ]] || return 0
+  jq --raw-output '._tag // empty' "$target" 2>/dev/null || true
+}
+
 # A pull request run is abandoned when no open pull request points at the run's
 # exact commit. A branch name match alone is not proof, because two open pull
 # requests from different forks can share one branch name while pointing at
@@ -479,6 +528,7 @@ queued_jobs_for_pool() {
 
 run_demand_poller() {
   local pool_index repository jobs queued idle deficit request
+  local live hold_tag hold_numbers
   local -a deploy_requests=()
   local -a standard_requests=()
   local -A repository_jobs=()
@@ -502,9 +552,18 @@ run_demand_poller() {
       fi
       if [[ "${repository_result[$repository]}" == unavailable ]]; then
         rm --force "$state_dir/queued/${pool_slug[$pool_index]}"
-        rm --force "$state_dir/held/${pool_slug[$pool_index]}"
+        # The supervisor cannot read demand, so it never even considers a runner.
+        # On 2026-09-06 that ran for ten hours and said so only in the journal,
+        # while the pool published the same zeroes a quiet morning publishes.
+        # Publish the refusal instead of erasing it.
+        write_hold "${pool_slug[$pool_index]}" DemandUnavailable
         log "Queued job demand is unavailable for ${pool_slug[$pool_index]}"
         continue
+      fi
+      # Demand reads again. Every later reason belongs to the gate, so this scan
+      # retires only the reason this scan owns.
+      if [[ "$(hold_tag_for "${pool_slug[$pool_index]}")" == DemandUnavailable ]]; then
+        clear_hold "${pool_slug[$pool_index]}"
       fi
       queued="$(queued_jobs_for_pool "$pool_index" "${repository_jobs[$repository]}")"
       publish_queue_count "$pool_index" "$queued"
@@ -516,6 +575,20 @@ run_demand_poller() {
       # its zero-demand drop then removes the marker beside the queued count.
       if (( queued == 0 )) && [[ -f "$state_dir/held/${pool_slug[$pool_index]}" ]]; then
         printf 'capacity\n' >"$scale_pipe"
+      fi
+      # The gate refuses a pool at its ceiling and then stops tracking it, so
+      # only this scan can retire that reason. A pool below its ceiling, or with
+      # nothing queued, is not held by its maximum. A busy pool with an empty
+      # queue is working, and must never render as a refused one.
+      live=$(( pool_warm[pool_index] + $(count_markers "$state_dir/burst/${pool_slug[$pool_index]}") ))
+      hold_tag="$(hold_tag_for "${pool_slug[$pool_index]}")"
+      if (( queued > 0 && live >= pool_max[pool_index] )); then
+        if [[ -z "$hold_tag" || "$hold_tag" == AtMaximum ]]; then
+          printf -v hold_numbers '{"live":%d,"maximum":%d}' "$live" "${pool_max[$pool_index]}"
+          write_hold "${pool_slug[$pool_index]}" AtMaximum "$hold_numbers"
+        fi
+      elif [[ "$hold_tag" == AtMaximum ]]; then
+        clear_hold "${pool_slug[$pool_index]}"
       fi
       idle="$(count_idle_burst "$pool_index")"
       deficit=$(( queued - idle ))
@@ -803,6 +876,7 @@ run_scaler() {
   local request pool_index container_name
   local burst_counter=0
   local slug live spent spent_memory available_memory ram_backed_memory hold_reason
+  local hold_tag hold_numbers
   local pending_pool pending_count attempt candidate priority_index queued_demand
   local -a pending_pools=()
   local -A pool_is_pending=()
@@ -843,7 +917,12 @@ run_scaler() {
         slug="${pool_slug[$pending_pool]}"
         live=$(( pool_warm[pending_pool] + $(count_markers "$state_dir/burst/$slug") ))
         if (( live >= pool_max[pending_pool] )); then
-          rm --force "$state_dir/held/$slug"
+          # Not a fault, and still a reason no runner started. A reader who sees
+          # queued work and no new runner needs the pool's own ceiling named.
+          # The demand poller retires this reason, because the gate drops the
+          # entry here and never looks at the pool again.
+          printf -v hold_numbers '{"live":%d,"maximum":%d}' "$live" "${pool_max[$pending_pool]}"
+          write_hold "$slug" AtMaximum "$hold_numbers"
           unset 'pool_is_pending[$pending_pool]'
           continue
         fi
@@ -859,7 +938,7 @@ run_scaler() {
             read -r queued_demand <"$state_dir/queued/$slug" || queued_demand=''
           fi
           if [[ "$queued_demand" == 0 ]]; then
-            rm --force "$state_dir/held/$slug"
+            clear_hold "$slug"
             unset 'pool_is_pending[$pending_pool]'
             log "Dropping held demand for $slug; its queued count returned to zero"
             continue
@@ -867,38 +946,54 @@ run_scaler() {
         fi
 
         hold_reason=''
+        hold_tag=''
+        hold_numbers=''
         spent="$(sum_markers "$state_dir/spend")"
         if (( spent + pool_cpus[pending_pool] > cpu_budget )); then
           hold_reason="CPU in flight $spent, burst threshold $cpu_budget"
+          hold_tag='CpuBudget'
+          printf -v hold_numbers '{"budgetCpu":%d,"inFlightCpu":%d,"poolCpu":%d}' \
+            "$cpu_budget" "$spent" "${pool_cpus[$pending_pool]}"
         else
           # Checked after CPU and never merged with it. A host can have cores to
           # spare and no memory to back them, which is the case this exists for.
           spent_memory="$(sum_markers "$state_dir/spend-memory")"
           if (( spent_memory + pool_memory_reservation_gib[pending_pool] > memory_budget_gib )); then
             hold_reason="Memory in flight ${spent_memory}g, budget ${memory_budget_gib}g"
+            hold_tag='MemoryBudget'
+            printf -v hold_numbers '{"budgetBytes":%d,"inFlightBytes":%d,"poolBytes":%d}' \
+              "$(( memory_budget_gib * 1024 ** 3 ))" \
+              "$(( spent_memory * 1024 ** 3 ))" \
+              "$(( pool_memory_reservation_gib[pending_pool] * 1024 ** 3 ))"
           else
             available_memory="$(host_available_memory_gib)"
             if [[ ! "$available_memory" =~ ^[0-9]+$ ]]; then
               hold_reason='Available memory is unknown'
+              hold_tag='MemoryUnknown'
             elif (( available_memory - pool_memory_reservation_gib[pending_pool] < memory_headroom_gib )); then
               hold_reason="Available memory ${available_memory}g, headroom ${memory_headroom_gib}g"
               ram_backed_memory="$(host_ram_backed_memory_gib)"
-              if [[ "$ram_backed_memory" =~ ^[0-9]+$ ]] && (( ram_backed_memory > 0 )); then
+              [[ "$ram_backed_memory" =~ ^[0-9]+$ ]] || ram_backed_memory=0
+              if (( ram_backed_memory > 0 )); then
                 hold_reason="${hold_reason}, RAM-backed filesystems hold ${ram_backed_memory}g"
               fi
+              hold_tag='MemoryHeadroom'
+              printf -v hold_numbers '{"availableBytes":%d,"headroomBytes":%d,"poolBytes":%d,"ramBackedBytes":%d}' \
+                "$(( available_memory * 1024 ** 3 ))" \
+                "$(( memory_headroom_gib * 1024 ** 3 ))" \
+                "$(( pool_memory_reservation_gib[pending_pool] * 1024 ** 3 ))" \
+                "$(( ram_backed_memory * 1024 ** 3 ))"
             fi
           fi
         fi
-        if [[ -n "$hold_reason" ]]; then
+        if [[ -n "$hold_tag" ]]; then
           log "$hold_reason; holding $slug at $live"
           # The journal already carries this, and nothing reads the journal until
-          # someone notices. `publish-status` turns the marker into the dashboard's
+          # someone notices. `publish-status` turns the marker into the snapshot's
           # hold state, so a pool held for hours stops looking like an idle one.
-          # That state ages the hold from the marker's mtime. Write the marker
-          # only while it is absent, so later gate runs keep the hold's start.
-          if [[ ! -e "$state_dir/held/$slug" ]]; then
-            printf '%s\n' "$hold_reason" >"$state_dir/held/$slug"
-          fi
+          # The numbers travel with the tag, because the reader needs the size of
+          # the shortfall, not only its name.
+          write_hold "$slug" "$hold_tag" "$hold_numbers"
           if (( pool_is_deploy[pending_pool] )); then
             pending_pools=("$pending_pool" "${pending_pools[@]}")
             break
@@ -910,7 +1005,7 @@ run_scaler() {
         unset 'pool_is_pending[$pending_pool]'
         # The hold ends when the gate admits the pool. Remove the marker beside
         # the scheduling it guarded, or the pool reports held while it runs.
-        rm --force "$state_dir/held/$slug"
+        clear_hold "$slug"
 
         # A restart resets this counter while a spared burst container from the
         # previous generation may still hold one of these names. Skip past it.

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -28,6 +28,9 @@ printf '%s\n' "$*" >>"$TEST_CALLS/gh"
 if [[ "$*" == *registration-token* ]]; then
   printf 'test-token\n'
 fi
+if [[ "$*" == *'actions/runs?status='* && -f "$TEST_CALLS/demand-unavailable" ]]; then
+  exit 1
+fi
 if [[ "$*" == *'actions/runs?status=in_progress'* && -f "$TEST_CALLS/queue-in-progress" ]]; then
   printf '78\t2026-08-27T04:30:00Z\tpull_request\tfix/live\t1111111111111111111111111111111111111111\n'
 fi
@@ -329,7 +332,7 @@ if (( $(wc -l <"$test_root/calls/burst") != 2 )); then
   exit 1
 fi
 
-if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, heldReason: null, heldSince: null, live: 0, maximum: 2, memoryLimitBytes: 2147483648, memoryReservationBytes: 1073741824, name: "example-ci", queued: 2, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
+if ! jq --exit-status '.pools == [{ cpuPerRunner: 1, hold: { _tag: "NotHeld" }, live: 0, maximum: 2, memoryLimitBytes: 2147483648, memoryReservationBytes: 1073741824, name: "example-ci", queued: 2, repository: "harlan-zw/example", running: 0 }]' "$test_root/calls/status.json" >/dev/null; then
   cat "$test_root/calls/status.json"
   printf 'Expected queued demand in the published runner status.\n' >&2
   exit 1
@@ -615,6 +618,8 @@ HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=2 \
 HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=2 \
 HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
 HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.05 \
+HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
 timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
 status=$?
 set -e
@@ -637,6 +642,23 @@ fi
 if ! grep --quiet 'RAM-backed filesystems hold [0-9]\+g; holding example-ci at 0' "$test_root/output"; then
   cat "$test_root/output"
   printf 'Expected the hold reason to name RAM-backed filesystem usage.\n' >&2
+  exit 1
+fi
+
+# A sentence in the journal cannot be read back. The snapshot carries the tag
+# and the numbers behind it, so a page can say how far short the pool fell.
+if ! jq --exit-status '
+  .pools[]
+  | select(.name == "example-ci")
+  | .hold._tag == "MemoryHeadroom"
+    and .hold.availableBytes == 2147483648
+    and .hold.headroomBytes == 2147483648
+    and .hold.poolBytes == 1073741824
+    and (.hold.ramBackedBytes | type) == "number"
+    and (.hold.since | type) == "number"
+' "$test_root/calls/status.json" >/dev/null; then
+  jq --compact-output '.pools[] | select(.name == "example-ci") | .hold' "$test_root/calls/status.json"
+  printf 'Expected the published hold to name the headroom shortfall and its numbers.\n' >&2
   exit 1
 fi
 
@@ -712,7 +734,7 @@ held_since_first=''
 held_since_drifted=''
 while kill -0 "$supervisor_pid" 2>/dev/null; do
   if [[ -s "$test_root/calls/status.json" ]]; then
-    held_since="$(jq --raw-output '.pools[] | select(.name == "example-ci") | .heldSince // empty' "$test_root/calls/status.json" 2>/dev/null || true)"
+    held_since="$(jq --raw-output '.pools[] | select(.name == "example-ci") | select(.hold._tag != "NotHeld") | .hold.since' "$test_root/calls/status.json" 2>/dev/null || true)"
     if [[ -n "$held_since" ]]; then
       if [[ -z "$held_since_first" ]]; then
         held_since_first="$held_since"
@@ -793,7 +815,7 @@ held_cleared=''
 while kill -0 "$supervisor_pid" 2>/dev/null; do
   pool_json="$(jq --compact-output '.pools[] | select(.name == "example-ci")' "$test_root/calls/status.json" 2>/dev/null || true)"
   if [[ -n "$pool_json" ]]; then
-    held_reason="$(jq --raw-output '.heldReason // empty' <<<"$pool_json")"
+    held_reason="$(jq --raw-output 'select(.hold._tag != "NotHeld") | .hold._tag' <<<"$pool_json")"
     queued_count="$(jq --raw-output '.queued' <<<"$pool_json")"
     if [[ -n "$held_reason" ]]; then
       saw_hold=1
@@ -934,13 +956,148 @@ if grep --quiet -- '-deploy-burst-' "$test_root/calls/burst" 2>/dev/null; then
   exit 1
 fi
 
-if ! jq --exit-status '.pools[] | select(.name == "example-deploy") | .heldReason == null and .heldSince == null' "$test_root/calls/status.json" >/dev/null; then
+if ! jq --exit-status '.pools[] | select(.name == "example-deploy") | .hold == { _tag: "NotHeld" }' "$test_root/calls/status.json" >/dev/null; then
   cat "$test_root/calls/status.json"
   printf 'Expected the dropped deploy demand to clear the published hold.\n' >&2
   exit 1
 fi
 
 printf 'Cancelled deploy reservation passed.\n'
+
+# Cause one of the 2026-09-06 outage. The supervisor could not read queued job
+# demand, so it never considered a runner, and it said so only in the journal.
+# The pool published the zeroes a quiet morning publishes, for ten hours. The
+# refusal must reach the snapshot, and it must go when demand reads again.
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/demand-unavailable"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|0|2|1|1g|2g|3g
+EOF
+
+set +e
+(
+  TEST_CALLS="$test_root/calls" \
+  PATH="$test_root/bin:$PATH" \
+  XDG_RUNTIME_DIR="$test_root/runtime" \
+  CREDENTIALS_DIRECTORY="$test_root/credentials" \
+  HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+  HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
+  HARLAN_DESKTOP_RUNNER_CPU_BUDGET=4 \
+  HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=4 \
+  HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+  HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+  HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.2 \
+  HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
+  timeout --preserve-status --kill-after=1 70 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+) &
+supervisor_pid=$!
+
+saw_demand_hold=''
+saw_hold_start=''
+restored_demand=''
+demand_hold_cleared=''
+while kill -0 "$supervisor_pid" 2>/dev/null; do
+  hold_json="$(jq --compact-output '.pools[] | select(.name == "example-ci") | .hold' "$test_root/calls/status.json" 2>/dev/null || true)"
+  if [[ -n "$hold_json" ]]; then
+    hold_tag="$(jq --raw-output '._tag' <<<"$hold_json")"
+    if [[ "$hold_tag" == DemandUnavailable ]]; then
+      saw_demand_hold=1
+      jq --exit-status '.since | type == "number"' <<<"$hold_json" >/dev/null && saw_hold_start=1
+      if [[ -z "$restored_demand" ]]; then
+        rm --force "$test_root/calls/demand-unavailable"
+        touch "$test_root/calls/queue-enabled"
+        restored_demand=1
+      fi
+    fi
+    if [[ -n "$restored_demand" && "$hold_tag" == NotHeld ]]; then
+      demand_hold_cleared=1
+    fi
+  fi
+  sleep 0.05
+done
+wait "$supervisor_pid"
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the unreadable demand run to drain cleanly.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet 'Queued job demand is unavailable for example-ci' "$test_root/output"; then
+  cat "$test_root/output"
+  printf 'Expected the unavailable demand decision in the supervisor log.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$saw_demand_hold" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/status.json"
+  printf 'Expected unreadable demand to publish a hold instead of an idle pool.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$saw_hold_start" ]]; then
+  cat "$test_root/calls/status.json"
+  printf 'Expected the demand hold to carry the time it was first seen.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$demand_hold_cleared" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/status.json"
+  printf 'Expected the demand hold to clear once demand read again.\n' >&2
+  exit 1
+fi
+
+printf 'Unreadable demand publishes a hold passed.\n'
+
+# A pool at its own ceiling starts no runner either. The gate drops the entry
+# and stops tracking the pool, so the demand scan owns this reason. Queued work
+# with no new runner needs the ceiling named, or the page shows only zeroes.
+rm -rf "$test_root/calls" "$test_root/runtime"
+mkdir -p "$test_root/calls" "$test_root/runtime"
+touch "$test_root/calls/queue-enabled"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|1|1|1|1g|2g|3g
+EOF
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=4 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=4 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS=0.05 \
+HARLAN_DESKTOP_RUNNER_STATUS_OUTPUT="$test_root/calls/status.json" \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the pool at its maximum to drain cleanly.\n' >&2
+  exit 1
+fi
+
+if ! jq --exit-status '
+  .pools[]
+  | select(.name == "example-ci")
+  | .hold._tag == "AtMaximum" and .hold.live == 1 and .hold.maximum == 1
+' "$test_root/calls/status.json" >/dev/null; then
+  jq --compact-output '.pools[] | select(.name == "example-ci") | .hold' "$test_root/calls/status.json"
+  printf 'Expected a pool at its maximum to publish that reason.\n' >&2
+  exit 1
+fi
+
+printf 'Pool at its maximum publishes a hold passed.\n'
 
 if [[ -n "$(find "$state_home" -mindepth 1 -print -quit)" ]]; then
   find "$state_home"


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

skilld.dev CI was down from 01:52Z to 12:19Z today and nothing surfaced it. The
status page showed the pool at zero runners, which is what a quiet morning looks
like. Two separate refusals were both invisible. The supervisor could not read
queued job demand for the repository, so it never considered a runner at all. The
memory gate was holding other pools. Both wrote one line a minute to the journal
and nowhere else.

Every place the supervisor decides not to start a runner now writes one tagged
marker per pool, and `publish-status` renders it into the snapshot. A hold carries
the numbers behind it and the time it was first seen, so a reader gets ten hours
rather than "held".

![How a refusal reaches a reader: the demand scan and the capacity gate both write one hold marker per pool, and the publisher renders it into status.json](https://github.com/user-attachments/assets/1d02208e-8d94-48d0-93b5-e823e844c509)

![Unreadable demand end to end: the API refuses the read, the demand scan writes a DemandUnavailable hold, and the snapshot carries it to the status page](https://github.com/user-attachments/assets/1f0cf863-ee8c-40ad-827f-19ccac9d0608)

Two decisions I would like a second opinion on:

- `AtMaximum` sits in the same union as the budget refusals. The gate drops a
  pool at its ceiling and stops tracking it, so the demand scan is the only thing
  that can retire that reason, up to 60 seconds late. I could not find a way to
  prove that retirement without a 65 second test case, so it is the one path here
  with no direct test.
- The publisher publishes `HoldUnreadable` for a marker it cannot parse, rather
  than falling back to no hold. That is a tag with no gate behind it, which the
  brief warned against. I kept it because the alternative renders a broken pool as
  a quiet one, which is the whole failure. Happy to drop it if you disagree.

I did not model a RAM-backed filesystem hold. #123 made that an annotation on the
headroom refusal, not a decision of its own, so it travels as `ramBackedBytes` on
`MemoryHeadroom`.

Snapshot version moves to 5. harlan-zw/hogwild.harlanzw.com#17 renders it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h
