### PR TITLE
feat(github-runner): register runners with just-in-time config

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -52,8 +52,8 @@ string everywhere and a site moves between hosts by changing one input.
 | `harlan-desktop-light` | Detection, reports, and API calls. Two CPUs and 2 GB by default. |
 | `harlan-desktop-deploy` | Production deploys. Larger container, one at a time. |
 
-Write them as `runs-on: [self-hosted, linux, x64, harlan-desktop-ci]`. The runner adds
-`self-hosted`, `linux`, and `x64` itself.
+Write them as `runs-on: [self-hosted, linux, x64, harlan-desktop-ci]`. The supervisor
+mints every runner with `self-hosted`, `linux`, and `x64` plus the pool labels.
 
 ## Host setup
 
@@ -230,6 +230,14 @@ Use `sudo hogwild-safe-poweroff` for a drained shutdown.
 
 ## Updating the runner
 
-Update `RUNNER_VERSION` and `RUNNER_SHA256` in the Dockerfile, update the tag in
-`HARLAN_DESKTOP_RUNNER_IMAGE` or the supervisor default, rebuild, then restart the
-service. GitHub requires a runner update within 30 days of a release.
+A just-in-time config cannot disable runner self-update. `config.sh` accepted
+`--disableupdate`; `generate-jitconfig` has no equivalent, and `run.sh --jitconfig`
+rejects the flag. While the image pin trails GitHub's latest release, every job
+container downloads that release, applies it, and runs its job on it. Jobs then
+execute an unpinned runner version, and every job pays the download until the
+image matches the latest release.
+
+Rebuild the image promptly after every runner release. Update `RUNNER_VERSION` and
+`RUNNER_SHA256` in the Dockerfile, update the tag in `HARLAN_DESKTOP_RUNNER_IMAGE` or
+the supervisor default, rebuild, then restart the service. GitHub requires a runner
+update within 30 days of a release.

--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -27,11 +27,14 @@ A warm listener remains optional for a pool that needs lower startup latency.
 ## Trust boundary
 
 - Every pool is repository-scoped and accepts jobs from that repository only.
-- Every job gets a newly registered ephemeral runner in a fresh container.
+- Every job gets a fresh container and a just-in-time runner that GitHub
+  removes after that one job.
 - Containers run unprivileged, drop all Linux capabilities, and receive no host
   filesystem mount and no Docker socket.
-- Registration tokens enter through stdin, never through a file or an
-  environment variable.
+- The host mints each runner's just-in-time config, because minting needs
+  repository administration and the container must never hold that credential.
+- The config enters through stdin, never through a file or an environment
+  variable.
 - **Public repositories are excluded on purpose.** A self-hosted runner on a
   public repository lets a fork pull request run code on this workstation.
   `unhead.unjs.io`, `request-indexing`, `harlanzw.com`, and `unlighthouse.dev`

--- a/infra/github-runner/entrypoint.sh
+++ b/infra/github-runner/entrypoint.sh
@@ -3,6 +3,9 @@
 # Hands the process to the runner listener with the just-in-time config the
 # supervisor minted. There is no `config.sh` step: the config already names the
 # runner, its labels, and its one-job lifetime.
+# Self-update cannot be disabled on this path: `--disableupdate` belongs to
+# `config.sh`, and `run.sh --jitconfig` rejects it. The README carries the
+# update story: rebuild the image promptly after each runner release.
 # The supervisor reads this container's stdout, so every line the runner prints
 # is a signal. Do not add quiet flags.
 

--- a/infra/github-runner/entrypoint.sh
+++ b/infra/github-runner/entrypoint.sh
@@ -1,27 +1,16 @@
 #!/usr/bin/env bash
 
-# Registers one ephemeral runner, then hands the process to the runner listener.
+# Hands the process to the runner listener with the just-in-time config the
+# supervisor minted. There is no `config.sh` step: the config already names the
+# runner, its labels, and its one-job lifetime.
 # The supervisor reads this container's stdout, so every line the runner prints
 # is a signal. Do not add quiet flags.
 
 set -euo pipefail
 
-if ! IFS= read -r registration_token || [[ -z "$registration_token" ]]; then
-  echo 'Runner registration token was not provided on stdin.' >&2
+if ! IFS= read -r jit_config || [[ -z "$jit_config" ]]; then
+  echo 'Runner just-in-time config was not provided on stdin.' >&2
   exit 1
 fi
 
