### PR TITLE
feat(hogwild): record the security pass and docker rules

### DIFF
--- a/infra/hogwild/README.md
+++ b/infra/hogwild/README.md
@@ -1,0 +1,114 @@
+# Hogwild host
+
+Hogwild runs the GitHub runner supervisor, the Harlan GitHub Agent, the status
+site, AdGuard DNS, Jellyfin, and a Cloudflare tunnel. This file records the
+host security layout after the security pass on 2026-09-11. The runner has its
+own file in `infra/github-runner`.
+
+## Accounts
+
+| Account | Purpose | sudo | docker |
+| --- | --- | --- | --- |
+| `harlan` | Runs the Harlan GitHub Agent as a `systemctl --user` unit. Owns `~/pkg`, `~/sites`, the Agent state, and its tools in `~/.local/bin`. | none | none |
+| `harlan-admin` | Host administration only. | `NOPASSWD: ALL` | yes |
+| `hogwild-deploy` | Receives status site releases over a forced SSH command. | one script | none |
+| `github-runner` | Runner supervisor service. Holds the Docker socket by design. | none | yes |
+
+The Agent runs `opencode run --auto` on public issue text. The account it runs
+as must never hold root or the Docker socket. Before 2026-09-11 `harlan` held
+both. `harlan-admin` now holds them and `harlan` holds neither.
+
+From the desktop:
+
+```bash
+ssh hogwild          # harlan: the Agent account. Desktop scripts use it. No sudo.
+ssh hogwild-admin    # harlan-admin: sudo and docker.
+```
+
+Both hosts use the same key. The desktop Agent scripts in `harlan-agent-kit`
+keep `hogwild`, so nothing there changed.
+
+If the Agent needs a package, install it as `harlan-admin`:
+
+```bash
+ssh hogwild-admin 'sudo apt-get install -y <package>'
+```
+
+If a tool needs a different name, link it into the Agent's path as `harlan`:
+
+```bash
+ssh hogwild 'ln -sf "$(command -v fdfind)" ~/.local/bin/fd'
+```
+
+If a future task needs containers, give `harlan` rootless Docker. Never add
+`harlan` to the `docker` group.
+
+## Docker network rules
+
+Docker publishes ports past ufw. A test container with `-p 5433:5433` answered
+from the LAN with no ufw rule. Containers could also reach the LAN router.
+
+Two controls close this:
+
+- `/etc/docker/daemon.json` sets `"ip": "127.0.0.1"`, so a published port binds
+  loopback unless the container asks for an address. Docker reads it at its
+  next restart.
+- `hogwild-docker-user.service` fills the `DOCKER-USER` chain from
+  `hogwild-docker-user-rules`. Containers cannot reach private networks, the
+  tailnet, or link-local addresses. The LAN and the tailnet cannot open
+  connections to published ports. The desktop DNS fallback and loopback still
+  work. The ufw rules in `infra/github-runner/README.md` still cover DNS to the
+  host itself, because that traffic is input, not forwarding.
+
+Install:
+
+```bash
+sudo install -Dm755 infra/hogwild/hogwild-docker-user-rules /usr/local/sbin/hogwild-docker-user-rules
+sudo install -Dm644 infra/hogwild/hogwild-docker-user.service /etc/systemd/system/hogwild-docker-user.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now hogwild-docker-user.service
+```
+
+The unit is `PartOf=docker.service`, so a Docker restart reloads it. `ufw reload`
+flushes every chain, including Docker's own. After a ufw reload, restart Docker.
+
+Verify:
+
+```bash
+sudo iptables -S DOCKER-USER
+docker run --rm alpine:3.20 sh -c 'nc -z -w2 192.168.50.1 80 && echo LAN-OPEN || echo LAN-closed'
+```
+
+## Audit
+
+`auditd` watches sshd config, sudoers, unit files, the Docker daemon config,
+Jellyfin, AdGuard, and both admin `authorized_keys` files. Rules live in
+`/etc/audit/rules.d/hogwild.rules`. Lynis runs nightly.
+
+## Pending
+
+- The Agent's running process still carries the old groups. A `systemctl
+  --user` restart does not refresh them; only the user manager does. The next
+  host reboot completes the change. Drain the runner first:
+  `sudo systemctl stop hogwild-github-runner.service`, then `sudo reboot`.
+- The runner credential in `/etc/credstore.encrypted` is an OAuth token with
+  `admin:org` and `admin:public_key`. Replace it with a fine-grained token that
+  has Administration write on the repositories in `runners.conf` only.
+- `agent.harlanzw.com` sits on the public internet behind HTTP Basic auth only.
+  Put Cloudflare Access in front, or remove the Caddy route and use the tailnet
+  URL.
+- The tailnet holds a device from another account. Add a Tailscale ACL that
+  limits it to Jellyfin.
+- The desktop key `~/.ssh/id_ed25519_hogwild` has no passphrase.
+- The Z.ai key in `~/.config/opencode/opencode.json` on Hogwild should be
+  rotated and loaded from the environment.
+- `harlan-zw/gscdump.com` stays in `runners.conf`. Remove it before that
+  repository goes public.
+
+## Accepted
+
+- AdGuard's admin UI binds every interface on port 5380. ufw blocks it on the
+  LAN. Binding it to the tailnet address would fail at boot if `tailscale0`
+  comes up late, so it stays.
+- The runner supervisor holds the Docker socket. Its containers drop every
+  capability, run as a non-root user, and get no socket.

--- a/infra/hogwild/hogwild-docker-user-rules
+++ b/infra/hogwild/hogwild-docker-user-rules
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Rules Docker consults before its own FORWARD rules.
+# 1. Containers must not reach the LAN, the tailnet, or link-local addresses.
+#    The desktop DNS fallback from /etc/docker/daemon.json stays reachable.
+# 2. The LAN and the tailnet must not reach published container ports.
+#    Docker publishes ports past ufw. Loopback still works.
+set -euo pipefail
+lan_dns=192.168.50.139
+iptables -N DOCKER-USER 2>/dev/null || true
+iptables -F DOCKER-USER
+for proto in udp tcp; do
+  iptables -A DOCKER-USER -i docker0 -d "$lan_dns" -p "$proto" --dport 53 -j RETURN
+done
+for net in 192.168.0.0/16 10.0.0.0/8 100.64.0.0/10 169.254.0.0/16; do
+  iptables -A DOCKER-USER -i docker0 -d "$net" -j DROP
+done
+iptables -A DOCKER-USER -i docker0 ! -o docker0 -d 172.16.0.0/12 -j DROP
+for iface in eno3 tailscale0; do
+  iptables -A DOCKER-USER -i "$iface" -o docker0 -m conntrack --ctstate NEW -j DROP
+done
+iptables -A DOCKER-USER -j RETURN

--- a/infra/hogwild/hogwild-docker-user.service
+++ b/infra/hogwild/hogwild-docker-user.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hogwild DOCKER-USER firewall rules
+After=docker.service ufw.service
+PartOf=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/hogwild-docker-user-rules
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation
- [x] 👌 Enhancement

### 📚 Description

A security pass on Hogwild found the GitHub Agent running as the account that held `NOPASSWD` sudo and the Docker socket. The Agent runs `opencode run --auto` on public issue text from the nuxt-modules repositories, so one injected issue was root on the host. Docker also published container ports past ufw, and a CI container could reach the LAN router.

The host now has a separate `harlan-admin` account for root and Docker, `harlan` keeps only what the Agent needs, and a `DOCKER-USER` unit keeps containers off the LAN and the tailnet. Those changes are live. This adds `infra/hogwild` with the layout, the rules and unit, the install steps, and the list of what is still open.

Loose end: the Agent's running process still carries the old groups. A user unit restart does not refresh them, only a user manager restart or a reboot does, and I did not want to kill in-flight Agent work. The README lists the drain-first reboot.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).