### PR TITLE
feat(nuxt-cloudflare): fail the build past static asset rule limits

### DIFF
--- a/packages/nuxt-cloudflare/README.md
+++ b/packages/nuxt-cloudflare/README.md
@@ -172,7 +172,7 @@ pnpm nuxt-cloudflare doctor --strict --allow-warning source-maps-disabled
 
 The CLI reads Wrangler config through Wrangler itself, so JSON, JSONC, TOML, environments, upward lookup, and Nitro generated-config redirects follow deployment semantics. It separately inspects root authoring format. Existing TOML remains supported and receives non-blocking guidance because Cloudflare recommends JSONC for new projects. Shadowed root configs warn because they can silently drift.
 
-Errors cover malformed asset patterns, invalid Durable Object lifecycles, invalid Container storage, queue limits, unsafe example bindings, and unflattened generated environments. Warnings cover blanket Worker-first assets, missing environment bindings, unrestricted email, local service fidelity, deprecated fields, telemetry gaps, and public endpoints. Secret values are never included.
+Errors cover `_headers` and `_redirects` files past Cloudflare's rule limits, malformed asset patterns, invalid Durable Object lifecycles, invalid Container storage, queue limits, unsafe example bindings, and unflattened generated environments. Warnings cover blanket Worker-first assets, missing environment bindings, unrestricted email, local service fidelity, deprecated fields, telemetry gaps, and public endpoints. Secret values are never included.
 
 Normal mode fails errors. `--strict` also fails warnings. Intentional exceptions remain visible and may be listed with `--allow-warning`. Module builds use the equivalent policy:
 

--- a/packages/nuxt-cloudflare/src/doctor.ts
+++ b/packages/nuxt-cloudflare/src/doctor.ts
@@ -1,6 +1,8 @@
 import type { WranglerDiagnostic, WranglerDiagnosticOptions } from './wrangler'
 import type { ReadProjectWranglerOptions } from './wrangler-reader'
+import { dirname, resolve } from 'pathe'
 import { diagnoseWranglerSourceConfigs, discoverWranglerSourceConfigs } from './diagnostics'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from './static-assets'
 import { diagnoseWranglerConfig } from './wrangler'
 import { readProjectWranglerConfig } from './wrangler-reader'
 
@@ -44,7 +46,15 @@ export function diagnoseWranglerProject(options: DiagnoseWranglerProjectOptions)
     diagnostics: [
       ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated, normalized: true }),
       ...diagnoseWranglerSourceConfigs(sourceConfigPaths),
+      ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(resolveAssetsDirectory(loaded.path, loaded.config.assets?.directory))),
     ],
     sourceConfigPaths,
   }
+}
+
+/** The assets directory is relative to the config that names it. Without one there is nothing to count. */
+function resolveAssetsDirectory(configPath: string | undefined, directory: string | undefined): string {
+  if (!configPath || !directory)
+    return ''
+  return resolve(dirname(configPath), directory)
 }

--- a/packages/nuxt-cloudflare/src/doctor.ts
+++ b/packages/nuxt-cloudflare/src/doctor.ts
@@ -1,8 +1,7 @@
 import type { WranglerDiagnostic, WranglerDiagnosticOptions } from './wrangler'
 import type { ReadProjectWranglerOptions } from './wrangler-reader'
-import { dirname, resolve } from 'pathe'
 import { diagnoseWranglerSourceConfigs, discoverWranglerSourceConfigs } from './diagnostics'
-import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from './static-assets'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles, resolveConfigStaticAssetDirectory } from './static-assets'
 import { diagnoseWranglerConfig } from './wrangler'
 import { readProjectWranglerConfig } from './wrangler-reader'
 
@@ -41,24 +40,16 @@ export function diagnoseWranglerProject(options: DiagnoseWranglerProjectOptions)
       sourceConfigPaths,
     }
   }
+  const staticAssetDirectory = resolveConfigStaticAssetDirectory(loaded.path, loaded.config)
   return {
     configPath: loaded.path,
     diagnostics: [
       ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated, normalized: true }),
       ...diagnoseWranglerSourceConfigs(sourceConfigPaths),
-      ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(resolveAssetsDirectories(loaded.path, loaded.config.assets?.directory))),
+      ...(staticAssetDirectory === undefined
+        ? []
+        : diagnoseStaticAssetRules(readStaticAssetRuleFiles(staticAssetDirectory))),
     ],
     sourceConfigPaths,
   }
