### PR TITLE
docs(github-runner): record the docker0 DNS firewall rules

### DIFF
--- a/infra/github-runner/README.md
+++ b/infra/github-runner/README.md
@@ -91,6 +91,24 @@ then `hogwild-tmp.conf` keeps the tmpfs small.
 Restart drains: running jobs finish first. Use `sudo hogwild-safe-poweroff` for a
 drained shutdown.
 
+### Firewall
+
+Containers resolve DNS through the host's AdGuard at `192.168.50.211:53`, set in
+`/etc/docker/daemon.json` under `dns`. ufw allows port 53 from the LAN only, and
+containers arrive from `172.17.0.0/16` on `docker0`. Without these rules ufw
+drops every lookup to the first nameserver, glibc waits 5 seconds before the
+second answers, and a parallel Nuxt build pushes undici past its 10 second
+connect timeout (2026-09-10, gscdump.com deploy failed on `fonts.gstatic.com`).
+
+```bash
+sudo ufw allow in on docker0 from 172.17.0.0/16 to 192.168.50.211 port 53 proto udp comment 'AdGuard DNS for runner containers'
+sudo ufw allow in on docker0 from 172.17.0.0/16 to 192.168.50.211 port 53 proto tcp comment 'AdGuard DNS for runner containers'
+```
+
+If the host IP or the resolver changes, update `daemon.json` and these rules
+together. A `[UFW BLOCK] IN=docker0 ... DPT=53` line in `journalctl -k` means
+they have drifted.
+
 ## Status
 
 On Hogwild the source of truth is the supervisor's `status.json`:


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation

### 📚 Description

The gscdump.com deploy on 2026-09-10 failed fetching `fonts.gstatic.com`, and an agent read that as an offline build. It was not. Hogwild's ufw allowed port 53 from the LAN only, so runner containers on `docker0` lost every lookup to the host AdGuard resolver and waited 5 seconds for the second nameserver, which pushed a parallel Nuxt build past undici's 10 second connect timeout.

```
[UFW BLOCK] IN=docker0 OUT= PHYSIN=veth16251cb SRC=172.17.0.3 DST=192.168.50.211 PROTO=UDP DPT=53
```

The allow rules are live on the host now but lived nowhere in the repo. This records them in the installation section with the journal line that means they have drifted.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012PsTeooG9PHkxZjBtKp33D