### PR TITLE
fix(github-runner): exclude gscdump before its public launch

### DIFF
--- a/infra/github-runner/hogwild-runners.conf
+++ b/infra/github-runner/hogwild-runners.conf
@@ -26,7 +26,6 @@ skilld-dev/skilld.dev|harlan-desktop-ci|0|4|4|4g|12g|14g
 skilld-dev/skilld.dev|harlan-desktop-deploy|0|1|4|5g|7g|9g
 
 harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|2g|4g|5g
-harlan-zw/gscdump|harlan-desktop-ci|0|2|4|3g|5g|6g
 harlan-zw/massivemonster.com|harlan-desktop-ci|0|2|8|3g|6g|8g
 harlan-zw/nuxt-audit|harlan-desktop-ci|0|2|4|2g|4g|5g
 harlan-zw/ripast|harlan-desktop-ci|0|2|2|1g|2g|3g

--- a/infra/github-runner/runners.conf
+++ b/infra/github-runner/runners.conf
@@ -39,7 +39,6 @@ skilld-dev/skilld.dev|harlan-desktop-ci|0|3|6|4g|12g|14g
 # Packages and smaller sites moved off GitHub-hosted runners 2026-08-31.
 # Sizes are the hogwild (30g) measurements; a larger host can raise them.
 harlan-zw/eslint-worker-pool|harlan-desktop-ci|0|2|8|2g|4g|5g
-harlan-zw/gscdump|harlan-desktop-ci|0|2|4|3g|5g|6g
 harlan-zw/massivemonster.com|harlan-desktop-ci|0|2|4|3g|6g|8g
 harlan-zw/nuxt-audit|harlan-desktop-ci|0|2|4|2g|4g|5g
 harlan-zw/ripast|harlan-desktop-ci|0|2|2|1g|2g|3g


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

gscdump will accept public fork PRs, which must not reach Hogwild's runner pools.
Remove gscdump from both pool configurations as its workflows move to GitHub-hosted runners.

### 📝 Migration

Apply the matching runner configuration before making gscdump public.
When runner jobs finish, restart the supervisor to load it.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