-}
-
-/**
- * Where a deploy would read `_headers` and `_redirects` from. The assets
- * directory is relative to the config that names it, and a config with no
- * assets uploads no rule files, so there is nothing to count.
- */
-function resolveAssetsDirectories(configPath: string | undefined, directory: string | undefined): string[] {
-  if (!configPath || !directory)
-    return []
-  return [resolve(dirname(configPath), directory)]
 }

--- a/packages/nuxt-cloudflare/src/doctor.ts
+++ b/packages/nuxt-cloudflare/src/doctor.ts
@@ -46,15 +46,19 @@ export function diagnoseWranglerProject(options: DiagnoseWranglerProjectOptions)
     diagnostics: [
       ...diagnoseWranglerConfig(loaded.config, { ...options, generated: loaded.generated, normalized: true }),
       ...diagnoseWranglerSourceConfigs(sourceConfigPaths),
-      ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(resolveAssetsDirectory(loaded.path, loaded.config.assets?.directory))),
+      ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(resolveAssetsDirectories(loaded.path, loaded.config.assets?.directory))),
     ],
     sourceConfigPaths,
   }
 }
 
-/** The assets directory is relative to the config that names it. Without one there is nothing to count. */
-function resolveAssetsDirectory(configPath: string | undefined, directory: string | undefined): string {
+/**
+ * Where a deploy would read `_headers` and `_redirects` from. The assets
+ * directory is relative to the config that names it, and a config with no
+ * assets uploads no rule files, so there is nothing to count.
+ */
+function resolveAssetsDirectories(configPath: string | undefined, directory: string | undefined): string[] {
   if (!configPath || !directory)
-    return ''
-  return resolve(dirname(configPath), directory)
+    return []
+  return [resolve(dirname(configPath), directory)]
 }

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -12,7 +12,7 @@ import {
 } from './diagnostics'
 import { findHtmlCacheRouteRuleViolations, formatHtmlCacheRouteRuleViolations } from './html-cache'
 import { resolveHtmlCacheGuarantee, staleDirectivesAreDisabled } from './runtime/server/utils/workers-cache'
-import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from './static-assets'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles, resolveBuildStaticAssetDirectory } from './static-assets'
 import {
   applyCloudflareDefaults,
   diagnoseWranglerConfig,
@@ -266,9 +266,9 @@ async function auditGeneratedWranglerConfig(
     ...diagnoseWranglerSourceConfigs(discoverWranglerSourceConfigs(rootDir)),
     // Every module's prerender headers land in one `_headers` file, and the
     // upload is the first thing that counts them. Count them here instead.
-    // Workers presets write the files under the public directory; the Pages
-    // presets write them at the output root.
-    ...diagnoseStaticAssetRules(readStaticAssetRuleFiles([nitro.options.output.publicDir, nitro.options.output.dir])),
+    ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(
+      resolveBuildStaticAssetDirectory(nitro.options.preset, nitro.options.output),
+    )),
   ]
   const policy = options.doctor ?? { _tag: 'advisory' }
   const outcome = evaluateWranglerDiagnostics(diagnostics, policy)

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -266,7 +266,9 @@ async function auditGeneratedWranglerConfig(
     ...diagnoseWranglerSourceConfigs(discoverWranglerSourceConfigs(rootDir)),
     // Every module's prerender headers land in one `_headers` file, and the
     // upload is the first thing that counts them. Count them here instead.
-    ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(nitro.options.output.publicDir)),
+    // Workers presets write the files under the public directory; the Pages
+    // presets write them at the output root.
+    ...diagnoseStaticAssetRules(readStaticAssetRuleFiles([nitro.options.output.publicDir, nitro.options.output.dir])),
   ]
   const policy = options.doctor ?? { _tag: 'advisory' }
   const outcome = evaluateWranglerDiagnostics(diagnostics, policy)

