### PR TITLE
fix(github-runner): keep aged push runs for open pull requests

### DIFF
--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -76,12 +76,18 @@ readonly demand_poll_seconds=$(( configured_demand_poll_seconds > minimum_demand
 # neither run nor be cancelled, so they must not keep creating runner demand.
 #
 # Age alone cannot identify one. A pull request that waits behind a saturated
-# host ages past any threshold too, and dropping its demand starves it for good:
-# it never bursts a runner, so it only ages further. An aged pull request run
-# therefore keeps its demand while an open pull request still points at the run's
-# exact commit. The branch name is not enough, because a new pull request can
-# reuse a closed pull request's branch name. A run of any other event has no
-# branch to verify. Age stays its only bound.
+# host, or behind a host that could not reach GitHub for a morning, ages past
+# any threshold too, and dropping its demand starves it for good: it never
+# bursts a runner, so it only ages further. An aged pull request or push run
+# therefore keeps its demand while an open pull request still points at the
+# run's exact commit. A push run qualifies because a workflow that triggers on
+# `push` is the only CI a pull request from the same repository gets. The
+# branch name is not enough, because a new pull request can reuse a closed pull
+# request's branch name. A run of any other event names no pull request to
+# verify, so age stays its only bound.
+#
+# Age counts from the latest attempt, not the run's creation. A rerun of an
+# aged run is fresh demand a person just asked for.
 readonly queued_run_max_age_seconds="${HARLAN_DESKTOP_RUNNER_QUEUED_RUN_MAX_AGE_SECONDS:-21600}"
 readonly fixed_now_epoch="${HARLAN_DESKTOP_RUNNER_NOW_EPOCH:-}"
 readonly status_interval_seconds="${HARLAN_DESKTOP_RUNNER_STATUS_INTERVAL_SECONDS:-15}"
@@ -398,8 +404,8 @@ hold_tag_for() {
 # different commits. Verification therefore keys open pull requests by commit,
 # so an aged run survives while any open pull request holds its commit. A run
 # whose listing gave no commit falls back to the branch name. Every aged run of
-# another event is abandoned before this check, because it has no branch to
-# verify and age is its only bound on demand.
+# an event other than a pull request or a push is abandoned before this check,
+# because it names no pull request to verify and age is its only bound on demand.
 aged_run_is_abandoned() {
   local head_branch="$1"
   local head_sha="$2"
@@ -419,7 +425,7 @@ aged_run_is_abandoned() {
 # label text.
 queued_job_labels_for_repository() {
   local repository="$1"
-  local listing jobs run_id run_status created_at created_epoch
+  local listing jobs run_id run_status started_at started_epoch
   local event head_branch head_sha aged_run branch sha
   local now_epoch oldest_epoch
   local -a run_ids=()
@@ -440,17 +446,17 @@ queued_job_labels_for_repository() {
   for run_status in queued in_progress; do
     if ! listing="$(github_api --paginate \
       "repos/$repository/actions/runs?status=$run_status&per_page=100" \
-      --jq '.workflow_runs[] | [.id, .created_at, .event, .head_branch, .head_sha] | @tsv' 2>/dev/null)"; then
+      --jq '.workflow_runs[] | [.id, (.run_started_at // .created_at), .event, .head_branch, .head_sha] | @tsv' 2>/dev/null)"; then
       return 1
     fi
-    while IFS=$'\t' read -r run_id created_at event head_branch head_sha; do
+    while IFS=$'\t' read -r run_id started_at event head_branch head_sha; do
       [[ -z "$run_id" || -n "${seen_run_ids[$run_id]:-}" ]] && continue
-      if ! created_epoch="$(date --date="$created_at" +%s 2>/dev/null)"; then
-        log "Ignoring runner demand with an invalid creation time in $repository" >&2
+      if ! started_epoch="$(date --date="$started_at" +%s 2>/dev/null)"; then
+        log "Ignoring runner demand with an invalid start time in $repository" >&2
         continue
       fi
       seen_run_ids[$run_id]=true
-      if (( created_epoch < oldest_epoch )); then
+      if (( started_epoch < oldest_epoch )); then
         aged_runs+=("$run_id"$'\t'"$event"$'\t'"$head_branch"$'\t'"$head_sha")
         continue
       fi
@@ -459,13 +465,14 @@ queued_job_labels_for_repository() {
   done
 
   # Verifying costs one more read of the shared API budget, so only a
-  # repository holding an aged pull request run pays for it. An aged run of any
-  # other event is dropped here, because age is its only bound on demand.
+  # repository holding an aged pull request or push run pays for it. An aged
+  # run of any other event is dropped here, because age is its only bound on
+  # demand.
   local -a verifiable_aged_runs=()
   if (( ${#aged_runs[@]} > 0 )); then
     for aged_run in "${aged_runs[@]}"; do
       IFS=$'\t' read -r run_id event head_branch head_sha <<<"$aged_run"
-      if [[ "$event" == pull_request || "$event" == pull_request_target ]]; then
+      if [[ "$event" == pull_request || "$event" == pull_request_target || "$event" == push ]]; then
         verifiable_aged_runs+=("$aged_run")
       else
         log "Ignoring runner demand from aged $event run $run_id in $repository" >&2

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -84,6 +84,34 @@ fi
 if [[ "$*" == *'actions/runs/75/jobs'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
   printf 'self-hosted,harlan-desktop-ci\n'
 fi
+if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-rot-push" ]]; then
+  printf 'fix/other\t9999999999999999999999999999999999999999\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-rot-schedule" ]]; then
+  printf '77\t2026-08-26T00:00:00Z\tschedule\tmain\t4444444444444444444444444444444444444444\n'
+fi
+if [[ "$*" == *'actions/runs/77/jobs'* && -f "$TEST_CALLS/queue-rot-schedule" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved-push" ]]; then
+  printf '78\t2026-08-26T00:00:00Z\tpush\tfix/open\t2222222222222222222222222222222222222222\n'
+fi
+if [[ "$*" == *'actions/runs/78/jobs'* && -f "$TEST_CALLS/queue-starved-push" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
+if [[ "$*" == *'pulls?state=open'* && -f "$TEST_CALLS/queue-starved-push" ]]; then
+  printf 'fix/open\t2222222222222222222222222222222222222222\n'
+fi
+if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-rerun" ]]; then
+  if [[ "$*" == *'.run_started_at'* ]]; then
+    printf '79\t2026-08-27T04:30:00Z\tpush\tfix/rerun\t1111111111111111111111111111111111111111\n'
+  else
+    printf '79\t2026-08-26T00:00:00Z\tpush\tfix/rerun\t1111111111111111111111111111111111111111\n'
+  fi
+fi
+if [[ "$*" == *'actions/runs/79/jobs'* && -f "$TEST_CALLS/queue-rerun" ]]; then
+  printf 'self-hosted,harlan-desktop-ci\n'
+fi
 if [[ "$*" == *'actions/runs?status=queued'* && -f "$TEST_CALLS/queue-starved" ]]; then
   printf '75\t2026-08-26T00:00:00Z\tpull_request\tfix/open\t2222222222222222222222222222222222222222\n'
 fi
@@ -426,7 +454,7 @@ fi
 
 printf 'Closed pull request demand filtering passed.\n'
 
-begin_case 'Aged non-pull_request demand filtering'
+begin_case 'Aged push demand filtering'
 touch "$test_root/calls/queue-rot-push"
 
 set +e
@@ -446,17 +474,113 @@ set -e
 if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
   cat "$test_root/output"
   cat "$test_root/calls/gh"
-  printf 'Expected an aged non-pull_request run to leave a zero-warm pool stopped.\n' >&2
+  printf 'Expected an aged push run whose commit no open pull request holds to leave a zero-warm pool stopped.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet 'pulls?state=open' "$test_root/calls/gh"; then
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged push run to be verified against open pull requests.\n' >&2
+  exit 1
+fi
+
+if grep --quiet 'actions/runs/75/jobs' "$test_root/calls/gh"; then
+  cat "$test_root/calls/gh"
+  printf 'Expected the abandoned push run to be dropped before its jobs were read.\n' >&2
+  exit 1
+fi
+
+printf 'Aged push demand filtering passed.\n'
+
+begin_case 'Aged schedule demand filtering'
+touch "$test_root/calls/queue-rot-schedule"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged schedule run to leave a zero-warm pool stopped.\n' >&2
   exit 1
 fi
 
 if grep --quiet 'pulls?state=open' "$test_root/calls/gh"; then
   cat "$test_root/calls/gh"
-  printf 'Expected an aged non-pull_request run to skip pull request verification.\n' >&2
+  printf 'Expected an aged schedule run to skip pull request verification.\n' >&2
   exit 1
 fi
 
-printf 'Aged non-pull_request demand filtering passed.\n'
+printf 'Aged schedule demand filtering passed.\n'
+
+begin_case 'Starved push demand'
+touch "$test_root/calls/queue-starved-push"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected an aged push run whose commit an open pull request holds to still start a runner.\n' >&2
+  exit 1
+fi
+
+printf 'Starved push demand passed.\n'
+
+begin_case 'Rerun demand'
+touch "$test_root/calls/queue-rerun"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected a rerun of an old run to count as fresh demand.\n' >&2
+  exit 1
+fi
+
+if grep --quiet 'pulls?state=open' "$test_root/calls/gh"; then
+  cat "$test_root/calls/gh"
+  printf 'Expected a fresh rerun to skip pull request verification.\n' >&2
+  exit 1
+fi
+
+printf 'Rerun demand passed.\n'
 
 begin_case 'Starved pull request demand'
 touch "$test_root/calls/queue-starved"


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Hogwild's runner containers could not resolve `api.github.com` from 03:28 to 12:56 AEST today (Docker DNS was pinned to the desktop's AdGuard, since fixed on the host). Every run that queued in that window aged past the six hour bound. gscdump's test workflow triggers on `push`, so the supervisor logged `Ignoring runner demand from aged push run 34257264490` for gscdump#49 and would never serve it, while the open pull request sat with its CI gate PENDING. Only `pull_request` runs got the open-pull-request check.

An aged `push` run now keeps its demand while an open pull request holds its head SHA, the same check the `pull_request` runs already get. Age also counts from `run_started_at` rather than `created_at`, so a `gh run rerun` is fresh demand instead of an aged run that stays ignored. GitHub does move `run_started_at` on rerun (gscdump run 33964758489: created 11:58, attempt 2 started 12:14).

Schedule and other event runs keep the age-only bound. A cron sweep from ten hours ago is not wanted.

Not touched: Hogwild still runs the installed copy at `/var/lib/github-runner/bin/supervisor`. After merge it needs the `sudo install` step from `infra/github-runner/README.md` (Hogwild installation) and a `systemctl restart hogwild-github-runner.service` between jobs.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01M7niME5WXD6s62J8L9BF6i