### PR TITLE
fix(runner): admit pools that fit past an idle deploy hold

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -59,9 +59,9 @@ mints every runner with `self-hosted`, `linux`, and `x64` plus the pool labels.
 
 ## Hogwild installation
 
-Needs Docker and a GitHub token with repository administration access on every
-repository in `hogwild-runners.conf`, loaded through the unit's encrypted
-credentials.
+Needs Docker, `systemd-zram-generator`, and a GitHub token with repository
+administration access on every repository in `hogwild-runners.conf`, loaded
+through the unit's encrypted credentials.
 
 ```bash
 docker build --tag harlan-desktop-github-runner:2.336.0 infra/github-runner
@@ -74,12 +74,19 @@ sudo install -Dm644 infra/github-runner/hogwild-runners.conf /var/lib/github-run
 sudo install -Dm644 infra/github-runner/hogwild-github-runner.service /etc/systemd/system/hogwild-github-runner.service
 sudo install -Dm644 infra/github-runner/hogwild-logind.conf /etc/systemd/logind.conf.d/runner-safe-power.conf
 sudo install -Dm644 infra/github-runner/hogwild-tmp.conf /etc/tmpfiles.d/runner-tmp.conf
+sudo install -Dm644 infra/github-runner/hogwild-zram-generator.conf /etc/systemd/zram-generator.conf
 sudo install -Dm755 infra/github-runner/hogwild-safe-poweroff /usr/local/sbin/hogwild-safe-poweroff
+sudo systemctl mask tmp.mount
 sudo systemctl daemon-reload
+sudo systemctl restart systemd-zram-setup@zram0.service
 sudo systemd-tmpfiles --clean
 sudo systemctl kill --signal HUP systemd-logind
 sudo systemctl restart hogwild-github-runner.service
 ```
+
+Ubuntu mounts `/tmp` as a tmpfs, so every file in it spends the pages the pools
+budget. Masking `tmp.mount` puts `/tmp` on the NVMe at the next boot. Until
+then `hogwild-tmp.conf` keeps the tmpfs small.
 
 Restart drains: running jobs finish first. Use `sudo hogwild-safe-poweroff` for a
 drained shutdown.

--- a/infra/github-runner/hogwild-tmp.conf
+++ b/infra/github-runner/hogwild-tmp.conf
@@ -6,5 +6,7 @@
 # over three hours while the supervisor logged a correct refusal every 30s.
 #
 # Two days keeps a build's scratch alive far longer than any job runs, and caps
-# what a leaking process can take out of the memory budget.
+# what a leaking process can take out of the memory budget. `tmp.mount` is
+# masked, so after the next boot /tmp sits on the NVMe and this only bounds
+# disk; the tmpfs case above returns with any host that boots without the mask.
 q /tmp 1777 root root 2d

--- a/infra/github-runner/hogwild-zram-generator.conf
+++ b/infra/github-runner/hogwild-zram-generator.conf
@@ -1,0 +1,12 @@
+# Hogwild has 32g of RAM, one SODIMM slot filled, and no budget for a second
+# stick. Its swap is an 8g file on the NVMe, and the runner pools plus the
+# GitHub agent's opencode sessions push 3g to 4g into it on a normal evening.
+#
+# zram swaps into compressed RAM instead. Node heaps and build scratch compress
+# about three to one, so 16g of zram costs roughly 5g of RAM when full and pages
+# back in without touching the disk. The swap file stays as overflow at its
+# lower default priority.
+[zram0]
+zram-size = ram / 2
+compression-algorithm = zstd
+swap-priority = 100