--- a/packages/nuxt-cloudflare/src/module.ts
+++ b/packages/nuxt-cloudflare/src/module.ts
@@ -12,6 +12,7 @@ import {
 } from './diagnostics'
 import { findHtmlCacheRouteRuleViolations, formatHtmlCacheRouteRuleViolations } from './html-cache'
 import { resolveHtmlCacheGuarantee, staleDirectivesAreDisabled } from './runtime/server/utils/workers-cache'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from './static-assets'
 import {
   applyCloudflareDefaults,
   diagnoseWranglerConfig,
@@ -263,6 +264,9 @@ async function auditGeneratedWranglerConfig(
       publicVarNames: options.publicVarNames,
     }),
     ...diagnoseWranglerSourceConfigs(discoverWranglerSourceConfigs(rootDir)),
+    // Every module's prerender headers land in one `_headers` file, and the
+    // upload is the first thing that counts them. Count them here instead.
+    ...diagnoseStaticAssetRules(readStaticAssetRuleFiles(nitro.options.output.publicDir)),
   ]
   const policy = options.doctor ?? { _tag: 'advisory' }
   const outcome = evaluateWranglerDiagnostics(diagnostics, policy)

--- a/packages/nuxt-cloudflare/src/static-assets.ts
+++ b/packages/nuxt-cloudflare/src/static-assets.ts
@@ -1,0 +1,93 @@
+import type { WranglerDiagnostic } from './wrangler'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'pathe'
+
+/**
+ * Cloudflare's published caps for the static asset control files. The upload
+ * rejects a file past them, which fails the whole deploy minutes after the
+ * build said it was fine.
+ */
+export const STATIC_ASSET_RULE_LIMITS = {
+  headers: 100,
+  redirectsStatic: 2000,
+  redirectsDynamic: 100,
+} as const
+
+export interface StaticAssetRuleFiles {
+  headers?: string
+  redirects?: string
+}
+
+/** The `_headers` and `_redirects` files under an output public directory, when present. */
+export function readStaticAssetRuleFiles(publicDir: string): StaticAssetRuleFiles {
+  const files: StaticAssetRuleFiles = {}
+  for (const [key, name] of [['headers', '_headers'], ['redirects', '_redirects']] as const) {
+    const path = join(publicDir, name)
+    if (existsSync(path))
+      files[key] = readFileSync(path, 'utf8')
+  }
+  return files
+}
+
+/** Rule lines: everything that is not blank, a comment, or an indented header line. */
+function ruleLines(contents: string): string[] {
+  return contents.split(/\r?\n/).filter(line => /^[^\s#]/.test(line))
+}
+
+/** `/guide/foo/bar` becomes `/guide/*`, so the count points at the module or route group that owns it. */
+function rulePrefix(route: string): string {
+  const segments = route.split('/').filter(Boolean)
+  return segments.length > 1 ? `/${segments[0]}/*` : route
+}
+
+function topPrefixes(routes: readonly string[], limit = 3): string {
+  const counts = new Map<string, number>()
+  for (const route of routes)
+    counts.set(rulePrefix(route), (counts.get(rulePrefix(route)) ?? 0) + 1)
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([prefix, count]) => `${prefix} (${count})`)
+    .join(', ')
+}
+
+function isDynamicRedirect(source: string): boolean {
+  return source.includes('*') || source.includes(':')
+}
+
+/**
+ * Errors for a `_headers` or `_redirects` file Cloudflare would refuse. The
+ * message names the path prefixes holding the most rules, because the file is
+ * assembled from every module's route rules and the reader needs to know
+ * which one to trim.
+ */
+export function diagnoseStaticAssetRules(files: StaticAssetRuleFiles): WranglerDiagnostic[] {
+  const diagnostics: WranglerDiagnostic[] = []
+  if (files.headers !== undefined) {
+    const routes = ruleLines(files.headers).map(line => line.trim())
+    if (routes.length > STATIC_ASSET_RULE_LIMITS.headers) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'static-headers-rule-limit',
+        message: `_headers has ${routes.length} rules and Cloudflare accepts ${STATIC_ASSET_RULE_LIMITS.headers}. The upload fails past that. Most rules sit under: ${topPrefixes(routes)}. Collapse them into globs or stop the module that emits them.`,
+        sourcePath: '_headers',
+      })
+    }
+  }
+  if (files.redirects !== undefined) {
+    const sources = ruleLines(files.redirects).map(line => line.trim().split(/\s+/)[0]!)
+    const dynamic = sources.filter(isDynamicRedirect)
+    const staticCount = sources.length - dynamic.length
+    const overStatic = staticCount > STATIC_ASSET_RULE_LIMITS.redirectsStatic
+    const overDynamic = dynamic.length > STATIC_ASSET_RULE_LIMITS.redirectsDynamic
+    if (overStatic || overDynamic) {
+      diagnostics.push({
+        _tag: 'error',
+        code: 'static-redirects-rule-limit',
+        message: `_redirects has ${staticCount} static and ${dynamic.length} dynamic rules and Cloudflare accepts ${STATIC_ASSET_RULE_LIMITS.redirectsStatic} static and ${STATIC_ASSET_RULE_LIMITS.redirectsDynamic} dynamic. The upload fails past that. Most rules sit under: ${topPrefixes(sources)}.`,
+        sourcePath: '_redirects',
+      })
+    }
+  }
+  return diagnostics
+}

