### PR TITLE
feat: add root pnpm release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ Packages are pnpm workspace members under `packages/*`. Shared dependency versio
 
 ## Releases
 
-Push a `<package>-v<version>` tag, for example `nuxt-dx-v0.0.2`. The trusted GitHub Actions publisher releases that package under the `latest` npm tag with provenance.
+Merge the package version bump through a pull request first. Then run from the repo root:
+
+```bash
+pnpm release                         # choose a package and confirm publishing
+pnpm release nuxt-dx --dry-run        # preview the version, commit, and tag
+pnpm release nuxt-dx --yes            # publish without a prompt
+```
+
+The command reads the version from `origin/main` and pushes its `<package>-v<version>` tag.
+It rejects existing tags and prerelease versions.
+The trusted GitHub Actions publisher releases that package under the `latest` npm tag with provenance.
 
 ## Sponsors
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,14 @@
     "dev:prepare": "pnpm -r --if-present run dev:prepare",
     "lint": "pnpm -r --if-present run lint",
     "lint:fix": "pnpm -r --if-present run lint:fix",
+    "release": "node scripts/release.mjs",
     "typecheck": "pnpm -r --if-present run typecheck",
-    "test": "pnpm -r --if-present run test",
+    "test": "node --test scripts/*.test.mjs && pnpm -r --if-present run test",
     "test:attw": "pnpm -r --if-present run test:attw",
     "test:pack": "pnpm -r --if-present run test:pack"