--- a/infra/github-runner/supervisor
+++ b/infra/github-runner/supervisor
@@ -903,6 +903,7 @@ run_scaler() {
   local pending_pool pending_count attempt candidate priority_index queued_demand
   local -a pending_pools=()
   local -A pool_is_pending=()
+  local -A tried_pools=()
 
   while true; do
     while IFS=' ' read -r request pool_index; do
@@ -924,17 +925,25 @@ run_scaler() {
       # Try each denied pool once. A pool that still cannot fit moves to the
       # back, so repeated capacity changes distribute slots across repositories.
       # The oldest pending deploy goes first. Once denied, it stays first and
-      # reserves future capacity by stopping lower-priority admissions.
+      # reserves future capacity by stopping lower-priority admissions, but
+      # only while work is in flight to return that capacity. With nothing in
+      # flight the deploy waits on the host alone, and holding smaller pools
+      # behind it starves them for no gain (2026-09-10, 16 minutes at 0).
       pending_count="${#pending_pools[@]}"
+      tried_pools=()
       for (( attempt = 0; attempt < pending_count; attempt++ )); do
-        priority_index=0
+        priority_index=''
         for candidate in "${!pending_pools[@]}"; do
+          [[ -n "${tried_pools[${pending_pools[$candidate]}]:-}" ]] && continue
           if (( pool_is_deploy[pending_pools[candidate]] )); then
             priority_index="$candidate"
             break
           fi
+          [[ -z "$priority_index" ]] && priority_index="$candidate"
         done
+        [[ -z "$priority_index" ]] && break
         pending_pool="${pending_pools[$priority_index]}"
+        tried_pools[$pending_pool]=true
         unset "pending_pools[$priority_index]"
         pending_pools=("${pending_pools[@]}")
         slug="${pool_slug[$pending_pool]}"
@@ -1019,7 +1028,8 @@ run_scaler() {
           write_hold "$slug" "$hold_tag" "$hold_numbers"
           if (( pool_is_deploy[pending_pool] )); then
             pending_pools=("$pending_pool" "${pending_pools[@]}")
-            break
+            (( spent > 0 )) && break
+            continue
           fi
           pending_pools+=("$pending_pool")
           continue

--- a/infra/github-runner/supervisor.test.sh
+++ b/infra/github-runner/supervisor.test.sh
@@ -1092,6 +1092,61 @@ fi
 
 printf 'Deploy priority passed.\n'
 
+# A held deploy reserves the capacity that in-flight work will return. With
+# nothing in flight, no job can return capacity, so the deploy waits on the host
+# alone and every pool behind it starved for no gain: on 2026-09-10 a 13g deploy
+# held on host memory kept a 1g CI pool and a 1g light pool at 0 for 16 minutes
+# while both would have fit. The deploy still goes first on every pass.
+begin_case 'Idle deploy hold admits pools that fit'
+touch "$test_root/calls/queue-priority"
+cat >"$test_root/runners.conf" <<'EOF'
+harlan-zw/example|harlan-desktop-ci|0|1|4|1g|2g|3g
+harlan-zw/example|harlan-desktop-deploy|0|1|4|30g|31g|32g
+EOF
+
+set +e
+TEST_CALLS="$test_root/calls" \
+PATH="$test_root/bin:$PATH" \
+XDG_RUNTIME_DIR="$test_root/runtime" \
+CREDENTIALS_DIRECTORY="$test_root/credentials" \
+HARLAN_DESKTOP_RUNNER_CONFIG="$test_root/runners.conf" \
+HARLAN_DESKTOP_RUNNER_HISTORY_DIR="$test_root/history" \
+HARLAN_DESKTOP_RUNNER_CPU_BUDGET=16 \
+HARLAN_DESKTOP_RUNNER_MEMORY_BUDGET_GIB=31 \
+HARLAN_DESKTOP_RUNNER_MEMORY_HEADROOM_GIB=2 \
+HARLAN_DESKTOP_RUNNER_DEMAND_POLL_SECONDS=1 \
+HARLAN_DESKTOP_RUNNER_NOW_EPOCH=1787808600 \
+timeout --preserve-status --kill-after=1 2 ./infra/github-runner/supervisor >"$test_root/output" 2>&1
+status=$?
+set -e
+
+if (( status != 0 )); then
+  cat "$test_root/output"
+  printf 'Expected the idle deploy hold to drain cleanly.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet 'Available memory 24g, headroom 2g.*; holding example-deploy at 0' "$test_root/output"; then
+  cat "$test_root/output"
+  printf 'Expected host memory to hold the deploy.\n' >&2
+  exit 1
+fi
+
+if grep --quiet --fixed-strings -- '-deploy-burst-' "$test_root/calls/burst" 2>/dev/null; then
+  cat "$test_root/output"
+  cat "$test_root/calls/burst"
+  printf 'Expected the held deploy not to burst.\n' >&2
+  exit 1
+fi
+
+if ! grep --quiet --fixed-strings -- '-ci-burst-' "$test_root/calls/burst" 2>/dev/null; then
+  cat "$test_root/output"
+  printf 'Expected CI to be admitted past a deploy held with nothing in flight.\n' >&2
+  exit 1
+fi
+
+printf 'Idle deploy hold admits pools that fit passed.\n'
+
 # A deploy run cancelled while its burst request is held must release the
 # reservation. Scan one queues the deploy, scan two lists it gone, and only
 # then does the busy slot return capacity. CI has to be admitted on the freed


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Tonight the nuxtseo.com deploy pool sat at 0 for 16 minutes because the host had 17g available and the pool reserves 13g against a 6g headroom. That part is correct. The problem is that a held deploy also stops every pool behind it, so a 1g CI job and a 1g light job waited the same 16 minutes when both would have fit. Nothing was in flight, so no job could ever return the capacity the deploy was "reserving".

```
09:57:48Z Available memory 17g, headroom 6g, RAM-backed filesystems hold 7g; holding nuxtseo-com-deploy at 0
```

A held deploy now only blocks lower pools while work is in flight. With nothing running, the smaller pools proceed and the deploy still goes first on every later pass.

Two host changes ride along for the same evening. `/tmp` was a tmpfs holding 4.8g of opencode scratch, so `tmp.mount` is masked and lands on the NVMe at the next boot. zram now sits in front of the 8g swap file, since a second 32g SODIMM is off the table at current prices.

Left alone: the 13g deploy reservation. The one deploy I measured tonight peaked at 3.8g, but that was `deploy-tail` with the site matrix cancelled, so it says nothing about the build.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012jXxMt6hF9sHNnLGdMpSxn