--- a/packages/nuxt-cloudflare/src/static-assets.ts
+++ b/packages/nuxt-cloudflare/src/static-assets.ts
@@ -18,13 +18,23 @@ export interface StaticAssetRuleFiles {
   redirects?: string
 }
 
-/** The `_headers` and `_redirects` files under an output public directory, when present. */
-export function readStaticAssetRuleFiles(publicDir: string): StaticAssetRuleFiles {
+/**
+ * The `_headers` and `_redirects` files an output carries, when present.
+ *
+ * Nitro's Workers presets write them under the public directory. The Pages
+ * presets write them at the output root, so the caller passes every place a
+ * preset can put them and the first directory holding a file wins.
+ */
+export function readStaticAssetRuleFiles(directories: readonly string[]): StaticAssetRuleFiles {
   const files: StaticAssetRuleFiles = {}
   for (const [key, name] of [['headers', '_headers'], ['redirects', '_redirects']] as const) {
-    const path = join(publicDir, name)
-    if (existsSync(path))
-      files[key] = readFileSync(path, 'utf8')
+    for (const directory of directories) {
+      const path = join(directory, name)
+      if (existsSync(path)) {
+        files[key] = readFileSync(path, 'utf8')
+        break
+      }
+    }
   }
   return files
 }

--- a/packages/nuxt-cloudflare/src/static-assets.ts
+++ b/packages/nuxt-cloudflare/src/static-assets.ts
@@ -1,6 +1,6 @@
 import type { WranglerDiagnostic } from './wrangler'
 import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'pathe'
+import { dirname, join, resolve } from 'pathe'
 
 /**
  * Cloudflare's published caps for the static asset control files. The upload
@@ -19,22 +19,40 @@ export interface StaticAssetRuleFiles {
 }
 
 /**
- * The `_headers` and `_redirects` files an output carries, when present.
- *
- * Nitro's Workers presets write them under the public directory. The Pages
- * presets write them at the output root, so the caller passes every place a
- * preset can put them and the first directory holding a file wins.
+ * Where a Nitro build writes `_headers` and `_redirects`. Its Workers presets
+ * put them under the public directory; its Pages presets put them at the
+ * output root, which is what `wrangler pages deploy` uploads.
  */
-export function readStaticAssetRuleFiles(directories: readonly string[]): StaticAssetRuleFiles {
+export function resolveBuildStaticAssetDirectory(
+  preset: string | undefined,
+  output: { dir: string, publicDir: string },
+): string {
+  return String(preset || '').includes('pages') ? output.dir : output.publicDir
+}
+
+/**
+ * Where a deploy of this config reads the rule files from, relative to the
+ * config that names it. A Worker uploads its `assets.directory`; a Pages
+ * project uploads `pages_build_output_dir`. A config naming neither uploads
+ * no rule files, so there is nothing to count.
+ */
+export function resolveConfigStaticAssetDirectory(
+  configPath: string | undefined,
+  config: { assets?: { directory?: string }, pages_build_output_dir?: string },
+): string | undefined {
+  const directory = config.assets?.directory ?? config.pages_build_output_dir
+  if (!configPath || !directory)
+    return undefined
+  return resolve(dirname(configPath), directory)
+}
+
+/** The `_headers` and `_redirects` files in one directory, when present. */
+export function readStaticAssetRuleFiles(directory: string): StaticAssetRuleFiles {
   const files: StaticAssetRuleFiles = {}
   for (const [key, name] of [['headers', '_headers'], ['redirects', '_redirects']] as const) {
-    for (const directory of directories) {
-      const path = join(directory, name)
-      if (existsSync(path)) {
-        files[key] = readFileSync(path, 'utf8')
-        break
-      }
-    }
+    const path = join(directory, name)
+    if (existsSync(path))
+      files[key] = readFileSync(path, 'utf8')
   }
   return files
 }

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -107,6 +107,8 @@ export interface WranglerConfigInput extends Record<string, unknown> {
   }
   mtls_certificates?: WranglerRemoteBindingInput[]
   no_bundle?: boolean
+  /** Pages projects name their upload directory here instead of `assets.directory`. */
+  pages_build_output_dir?: string
   observability?: WranglerObservabilityInput
   placement?: WranglerPlacementInput
   preview_urls?: boolean

--- a/packages/nuxt-cloudflare/src/wrangler.ts
+++ b/packages/nuxt-cloudflare/src/wrangler.ts
@@ -174,6 +174,8 @@ export const WRANGLER_DIAGNOSTIC_CODES = [
   'secret-declared-as-var',
   'source-maps-disabled',
   'stale-compatibility-date',
+  'static-headers-rule-limit',
+  'static-redirects-rule-limit',
   'traces-disabled',
   'remote-binding-not-enabled',
   'unsafe-hello-world-binding',

--- a/packages/nuxt-cloudflare/tests/doctor.test.ts
+++ b/packages/nuxt-cloudflare/tests/doctor.test.ts
@@ -32,6 +32,27 @@ describe('diagnoseWranglerProject', () => {
     }
   })
 
+  it('counts the rule files under a Pages build output directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await mkdir(join(root, 'dist'))
+    await writeFile(join(root, 'wrangler.jsonc'), JSON.stringify({
+      name: 'pages-site',
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      pages_build_output_dir: './dist',
+    }))
+    await writeFile(join(root, 'dist/_headers'), Array.from({ length: 101 }, (_, i) => `/p${i}\n  X-A: 1`).join('\n'))
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: root, now: new Date('2026-08-11T00:00:00Z') })
+
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({ _tag: 'error', code: 'static-headers-rule-limit' }))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it('counts the rule files under the assets directory the config names', async () => {
     const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
     await mkdir(join(root, 'public'))

--- a/packages/nuxt-cloudflare/tests/doctor.test.ts
+++ b/packages/nuxt-cloudflare/tests/doctor.test.ts
@@ -10,6 +10,52 @@ import {
 import { diagnoseWranglerProject } from '../src/doctor'
 
 describe('diagnoseWranglerProject', () => {
+  it('counts no rule file when the config declares no assets directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await writeFile(join(root, 'wrangler.jsonc'), JSON.stringify({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      workers_dev: false,
+      upload_source_maps: true,
+      observability: { enabled: true },
+      version_metadata: { binding: 'CF_VERSION_METADATA' },
+    }))
+    await writeFile(join(root, '_headers'), Array.from({ length: 101 }, (_, i) => `/p${i}\n  X-A: 1`).join('\n'))
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: root, now: new Date('2026-08-11T00:00:00Z') })
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain('static-headers-rule-limit')
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('counts the rule files under the assets directory the config names', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
+    await mkdir(join(root, 'public'))
+    await writeFile(join(root, 'wrangler.jsonc'), JSON.stringify({
+      compatibility_date: '2026-08-11',
+      compatibility_flags: ['nodejs_compat'],
+      workers_dev: false,
+      upload_source_maps: true,
+      assets: { directory: './public', binding: 'ASSETS' },
+      observability: { enabled: true },
+      version_metadata: { binding: 'CF_VERSION_METADATA' },
+    }))
+    await writeFile(join(root, 'public/_headers'), Array.from({ length: 101 }, (_, i) => `/p${i}\n  X-A: 1`).join('\n'))
+
+    try {
+      const result = diagnoseWranglerProject({ cwd: root, now: new Date('2026-08-11T00:00:00Z') })
+
+      expect(result.diagnostics).toContainEqual(expect.objectContaining({ _tag: 'error', code: 'static-headers-rule-limit' }))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it('warns when the authored config uses legacy TOML even if Wrangler can load it', async () => {
     const root = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-doctor-'))
     await mkdir(join(root, 'apps/site'), { recursive: true })

--- a/packages/nuxt-cloudflare/tests/static-assets.test.ts
+++ b/packages/nuxt-cloudflare/tests/static-assets.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -50,12 +50,19 @@ describe('diagnoseStaticAssetRules', () => {
 })
 
 describe('readStaticAssetRuleFiles', () => {
-  it('reads whichever files the output carries', async () => {
+  it('reads each file from the first directory that holds it', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-assets-'))
     try {
-      await writeFile(join(dir, '_headers'), '/*\n  X-A: 1\n')
-      expect(readStaticAssetRuleFiles(dir)).toEqual({ headers: '/*\n  X-A: 1\n' })
-      expect(readStaticAssetRuleFiles(join(dir, 'missing'))).toEqual({})
+      await mkdir(join(dir, 'public'))
+      await writeFile(join(dir, 'public/_headers'), '/*\n  X-A: 1\n')
+      await writeFile(join(dir, '_redirects'), '/old /new 301\n')
+
+      expect(readStaticAssetRuleFiles([join(dir, 'public'), dir])).toEqual({
+        headers: '/*\n  X-A: 1\n',
+        redirects: '/old /new 301\n',
+      })
+      expect(readStaticAssetRuleFiles([join(dir, 'missing')])).toEqual({})
+      expect(readStaticAssetRuleFiles([])).toEqual({})
     }
     finally {
       await rm(dir, { force: true, recursive: true })

--- a/packages/nuxt-cloudflare/tests/static-assets.test.ts
+++ b/packages/nuxt-cloudflare/tests/static-assets.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from '../src/static-assets'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles, resolveBuildStaticAssetDirectory, resolveConfigStaticAssetDirectory } from '../src/static-assets'
 
 function headerRules(prefix: string, count: number): string {
   return Array.from({ length: count }, (_, i) => `${prefix}/page-${i}.md\n  Content-Type: text/markdown\n`).join('')
@@ -50,22 +50,47 @@ describe('diagnoseStaticAssetRules', () => {
 })
 
 describe('readStaticAssetRuleFiles', () => {
-  it('reads each file from the first directory that holds it', async () => {
+  it('reads whichever files the directory carries', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-assets-'))
     try {
-      await mkdir(join(dir, 'public'))
-      await writeFile(join(dir, 'public/_headers'), '/*\n  X-A: 1\n')
-      await writeFile(join(dir, '_redirects'), '/old /new 301\n')
-
-      expect(readStaticAssetRuleFiles([join(dir, 'public'), dir])).toEqual({
-        headers: '/*\n  X-A: 1\n',
-        redirects: '/old /new 301\n',
-      })
-      expect(readStaticAssetRuleFiles([join(dir, 'missing')])).toEqual({})
-      expect(readStaticAssetRuleFiles([])).toEqual({})
+      await writeFile(join(dir, '_headers'), '/*\n  X-A: 1\n')
+      expect(readStaticAssetRuleFiles(dir)).toEqual({ headers: '/*\n  X-A: 1\n' })
+      expect(readStaticAssetRuleFiles(join(dir, 'missing'))).toEqual({})
     }
     finally {
       await rm(dir, { force: true, recursive: true })
     }
+  })
+})
+
+describe('resolveBuildStaticAssetDirectory', () => {
+  const output = { dir: '/site/.output', publicDir: '/site/.output/public' }
+
+  it.each([
+    ['cloudflare-module', '/site/.output/public'],
+    ['cloudflare-durable', '/site/.output/public'],
+    ['cloudflare_module', '/site/.output/public'],
+    ['cloudflare-pages', '/site/.output'],
+    ['cloudflare-pages-static', '/site/.output'],
+    [undefined, '/site/.output/public'],
+  ])('%s uploads from %s', (preset, expected) => {
+    expect(resolveBuildStaticAssetDirectory(preset, output)).toBe(expected)
+  })
+})
+
+describe('resolveConfigStaticAssetDirectory', () => {
+  it('resolves a Worker assets directory against the config location', () => {
+    expect(resolveConfigStaticAssetDirectory('/site/.output/server/wrangler.json', { assets: { directory: '../public' } }))
+      .toBe('/site/.output/public')
+  })
+
+  it('resolves a Pages build output directory the same way', () => {
+    expect(resolveConfigStaticAssetDirectory('/site/wrangler.jsonc', { pages_build_output_dir: './dist' }))
+      .toBe('/site/dist')
+  })
+
+  it('has nothing to count when the config uploads no assets', () => {
+    expect(resolveConfigStaticAssetDirectory('/site/wrangler.jsonc', {})).toBeUndefined()
+    expect(resolveConfigStaticAssetDirectory(undefined, { assets: { directory: 'public' } })).toBeUndefined()
   })
 })

--- a/packages/nuxt-cloudflare/tests/static-assets.test.ts
+++ b/packages/nuxt-cloudflare/tests/static-assets.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { diagnoseStaticAssetRules, readStaticAssetRuleFiles } from '../src/static-assets'
+
+function headerRules(prefix: string, count: number): string {
+  return Array.from({ length: count }, (_, i) => `${prefix}/page-${i}.md\n  Content-Type: text/markdown\n`).join('')
+}
+
+describe('diagnoseStaticAssetRules', () => {
+  it('is quiet when every file is under its limit', () => {
+    const diagnostics = diagnoseStaticAssetRules({
+      headers: `# generated\n\n/*\n  X-Frame-Options: DENY\n${headerRules('/guide', 98)}`,
+      redirects: '/old /new 301\n/blog/* /posts/:splat 302\n',
+    })
+
+    expect(diagnostics).toEqual([])
+  })
+
+  it('fails a _headers file over 100 rules and names the prefixes that fill it', () => {
+    const diagnostics = diagnoseStaticAssetRules({
+      headers: `/*\n  X-Frame-Options: DENY\n${headerRules('/guide', 60)}${headerRules('/learn', 45)}`,
+    })
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({ _tag: 'error', code: 'static-headers-rule-limit', sourcePath: '_headers' })
+    expect(diagnostics[0]!.message).toContain('106 rules')
+    expect(diagnostics[0]!.message).toContain('/guide/* (60)')
+    expect(diagnostics[0]!.message).toContain('/learn/* (45)')
+  })
+
+  it('counts static and dynamic redirects against their own limits', () => {
+    const dynamic = Array.from({ length: 101 }, (_, i) => `/d${i}/* /x/:splat 301`).join('\n')
+    const diagnostics = diagnoseStaticAssetRules({ redirects: `${dynamic}\n/one /two 301\n` })
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({ _tag: 'error', code: 'static-redirects-rule-limit', sourcePath: '_redirects' })
+    expect(diagnostics[0]!.message).toContain('101 dynamic')
+  })
+
+  it('ignores comments and blank lines', () => {
+    const diagnostics = diagnoseStaticAssetRules({
+      headers: `# one\n\n${headerRules('/a', 100)}\n# trailing\n`,
+      redirects: '# none\n\n',
+    })
+
+    expect(diagnostics).toEqual([])
+  })
+})
+
+describe('readStaticAssetRuleFiles', () => {
+  it('reads whichever files the output carries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'nuxt-cloudflare-assets-'))
+    try {
+      await writeFile(join(dir, '_headers'), '/*\n  X-A: 1\n')
+      expect(readStaticAssetRuleFiles(dir)).toEqual({ headers: '/*\n  X-A: 1\n' })
+      expect(readStaticAssetRuleFiles(join(dir, 'missing'))).toEqual({})
+    }
+    finally {
+      await rm(dir, { force: true, recursive: true })
+    }
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

unlighthouse.dev's deploy died today on the upload, five minutes after a green build:

```
Invalid _headers configuration:
Line 304: Maximum number of _headers rules limit of 100 exceeded [code: 100324]
```

The cause was nuxt-ai-ready writing one `_headers` rule per prerendered page (harlan-zw/nuxt-ai-ready#110 fixes that side). But nothing here had a chance to say so first, and every module's prerender headers land in that one file, so the same shape will come back from some other module.

The build audit and the CLI doctor now count `_headers` and `_redirects` against Cloudflare's published caps and fail with an error that names the prefixes holding the most rules. Under the limits nothing changes.

```
ERROR static-headers-rule-limit _headers: _headers has 146 rules and Cloudflare accepts 100. The upload fails past that. Most rules sit under: /guide/* (145), /* (1). Collapse them into globs or stop the module that emits them.
```

I did not add an auto-collapse. This module cannot know which rules matter, so it fails loud and points at the owner.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012AMRtb4ywqcEMJGoZyTd5H