+  },
+  "devDependencies": {
+    "consola": "catalog:",
+    "yaml": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,14 @@ catalogs:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      consola:
+        specifier: 'catalog:'
+        version: 3.4.2
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
 
   packages/comark-content:
     dependencies:

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+import { consola } from 'consola'
+import { parse } from 'yaml'
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+}
+
+async function main() {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      'dry-run': { type: 'boolean' },
+      'yes': { type: 'boolean', short: 'y' },
+      'help': { type: 'boolean', short: 'h' },
+    },
+  })
+  if (values.help) {
+    consola.log('Usage: pnpm release [package] [--dry-run] [--yes]')
+    consola.log('Publish a stable package version already merged into origin/main.')
+    return
+  }
+  if (positionals.length > 1)
+    throw new Error('Choose one package: pnpm release [package] [--dry-run] [--yes].')
+
+  git('fetch', 'origin', 'refs/heads/main')
+  const commit = git('rev-parse', 'FETCH_HEAD')
+  const workflow = parse(git('show', `${commit}:.github/workflows/release.yml`))
+  const packages = workflow.on.push.tags
+    .filter(tag => tag.endsWith('-v*'))
+    .map(tag => tag.slice(0, -3))
+    .sort()
+
+  let selected = positionals[0]?.replace(/^@harlan-zw\//, '')
+  if (!selected) {
+    if (!process.stdin.isTTY)
+      throw new Error('Choose a package: pnpm release <package> [--dry-run] [--yes].')
+    selected = await consola.prompt('Choose a package to publish:', {
+      type: 'select',
+      options: packages,
+      cancel: 'reject',
+    })
+  }
+  if (!packages.includes(selected))
+    throw new Error(`Unknown package: ${selected}. Choose: ${packages.join(', ')}.`)
+
+  const manifest = JSON.parse(git('show', `${commit}:packages/${selected}/package.json`))
+  if (manifest.private)
+    throw new Error(`Package ${selected} is private.`)
+  if (typeof manifest.version !== 'string' || !/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(manifest.version))
+    throw new Error('The publisher requires a stable version, such as 1.2.3.')
+
+  const tag = `${selected}-v${manifest.version}`
+  if (git('ls-remote', '--tags', 'origin', `refs/tags/${tag}`))
+    throw new Error(`Tag ${tag} already exists. Merge a version bump before releasing again.`)
+
+  consola.info(`Release: ${manifest.name}@${manifest.version}`)
+  consola.info(`Commit: ${commit} (origin/main)`)
+  consola.info(`Tag: ${tag}`)
+  if (values['dry-run']) {
+    consola.success('Dry run complete. No tag was pushed.')
+    return
+  }
+  if (!values.yes) {
+    if (!process.stdin.isTTY)
+      throw new Error('If you want to publish, run again with --yes.')
+    const confirmed = await consola.prompt('Push this tag and start npm publishing?', {
+      type: 'confirm',
+      initial: false,
+      cancel: 'reject',
+    })
+    if (!confirmed)
+      return
+  }
+
+  // Push only the selected tag. Local changes and branches stay outside the release.
+  git('push', 'origin', `${commit}:refs/tags/${tag}`)
+  consola.success(`Pushed ${tag}. GitHub Actions will publish the package.`)
+}
+
+main().catch((error) => {
+  consola.error(error.message)
+  process.exitCode = 1
+})

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,115 @@
+/* eslint test/no-import-node-test: off -- The root CLI uses Node's built-in test runner. */
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const command = fileURLToPath(new URL('./release.mjs', import.meta.url))
+
+function fixture(t) {
+  const root = mkdtempSync(join(tmpdir(), 'harlan-release-'))
+  t.after(() => rmSync(root, { recursive: true, force: true }))
+  const cwd = join(root, 'checkout')
+  const remote = join(root, 'origin.git')
+  const git = (...args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+  execFileSync('git', ['init', '--bare', '--initial-branch=main', remote], { stdio: 'ignore' })
+  mkdirSync(cwd)
+  git('init', '--initial-branch=main')
+  git('config', 'user.name', 'Release Test')
+  git('config', 'user.email', 'release@example.test')
+  git('config', 'core.hooksPath', '/dev/null')
+  git('config', 'commit.gpgsign', 'false')
+  git('remote', 'add', 'origin', remote)
+  mkdirSync(join(cwd, '.github/workflows'), { recursive: true })
+  writeFileSync(join(cwd, '.github/workflows/release.yml'), 'on:\n  push:\n    tags:\n      - nuxt-dx-v*\n      - nuxt-use-query-v*\n')
+  for (const name of ['nuxt-dx', 'nuxt-use-query']) {
+    mkdirSync(join(cwd, 'packages', name), { recursive: true })
+    writeFileSync(join(cwd, 'packages', name, 'package.json'), JSON.stringify({ name: `@harlan-zw/${name}`, version: '1.2.3' }))
+  }
+  git('add', '.')
+  git('commit', '-m', 'chore: create release fixture')
+  git('push', '-u', 'origin', 'main')
+  const sha = git('rev-parse', 'HEAD')
+  const run = (...args) => spawnSync(process.execPath, [command, ...args], { cwd, encoding: 'utf8', env: { ...process.env, CI: 'true' } })
+  return { cwd, git, sha, run }
+}
+
+test('publishes only the selected package tag at remote main', (t) => {
+  const { git, run, sha } = fixture(t)
+  git('switch', '-c', 'feature/unmerged')
+  git('commit', '--allow-empty', '-m', 'feat: keep an unmerged change')
+  const result = run('nuxt-dx', '--yes')
+  assert.equal(result.status, 0, result.stderr)
+  assert.equal(git('ls-remote', '--tags', 'origin'), `${sha}\trefs/tags/nuxt-dx-v1.2.3`)
+  assert.equal(git('ls-remote', 'origin', 'refs/heads/main'), `${sha}\trefs/heads/main`)
+  assert.equal(git('branch', '--show-current'), 'feature/unmerged')
+})
+
+test('dry run leaves the remote without tags', (t) => {
+  const { git, run } = fixture(t)
+  const result = run('@harlan-zw/nuxt-dx', '--dry-run')
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /nuxt-dx-v1\.2\.3/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), '')
+})
+
+test('rejects an existing release tag without changing it', (t) => {
+  const { git, run, sha } = fixture(t)
+  git('push', 'origin', `${sha}:refs/tags/nuxt-dx-v1.2.3`)
+  const result = run('nuxt-dx', '--yes')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /already exists/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), `${sha}\trefs/tags/nuxt-dx-v1.2.3`)
+})
+
+test('rejects unknown packages before publishing', (t) => {
+  const { git, run } = fixture(t)
+  const result = run('../nuxt-dx', '--yes')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Unknown package/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), '')
+})
+
+test('requires explicit confirmation without a terminal', (t) => {
+  const { git, run } = fixture(t)
+  const result = run('nuxt-dx')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /--yes/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), '')
+})
+
+test('rejects prereleases because the publisher uses latest', (t) => {
+  const { cwd, git, run } = fixture(t)
+  writeFileSync(join(cwd, 'packages/nuxt-dx/package.json'), JSON.stringify({ name: '@harlan-zw/nuxt-dx', version: '1.3.0-beta.1' }))
+  git('add', '.')
+  git('commit', '-m', 'chore: prepare prerelease')
+  git('push')
+  const result = run('nuxt-dx', '--yes')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /stable version/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), '')
+})
+
+test('rejects private packages before publishing', (t) => {
+  const { cwd, git, run } = fixture(t)
+  writeFileSync(join(cwd, 'packages/nuxt-dx/package.json'), JSON.stringify({ name: '@harlan-zw/nuxt-dx', version: '1.2.3', private: true }))
+  git('add', '.')
+  git('commit', '-m', 'chore: make package private')
+  git('push')
+  const result = run('nuxt-dx', '--yes')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /is private/)
+  assert.equal(git('ls-remote', '--tags', 'origin'), '')
+})
+
+test('stops when the remote cannot be fetched', (t) => {
+  const { cwd, git, run } = fixture(t)
+  git('remote', 'set-url', 'origin', join(cwd, 'missing.git'))
+  const result = run('nuxt-dx', '--yes')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /git fetch/)
+  assert.equal(git('tag', '--list'), '')
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Release tags currently need manual Git commands. `pnpm release` selects a package and pushes its merged version tag, with a dry run and confirmation.

![The root command pushes a package tag from merged main to the existing npm publisher](https://github.com/user-attachments/assets/a4572380-4a9e-4319-9734-d623dae808ec)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