-./config.sh \
-  --disableupdate \
-  --ephemeral \
-  --labels "${RUNNER_LABELS}" \
-  --name "${RUNNER_NAME}" \
-  --token "$registration_token" \
-  --unattended \
-  --url "${RUNNER_URL}" \
-  --work _work
-
-registration_token=''
-unset registration_token
-
-exec ./run.sh
+exec ./run.sh --jitconfig "$jit_config"

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -690,8 +690,8 @@ ensure_pnpm_store() {
 
   # Cheap and idempotent, and it repairs a volume restored from a backup as the
   # wrong owner. Failure here is not fatal: pnpm would still work, just slower.
-  # `--entrypoint` is required: the image's entrypoint expects a registration
-  # token on stdin and exits without one.
+  # `--entrypoint` is required: the image's entrypoint expects a just-in-time
+  # runner config on stdin and exits without one.
   docker run --rm --user 0 --entrypoint chown \
     --volume "$pnpm_store_volume:/pnpm-store" \
     "$runner_image" --recursive 1001:1001 /pnpm-store >/dev/null 2>&1 \
@@ -744,32 +744,46 @@ run_container() {
   local container_name="$3"
 
   local repository="${pool_repository[$pool_index]}"
-  local registration_token
+  local jit_config
   local runner_name
   local line
   local job_name reported_outcome
   local -a pipe_status=()
-
-  if ! registration_token="$(github_api \
-    --method POST \
-    "repos/$repository/actions/runners/registration-token" \
-    --jq .token 2>/dev/null)"; then
-    log "Could not get a registration token for $repository"
-    return 1
-  fi
+  local -a label_fields=()
+  local label
 
   # This string is what a job's log prints as `Runner name:`, and it is the only
   # place a reader sees whose machine ran their code. Lead with the machine, not
   # the pool.
   runner_name="harlan-desktop-${pool_slug[$pool_index]}-$$-${RANDOM}"
 
-  # The token enters on stdin, so it never lands on disk and never lands in an
+  # A just-in-time config replaces the registration token and `config.sh`. The
+  # host mints it, because minting needs repository administration and the
+  # container must never hold that credential. GitHub creates the runner record
+  # here, with its name and labels fixed, and removes it after one job, so the
+  # container only listens. Runner group 1 is the default group every
+  # repository-scoped runner belongs to.
+  for label in ${pool_label[$pool_index]//,/ }; do
+    label_fields+=(--field "labels[]=$label")
+  done
+  if ! jit_config="$(github_api \
+    --method POST \
+    "repos/$repository/actions/runners/generate-jitconfig" \
+    --field "name=$runner_name" \
+    --field runner_group_id=1 \
+    "${label_fields[@]}" \
+    --jq .encoded_jit_config 2>/dev/null)"; then
+    log "Could not get a just-in-time runner config for $repository"
+    return 1
+  fi
+
+  # The config enters on stdin, so it never lands on disk and never lands in an
   # env var that `docker inspect` would echo back.
   #
   # errexit is lifted across the pipeline so the container's exit status can be
   # read from PIPESTATUS instead of aborting this function.
   set +e
-  printf '%s\n' "$registration_token" | docker run \
+  printf '%s\n' "$jit_config" | docker run \
     --rm \
     --interactive \
     --name "$container_name" \
@@ -785,9 +799,6 @@ run_container() {
     --pids-limit 4096 \
     --cap-drop ALL \
     --security-opt no-new-privileges \
-    --env "RUNNER_LABELS=${pool_label[$pool_index]}" \
-    --env "RUNNER_NAME=$runner_name" \
-    --env "RUNNER_URL=https://github.com/$repository" \
     "$runner_image" 2>&1 \
     | while IFS= read -r line; do
         printf '[%s] %s\n' "$container_name" "$line"
@@ -1035,16 +1046,18 @@ run_scaler() {
   done
 }
 
-# An ephemeral runner deregisters itself when it exits cleanly, but a host that
-# lost power, or a `docker kill`, leaves the registration behind. They accumulate
+# A just-in-time runner is removed when its one job completes, but a host that
+# lost power, a `docker kill`, or a container that never connected leaves the
+# registration behind. They accumulate
 # against the repository's runner limit and make `gh api ... /runners` unreadable,
 # so clear them at startup and on a timer after that. Only offline runners are
 # touched. A busy runner reports `online`, so it is never removed.
 #
 # WHY A DELETE NEEDS TWO SWEEPS
 #
-# A container registers before its listener connects. GitHub reports it offline
-# for a second or two in that gap, and it is very much alive. So the first sweep
+# The runner record exists from the moment the host mints its config, before
+# the container has even started. GitHub reports it offline in that gap, and it
+# is very much alive. So the first sweep
 # that sees a registration offline only remembers it, in a marker file named
 # after the runner id. The next sweep deletes it, but only if it is still
 # offline. A registration that came back online loses its marker instead.

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -763,7 +763,12 @@ run_container() {
   # here, with its name and labels fixed, and removes it after one job, so the
   # container only listens. Runner group 1 is the default group every
   # repository-scoped runner belongs to.
-  for label in ${pool_label[$pool_index]//,/ }; do
+  #
+  # `config.sh` added `self-hosted` and the image platform's OS and architecture
+  # as default labels; `generate-jitconfig` adds none. Workflows pin
+  # `runs-on: [self-hosted, linux, x64, <pool label>]`, so the mint must name
+  # them itself or no job can ever match the runner.
+  for label in self-hosted linux x64 ${pool_label[$pool_index]//,/ }; do
     label_fields+=(--field "labels[]=$label")
   done
   if ! jit_config="$(github_api \

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -18,8 +18,8 @@ if [[ "${GH_TOKEN:-}" != repository-token ]]; then
   exit 1
 fi
 printf '%s\n' "$*" >>"$TEST_CALLS/gh"
-if [[ "$*" == *registration-token* ]]; then
-  printf 'test-token\n'
+if [[ "$*" == *generate-jitconfig* ]]; then
+  printf 'test-jit-config\n'
 fi
 if [[ "$*" == *'actions/runs?status='* && -f "$TEST_CALLS/demand-unavailable" ]]; then
   exit 1

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -428,6 +428,45 @@ fi
 
 printf 'In-progress workflow demand passed.\n'
 
+# A just-in-time config fixes every label at mint time. `generate-jitconfig`
+# adds no default labels, so the supervisor has to send the image platform's
+# own. Workflows pin `runs-on: [self-hosted, linux, x64, <pool label>]`, so a
+# mint without the platform labels matches no job ever.
+begin_case 'Just-in-time config carries the platform labels'
+touch "$test_root/calls/queue-in-progress"
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=1 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=1 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )) || [[ ! -s "$test_root/calls/burst" ]]; then
+  cat "$test_root/output"
+  cat "$test_root/calls/gh"
+  printf 'Expected polled demand to mint a just-in-time runner config.\n' >&2
+  exit 1
+fi
+
+mint_line="$(grep 'generate-jitconfig' "$test_root/calls/gh")"
+for label in self-hosted linux x64 harlan-desktop-ci; do
+  if [[ "$mint_line" != *"labels[]=$label"* ]]; then
+    printf '%s\n' "$mint_line"
+    printf 'Expected the minted runner to carry the %s label.\n' "$label" >&2
+    exit 1
+  fi
+done
+
+printf 'Just-in-time config carries the platform labels passed.\n'
+
 begin_case 'Closed pull request demand filtering'
 touch "$test_root/calls/queue-stale"
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Every job container ran `config.sh` with a registration token before it could listen. That is a few seconds per job, and a container that died before that step left a registration GitHub could not tie to any job.

A just-in-time config names the runner, its labels, and its one-job lifetime in one host-side API call. The container now only runs `run.sh --jitconfig`, and GitHub removes the runner when its job ends. Borrowed from the JIT-token entries on [awesome-runners](https://github.com/jonico/awesome-runners).

The host still mints, because minting needs repository administration and the container must never hold that credential. The config still enters on stdin.

### 📝 Migration

The image entrypoint changed. Rebuild `harlan-desktop-github-runner:2.336.0` on hogwild and the desktop before restarting the supervisor. An old image fails fast, because `config.sh` rejects the JIT config as a token.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_013VGX2JHWttRuCeGi2qrPEv